### PR TITLE
re #1063 preventing double freeze or double unfreeze

### DIFF
--- a/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
+++ b/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
@@ -1214,6 +1214,11 @@ PlusStatus vtkPlusCapistranoVideoSource::FreezeDevice(bool freeze)
     return PLUS_FAIL;
   }
 
+  if (this->Frozen == freeze) //already in desired mode
+  {
+    return PLUS_SUCCESS;
+  }
+
   this->Frozen=freeze;
   if (this->Frozen)
   {


### PR DESCRIPTION
This would cause a crash in usbProbe.dll