### PR TITLE
enable usage of openigtlink install-type files

### DIFF
--- a/src/PlusOpenIGTLink/igtlPlusClientInfoMessage.cxx
+++ b/src/PlusOpenIGTLink/igtlPlusClientInfoMessage.cxx
@@ -6,8 +6,8 @@ See License.txt for details.
 
 #include "PlusConfigure.h"
 #include "igtlPlusClientInfoMessage.h"
-#include "igtlutil/igtl_header.h"
-#include "igtlutil/igtl_util.h"
+#include "igtl_header.h"
+#include "igtl_util.h"
 #include "vtkPlusIgtlMessageFactory.h"
 
 namespace igtl 

--- a/src/PlusOpenIGTLink/igtlPlusTrackedFrameMessage.h
+++ b/src/PlusOpenIGTLink/igtlPlusTrackedFrameMessage.h
@@ -14,8 +14,8 @@
 #include "igtl_win32header.h"
 #include "igtlMessageBase.h"
 #include "igtlObject.h"
-#include "igtlutil/igtl_header.h"
-#include "igtlutil/igtl_util.h"
+#include "igtl_header.h"
+#include "igtl_util.h"
 #include "vtkMatrix4x4.h"
 #include "vtkSmartPointer.h"
 #include <string>

--- a/src/PlusOpenIGTLink/igtlPlusUsMessage.cxx
+++ b/src/PlusOpenIGTLink/igtlPlusUsMessage.cxx
@@ -8,8 +8,8 @@ See License.txt for details.
 #include "PlusTrackedFrame.h"
 #include "igtlPlusUsMessage.h"
 #include "igtl_image.h"
-#include "igtlutil/igtl_header.h"
-#include "igtlutil/igtl_util.h"
+#include "igtl_header.h"
+#include "igtl_util.h"
 #include "vtkPlusIgtlMessageFactory.h"
 
 namespace igtl


### PR DESCRIPTION
This commit modifies the include statements, so it is compatible with the installed version of openigtlink (as compared to only the built version). This is due to the fact, that OpenIGTLink installs header files to different locations in the install "distribution", specifically, the igtlutil subfolder is just installed into the base include folder.

compatibility witth installed version of OpenIGTLink