### PR TITLE
Fix MMF device frame rate bug

### DIFF
--- a/src/PlusDataCollection/MicrosoftMediaFoundation/vtkPlusMmfVideoSource.cxx
+++ b/src/PlusDataCollection/MicrosoftMediaFoundation/vtkPlusMmfVideoSource.cxx
@@ -253,7 +253,7 @@ vtkPlusMmfVideoSource::vtkPlusMmfVideoSource()
   this->MmfSourceReader = new MmfVideoSourceReader(this);
   this->RequireImageOrientationInConfiguration = true;
 
-  this->AcquisitionRate = vtkPlusDevice::VIRTUAL_DEVICE_FRAME_RATE;
+  this->AcquisitionRate = DEFAULT_ACQUISITION_RATE;
 
   this->RequestedVideoFormat.DeviceId = DEFAULT_DEVICE_ID;
   this->RequestedVideoFormat.StreamIndex = 0;


### PR DESCRIPTION
I'm using a microsoft Lifecam HD3000 webcam(mmf device) to stream video from a PLUS server into an openIGTLink node.  However, when I set FrameSize="640 480" and VideoFormat="YUY2" in my XML config file the resulting webcam stream has a very poor frame rate (10-15 FPS?).

I ran the [vtkmmfvideosourcetest](https://github.com/PlusToolkit/PlusLib/blob/1e2e3fe3dbd70aa01cfeab6823cd1fab5d9e7c19/src/PlusDataCollection/Testing/vtkMmfVideoSourceTest.cxx) with the --list-video-formats argument to  find the list of supported resolutions. See image below. 

Whenever I set an unsupported FrameSize that is not in the list, the stream will always default to 640x480, but I notice that my frame rate is now much better (30 FPS?). It's unclear why I receive a lower frame rate when I explicitly set it to 640x480 in my XML config file. I see in [vtkPlusMmfVideoSource.cxx](https://github.com/PlusToolkit/PlusLib/blob/5aaf92038716ae9192182d0ab56484014320654d/src/PlusDataCollection/MicrosoftMediaFoundation/vtkPlusMmfVideoSource.cxx#L47-L48) that there is a default frame size and acquisition rate.  However, the [vtkPlusMmfVideoSource()](https://github.com/PlusToolkit/PlusLib/blob/5aaf92038716ae9192182d0ab56484014320654d/src/PlusDataCollection/MicrosoftMediaFoundation/vtkPlusMmfVideoSource.cxx#L256) function sets the acquisition rate to some other variable. 
`this->AcquisitionRate = vtkPlusDevice::VIRTUAL_DEVICE_FRAME_RATE;`
I'm assuming this variable should be the variable at the top of the file which is what this pull request changes.
`const double DEFAULT_ACQUISITION_RATE = 30;`

@dzenanz has told me 

> That is quite possibly a bug.  I think that const int vtkPlusDevice::VIRTUAL_DEVICE_FRAME_RATE = 50; defined in vtkPlusDevice.cxx is meant for VirtualCapture, VirtualMixer etc.

Does anyone have any other insights why I can get a higher frame rate at 640x480 when I choose a FrameSize not in the list?

![video formats](https://cloud.githubusercontent.com/assets/15837524/25875007/4a510694-34e3-11e7-98ac-283c2d7df9d2.PNG).
