### PR TITLE
re #1187 support for VS2017 and Qt5.7

### DIFF
--- a/src/PlusWidgets/CMakeLists.txt
+++ b/src/PlusWidgets/CMakeLists.txt
@@ -39,6 +39,9 @@ SET (${PROJECT_NAME}_LIBS
 SET(${PROJECT_NAME}_INCLUDE_DIRS
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}
+  # VS2017 + Qt 5.7 puts generated headers (such as ui_QPlusDeviceSetSelectorWidget.h) into
+  # .../PlusLib-bin/src/PlusWidgets/PlusWidgets_autogen/include
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include
   )
 GENERATE_EXPORT_DIRECTIVE_FILE(${PROJECT_NAME})
 ADD_LIBRARY(${PROJECT_NAME}


### PR DESCRIPTION
Fix include directory for generated Qt headers under VS2017 Community
and Qt5.7.