### PR TITLE
fixes #1181 Support building PlusLib as part of Slicer's superbuild

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,9 @@ ENDIF()
 # Try to find ITK and include its settings (otherwise complain)
 FIND_PACKAGE (ITK REQUIRED PATHS ${ITK_DIR} NO_DEFAULT_PATH)
 IF(ITK_FOUND)
+  IF(ITK_NO_IO_FACTORY_REGISTER_MANAGER)
+    MESSAGE("ITK_NO_IO_FACTORY_REGISTER_MANAGER is true, disabling default I/O factory manager")
+  ENDIF()
   INCLUDE(${ITK_USE_FILE})
 ELSE()
   MESSAGE(FATAL_ERROR "This application requires ITK. One of these components is missing. Please verify configuration")
@@ -189,6 +192,14 @@ SET(PLUSLIB_INCLUDE_DIRS ${PLUSLIB_INCLUDE_DIRS} ${BASIC_INCLUDE_DIRS} CACHE INT
 # ..._INSTALL_CMAKE_FILES
 # vcProj_...
 # PLUSLIB_DEPENDENCIES
+
+IF(PLUS_USE_SYSTEM_ZLIB) # setting PlusZLib needs to come before processing subdirectories
+  SET(PlusZLib ${ZLIB_LIBRARY})
+  INCLUDE_DIRECTORIES( ${ZLIB_INCLUDE_DIR} )
+  LIST(APPEND PLUSLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR} CACHE INTERNAL "" )
+ELSE()
+  SET(PlusZLib vtkzlib)
+ENDIF()
 
 IF(PLUS_BUILD_WIDGETS)
   ADD_SUBDIRECTORY(PlusWidgets)

--- a/src/PlusCommon/CMakeLists.txt
+++ b/src/PlusCommon/CMakeLists.txt
@@ -60,10 +60,9 @@ SET(PlusCommon_LIBS
   vtkIOXMLParser
   vtkIOImage
   vtkCommonSystem
-  vtkzlib
   vtksys
   itksys
-  itkzlib
+  ${PlusZLib}
   ITKIONIFTI
   ITKIONRRD
   ITKIOGIPL

--- a/src/PlusDataCollection/CMakeLists.txt
+++ b/src/PlusDataCollection/CMakeLists.txt
@@ -1471,7 +1471,7 @@ IF(PLUS_USE_tesseract)
 
   SET(PlusDataCollection_LIBS ${PlusDataCollection_LIBS}
     ${tesseract_LIBRARIES}
-    vtkzlib vtkpng
+    ${PlusZLib} vtkpng
     )
 ENDIF()
 


### PR DESCRIPTION
ExternalProject_Add's CMAKE_CACHE_ARGS should have these:
  -DPLUS_USE_SYSTEM_ZLIB:BOOL=ON
  -DZLIB_INCLUDE_DIR:PATH=${ZLIB_INCLUDE_DIR}
  -DZLIB_LIBRARY:FILEPATH=${ZLIB_LIBRARY}
  -DITK_NO_IO_FACTORY_REGISTER_MANAGER:BOOL=ON

PLUS_USE_SYSTEM_ZLIB should be used in cases when ITK's and VTK's internal zlib build has been disabled.

ITK_NO_IO_FACTORY_REGISTER_MANAGER should be used in all the programs and libraries using itk::ImageFileReader and itk::ImageFileWriter classes. This makes sure there is only a single ITK I/O factory manager.