### PR TITLE
Added a freeze/unfreeze call to the Capistrano video device after an 'unknow…

### DIFF
--- a/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
+++ b/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
@@ -1263,12 +1263,16 @@ PlusStatus vtkPlusCapistranoVideoSource::WaitForFrame()
   break;
   case USB_NOTSEQ:
     LOG_ERROR("Lost Probe Synchronization. Please check probe cables and restart.");
+	FreezeDevice(true);
+	FreezeDevice(false);
     break;
   case USB_STOPPED:
     LOG_ERROR("USB: Stopped. Check probe and restart.");
     break;
   default:
     LOG_ERROR("USB: Unknown USB error: "<<usbErrorCode);
+	FreezeDevice(true);
+	FreezeDevice(false);
     break;
   }
 


### PR DESCRIPTION
…n USB error' or a 'Lost probe synchronization' error is caught. This fixes a bug where the video stream does not unfreeze after one of these errors is caught.