### PR TITLE
Re #1108 Scoliosis transverse process enhancer

### DIFF
--- a/src/PlusImageProcessing/Testing/vtkPlusTransverseProcessEnhancerTest.cxx
+++ b/src/PlusImageProcessing/Testing/vtkPlusTransverseProcessEnhancerTest.cxx
@@ -24,369 +24,168 @@ This is a program meant to test vtkPlusTransverseProcessEnhancer.cxx from the co
 
 //----------------------------------------------------------------------------
 
-//Global variables
 
-//Magic numbers, taken from PlusB-bin\PlusLibData\ConfigFiles\ImageProcessing\PlusDeviceSet_Server_TransverseProcessEnhancerConfig.xml
-const int numberOfScanLinesDefault = 200;
-const int numberOfSamplesPerScanLineDefault = 210;
-const double radiusStartMmDefault = 50.0;
-const double radiusStopMmDefault = 120.0;
-const int thetaStartDegDefault = -24;
-const int thetaStopDegDefault = 24;
-
-int argc;
-char **argv;
-
-//Variables that will be taken form command line arguments
-std::string inputFileName;
-std::string configFileName;
-std::string outputFileName;
-std::string linesImageFileName;
-std::string intermediateImageFileName;
-std::string processedLinesImageFileName;
-
-int numberOfScanLines = NULL;
-int numberOfSamplesPerScanLine = NULL;
-
-double radiusStartMm = NULL;
-double radiusStopMm = NULL;
-int thetaStartDeg = NULL;
-int thetaStopDeg = NULL;
-
-bool convertToLinesImage = NULL;
-bool thresholdingEnabled = NULL;
-bool gaussianEnabled = NULL;
-bool edgeDetectorEnabled = NULL;
-bool islandRemovalEnabled = NULL;
-bool erosionEnabled = NULL;
-bool dilationEnabled = NULL;
-bool reconvertBinaryToGreyscale = NULL;
-bool returnToFanImage = NULL;
-
-int gaussianStdDev = NULL;
-int gaussianKernelSize = NULL;
-int thresholdInValue = NULL;
-int thresholdOutValue = NULL;
-int lowerThreshold = NULL;
-int upperThreshold = NULL;
-int islandAreaThreshold = NULL;
-
-
-int verboseLevel = vtkPlusLogger::LOG_LEVEL_UNDEFINED;
-
-//miscellaneous global variables 
-vtkSmartPointer<vtkPlusTransverseProcessEnhancer> enhancer;
-vtkSmartPointer<vtkXMLDataElement> xmlData;
-
-
-int readCommandLine(){
-	/*
-	readCommandLine() --> int
-
-	Sets things up so that command line arguments can be read. Estrablishes what the 
-	command line arguments are, and checks if the manditory arguments have been 
-	given.
-
-	Returns EXIT_FAILURE if an issue occured
-	Returns EXIT_SUCCESS if not problems were encountered
-	*/
-
-	bool printHelp = false;
-	vtksys::CommandLineArguments args;
-
-
-
-	//Get command line arguments
-	args.Initialize(argc, argv);
-	args.AddArgument("--help", vtksys::CommandLineArguments::NO_ARGUMENT, &printHelp, "Print this help");
-	args.AddArgument("--input-seq-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &inputFileName, "The filename for the input ultrasound sequence to process.");
-	args.AddArgument("--config-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &configFileName, "The filename for input config file.");
-	args.AddArgument("--output-seq-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &outputFileName, "The filename to write the processed sequence to.");
-	args.AddArgument("--lines-image-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &linesImageFileName, "Optional output files for subsampled input image");
-	args.AddArgument("--intermediate-image-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &intermediateImageFileName, "Optional output file");
-	args.AddArgument("--processedlines-image-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &processedLinesImageFileName, "Optional output files for processed subsampled image");
-
-	args.AddArgument("--gaussian-standard-deviation", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &gaussianStdDev, "Value for Gaussian Standard Deviation.");
-	args.AddArgument("--threshold-in-value", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &thresholdInValue, "The in value for the threshold.");
-	args.AddArgument("--threshold-out-value", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &thresholdOutValue, "The out value for the threshold.");
-	args.AddArgument("--lower-threshold", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &lowerThreshold, "The value of the lower bound threshold.");
-	args.AddArgument("--upper-threshold", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &upperThreshold, "The value of the upper bound threshold.");
-
-	args.AddArgument("--gaussian-kernel-size", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &gaussianKernelSize, "Size of the Gaussian kernel.");
-	args.AddArgument("--island-area-threshold", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &islandAreaThreshold, "Threshold for island area.");
-	args.AddArgument("--number-of-scan-lines", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &numberOfScanLines, "The amount of scan lines to be used.");
-	args.AddArgument("--samples-per-scan-line", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &numberOfSamplesPerScanLine, "The amount of samples in each scan line.");
-
-	args.AddArgument("--convert-to-lines-image", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &convertToLinesImage, "if lines should be converted to an image.");
-	args.AddArgument("--thresholding-enabled", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &thresholdingEnabled, "if thresholding should be enabled.");
-	args.AddArgument("--gaussian-enabled", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &gaussianEnabled, "if Gaussian Deviation should be enabled.");
-	args.AddArgument("--edge-detection", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &edgeDetectorEnabled, "if Edge Detecting should be enabled.");
-	args.AddArgument("--island-removal", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &islandRemovalEnabled, "if Island Removal should be enabled.");
-	args.AddArgument("--erosion-enabled", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &erosionEnabled, "if Erosion should be enabled.");
-	args.AddArgument("--dilation-enabled", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &dilationEnabled, "if Dilation should be enabled.");
-	args.AddArgument("--binary-to-greyscale", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &reconvertBinaryToGreyscale, "if Greyscale should be reconverted to Binary");
-	args.AddArgument("--return-to-fan-image", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &returnToFanImage, "if the Fan image should be returned to how it was on input.");
-
-	args.AddArgument("--radius-start", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &radiusStartMm, "Double for the starting point of the radius, measured in mm.");
-	args.AddArgument("--radius-stop", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &radiusStopMm, "Double for the stopping point of the radius, measured in mm.");
-	args.AddArgument("--theta-start", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &thetaStartDeg, "Int for the starting point of theta, measured in degrees.");
-	args.AddArgument("--theta-stop", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &thetaStopDeg, "Int for the stopping point of theta, measured in degrees.");
-
-	args.AddArgument("--verbose", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &verboseLevel, "Verbose level (1=error only, 2=warning, 3=info, 4=debug, 5=trace)");
-
-	if (!args.Parse())
-	{
-		std::cerr << "Problem parsing arguments" << std::endl;
-		std::cout << "Help: " << args.GetHelp() << std::endl;
-		exit(EXIT_FAILURE);
-	}
-
-	vtkPlusLogger::Instance()->SetLogLevel(verboseLevel);
-
-
-	//check for various non-optional command line arguments
-	int commandCheckStatus = NULL;
-
-	if (inputFileName.empty()){
-		std::cerr << "--input-seq-file not found!" << std::endl;
-		commandCheckStatus = EXIT_FAILURE;
-	}
-	if (outputFileName.empty()){
-		std::cerr << "--output-seq-file not found!" << std::endl;
-		commandCheckStatus = EXIT_FAILURE;
-	}
-	if (configFileName.empty()){
-		std::cerr << "--config-file not found!" << std::endl;
-		commandCheckStatus = EXIT_FAILURE;
-	}
-
-	if (commandCheckStatus == EXIT_FAILURE){
-		return EXIT_FAILURE;
-	}
-
-	return EXIT_SUCCESS;
-}
-
-int setEnhancerVariables(){
-	/*
-	setEnhancerVariables() --> int
-
-	Sets the variables of enhancer based on arguments given via the command line.
-
-	Returns EXIT_FAILURE if an issue occured
-	returns EXIT_SUCCESS if no problems were encountered
-	*/
-
-	if (linesImageFileName.empty() == false){
-		enhancer->SetLinesImageFileName(linesImageFileName);
-	}
-	if (intermediateImageFileName.empty() == false){
-		enhancer->SetIntermediateImageFileName(intermediateImageFileName);
-	}
-	if (processedLinesImageFileName.empty() == false){
-		enhancer->SetProcessedLinesImageFileName(processedLinesImageFileName);
-	}
-
-	if (numberOfScanLines == NULL){
-		LOG_WARNING("--number-of-scan-lines not set. Setting to default value of " << numberOfScanLinesDefault);
-		numberOfScanLines = numberOfScanLinesDefault;
-	}
-	enhancer->SetNumberOfScanLines(numberOfScanLines);
-
-	if (numberOfSamplesPerScanLine == NULL){
-		LOG_WARNING("--samples-per-scan-line not set. Setting to default value of " << numberOfSamplesPerScanLineDefault);
-		numberOfSamplesPerScanLine = numberOfSamplesPerScanLineDefault;
-	}
-	enhancer->SetNumberOfSamplesPerScanLine(numberOfSamplesPerScanLine);
-
-	if (radiusStartMm == NULL){
-		radiusStartMm = radiusStartMmDefault;
-	}
-	if (radiusStopMm == NULL){
-		radiusStopMm = radiusStopMmDefault;
-	}
-	if (thetaStartDeg == NULL){
-		thetaStartDeg = thetaStartDegDefault;
-	}
-	if (thetaStopDeg == NULL){
-		thetaStopDeg = thetaStopDegDefault;
-	}
-
-	if (convertToLinesImage != NULL){
-		enhancer->SetConvertToLinesImage(convertToLinesImage);
-	}
-	if (thresholdingEnabled != NULL){
-		enhancer->SetThresholdingEnabled(thresholdingEnabled);
-	}
-	if (gaussianEnabled != NULL){
-		enhancer->SetGaussianEnabled(gaussianEnabled);
-	}
-	if (edgeDetectorEnabled != NULL){
-		enhancer->SetEdgeDetectorEnabled(edgeDetectorEnabled);
-	}
-	if (islandRemovalEnabled != NULL){
-		enhancer->SetIslandRemovalEnabled(islandRemovalEnabled);
-	}
-	if (erosionEnabled != NULL){
-		enhancer->SetErosionEnabled(erosionEnabled);
-	}
-	if (dilationEnabled != NULL){
-		enhancer->SetDilationEnabled(dilationEnabled);
-	}
-	if (reconvertBinaryToGreyscale != NULL){
-		enhancer->SetReconvertBinaryToGreyscale(reconvertBinaryToGreyscale);
-	}
-	if (returnToFanImage != NULL){
-		enhancer->SetReturnToFanImage(returnToFanImage);
-	}
-
-	if (gaussianStdDev != NULL){
-		enhancer->SetGaussianStdDev(gaussianStdDev);
-	}
-	if (gaussianKernelSize != NULL){
-		enhancer->SetGaussianKernelSize(gaussianKernelSize);
-	}
-	if (thresholdInValue != NULL){
-		enhancer->SetThresholdInValue(thresholdInValue);
-	}
-	if (thresholdOutValue != NULL){
-		enhancer->SetThresholdOutValue(thresholdOutValue);
-	}
-	if (lowerThreshold != NULL){
-		enhancer->SetLowerThreshold(lowerThreshold);
-	}
-	if (upperThreshold != NULL){
-		enhancer->SetUpperThreshold(upperThreshold);
-	}
-	if (islandAreaThreshold != NULL){
-		enhancer->SetIslandAreaThreshold(islandAreaThreshold);
-	}
-
-	
-
-	return EXIT_SUCCESS;
-}
-
-
-PlusStatus makeProcessXmlData(){
-	/*
-	makeProcessXmlData() --> PlusStatus
-
-	Creates the XML data that will be used when testing the ReadConfiguration and
-	WriteConfiguration mothods for enhancer.
-
-	The data is saved to the global variable xmlData.
-	*/
-
-	//Create xml data for Processor
-
-	xmlData = vtkSmartPointer<vtkXMLDataElement>::New();
-	xmlData->SetName("Processor");
-	xmlData->SetAttribute("Type", "vtkPlusTransverseProcessEnhancer");
-	xmlData->SetIntAttribute("NumberOfScanLines", numberOfScanLines);
-	xmlData->SetIntAttribute("NumberOfSamplesPerScanLine", numberOfSamplesPerScanLine);
-
-	//Create xml data for ScanConversion
-	XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(scanConversion, xmlData, "ScanConversion");
-	scanConversion->SetAttribute("TransducerName", "Ultrasonix_C5-2");
-	scanConversion->SetAttribute("TransducerGeometry", "CURVILINEAR");
-	scanConversion->SetDoubleAttribute("RadiusStartMm", radiusStartMm);
-	scanConversion->SetDoubleAttribute("RadiusStopMm", radiusStopMm);
-	scanConversion->SetIntAttribute("ThetaStartDeg", thetaStartDeg);
-	scanConversion->SetIntAttribute("ThetaStopDeg", thetaStopDeg);
-	scanConversion->SetAttribute("OutputImageSizePixel", "820 616");
-	scanConversion->SetAttribute("TransducerCenterPixel", "410 110");
-	scanConversion->SetAttribute("OutputImageSpacingMmPerPixel", "0.1526 0.1526");
-
-
-	return PLUS_SUCCESS;
-}
-
-
-int main(int Argc, char **Argv)
+int main(int argc, char** argv)
 {
-	argc = Argc;
-	argv = Argv;
+  bool printHelp = false;
+  vtksys::CommandLineArguments args;
 
-	if (readCommandLine() == EXIT_FAILURE){
-		return EXIT_FAILURE;
-	}
-	
-	enhancer = vtkSmartPointer<vtkPlusTransverseProcessEnhancer>::New();
-	if (setEnhancerVariables() == EXIT_FAILURE){
-		return EXIT_FAILURE;
-	}
+  //Setup variables for command line
+  std::string inputFileName;
+  std::string configFileName;
+  std::string outputFileName;
+  std::string linesImageFileName;
+  std::string intermediateImageFileName;
+  std::string shadowImageFileName;
+  std::string processedLinesImageFileName;
 
-	// Read input and output sequence
-	vtkSmartPointer<vtkPlusTrackedFrameList> trackedFrameListIn = vtkSmartPointer<vtkPlusTrackedFrameList>::New();
-	trackedFrameListIn->ReadFromSequenceMetafile(inputFileName.c_str());
+  int verboseLevel = vtkPlusLogger::LOG_LEVEL_UNDEFINED;
 
-	vtkSmartPointer<vtkPlusTrackedFrameList> trackedFrameListOut = vtkSmartPointer<vtkPlusTrackedFrameList>::New();
-	trackedFrameListOut->ReadFromSequenceMetafile(inputFileName.c_str());
+  //Get command line arguments
+  args.Initialize(argc, argv);
+  args.AddArgument("--help", vtksys::CommandLineArguments::NO_ARGUMENT, &printHelp, "Print this help");
+  args.AddArgument("--input-seq-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &inputFileName, "The filename for the input ultrasound sequence to process.");
+  args.AddArgument("--config-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &configFileName, "The filename for input config file.");
+  args.AddArgument("--output-seq-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &outputFileName, "The filename to write the processed sequence to.");
+  args.AddArgument("--lines-image-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &linesImageFileName, "Optional output files for subsampled lines input image");
+  args.AddArgument("--intermediate-image-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &intermediateImageFileName, "Optional output file for intermediate data");
+  args.AddArgument("--shadow-image-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &shadowImageFileName, "Optional output file for shadow image");
+  args.AddArgument("--processedlines-image-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &processedLinesImageFileName, "Optional output files for processed subsampled image");
+  args.AddArgument("--verbose", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &verboseLevel, "Verbose level (1=error only, 2=warning, 3=info, 4=debug, 5=trace)");
 
-	vtkSmartPointer<vtkImageCast> castToUchar = vtkSmartPointer<vtkImageCast>::New();
-	castToUchar->SetOutputScalarTypeToUnsignedChar();
+  if (!args.Parse())
+  {
+    std::cerr << "Problem parsing arguments" << std::endl;
+    std::cout << "Help: " << args.GetHelp() << std::endl;
+    exit(EXIT_FAILURE);
+  }
 
-	int numberOfFrames = trackedFrameListIn->GetNumberOfTrackedFrames();
-	std::cout << "Number of frames in input: " << numberOfFrames << std::endl;
+  vtkPlusLogger::Instance()->SetLogLevel(verboseLevel);
 
-	if (makeProcessXmlData()==PLUS_FAIL){
-		return EXIT_FAILURE;
-	}
+  //check for various non-optional command line arguments
+  int commandCheckStatus = NULL;
 
-	//Checks methods of vtkPlusTransverseProcessEnhancer for failure
+  if (inputFileName.empty())
+  {
+    std::cerr << "--input-seq-file not found!" << std::endl;
+    commandCheckStatus = EXIT_FAILURE;
+  }
+  if (outputFileName.empty())
+  {
+    std::cerr << "--output-seq-file not found!" << std::endl;
+    commandCheckStatus = EXIT_FAILURE;
+  }
+  if (configFileName.empty())
+  {
+    std::cerr << "--config-file not found!" << std::endl;
+    commandCheckStatus = EXIT_FAILURE;
+  }
 
-	//test the abillity to Write to the config file
-	LOG_DEBUG("Writing to config file...");
-	std::cout << "Writing to Config file." << std::endl;
-	if (enhancer->WriteConfiguration(xmlData) == PLUS_FAIL){
-		LOG_DEBUG("Unable to write to config file.");
-		std::cout << "Failed to write to Config file" << std::endl;
-		return EXIT_FAILURE;
-	}
-	PlusCommon::XML::PrintXML(configFileName, xmlData);
-	LOG_DEBUG("Writing to config file finished.");
-	std::cout << "Done Writing Config file." << std::endl;
+  if (commandCheckStatus == EXIT_FAILURE)
+  {
+    return EXIT_FAILURE;
+  }
 
+  vtkSmartPointer<vtkPlusTransverseProcessEnhancer> enhancer = vtkSmartPointer<vtkPlusTransverseProcessEnhancer>::New();
 
-	//test the abillity to read to the config file that was just writen/created
-	int configStatus = NULL;
+  // Read input sequence
+  vtkSmartPointer<vtkPlusTrackedFrameList> trackedFrameList = vtkSmartPointer<vtkPlusTrackedFrameList>::New();
+  if (trackedFrameList->ReadFromSequenceMetafile(inputFileName.c_str()) == PLUS_FAIL)
+  {
+    return EXIT_FAILURE;
+  }
+  vtkSmartPointer<vtkImageCast> castToUchar = vtkSmartPointer<vtkImageCast>::New();
+  castToUchar->SetOutputScalarTypeToUnsignedChar();
 
-	LOG_DEBUG("Reading config file...");
-	std::cout << "Reading Config file." << std::endl;
-	vtkSmartPointer<vtkXMLDataElement> configRootElement = vtkSmartPointer<vtkXMLDataElement>::New();
-	if (PlusXmlUtils::ReadDeviceSetConfigurationFromFile(configRootElement, configFileName.c_str()) == PLUS_FAIL){
-		configStatus = EXIT_FAILURE;
-	}
-	if (configStatus != EXIT_FAILURE && enhancer->ReadConfiguration(configRootElement) == PLUS_FAIL){
-		configStatus = EXIT_FAILURE;
-	}
-	if (configStatus == EXIT_FAILURE){
-		LOG_ERROR("Unable to read configuration from file " << configFileName.c_str());
-		std::cout << "Failed to read Config file" << std::endl;
-		return EXIT_FAILURE;
-	}
-	LOG_DEBUG("Reading config file finished.");
-	std::cout << "Done reading Config file." << std::endl;
+  int numberOfFrames = trackedFrameList->GetNumberOfTrackedFrames();
+  std::cout << "Number of frames in input: " << numberOfFrames << std::endl;
 
 
-	//test ProcessFrame method
-	LOG_DEBUG("attempting to Process Frames.");
-	std::cout << "Processing Frame." << std::endl;
-	for (int frameIndex = 0; frameIndex <numberOfFrames; frameIndex++){
-		PlusTrackedFrame* inputTrackedFrame = trackedFrameListIn->GetTrackedFrame(frameIndex);
-		PlusTrackedFrame* outputTrackedFrame = trackedFrameListOut->GetTrackedFrame(frameIndex);
-		if (enhancer->ProcessFrame(inputTrackedFrame, outputTrackedFrame) == PLUS_FAIL){
-			LOG_DEBUG("Could not Process Frames. Failed on frame " << frameIndex);
-			std::cout << "Failed processing frames. Failed on frame " << frameIndex << std::endl;
-			return EXIT_FAILURE;
-		}
-	}
-	LOG_DEBUG("Processed Frames successfully.");
-	std::cout << "Done processing frames" << std::endl;
+  //Check methods of vtkPlusTransverseProcessEnhancer for failure
 
-	trackedFrameListOut->SaveToSequenceMetafile(outputFileName.c_str());
+  enhancer->SetInputFrames(trackedFrameList);
 
-	std::cout << "Compleated Test Successfully." << std::endl;
-	return EXIT_SUCCESS;
+  //test the abillity to read to the config file
+  LOG_DEBUG("Reading config file...");
+  std::cout << "Reading Config file." << std::endl;
+  vtkSmartPointer<vtkXMLDataElement> configRootElement = vtkSmartPointer<vtkXMLDataElement>::New(); 
+  if (PlusXmlUtils::ReadDeviceSetConfigurationFromFile(configRootElement, configFileName.c_str()) == PLUS_FAIL)
+  {
+    LOG_ERROR("Unable to read configuration from file " << configFileName.c_str());
+    std::cout << "Failed to read Config file" << std::endl;
+
+    return EXIT_FAILURE;
+  }
+
+  vtkXMLDataElement* processorElement = configRootElement->FindNestedElementWithName("ScanConversion");
+  if (processorElement == NULL)
+  {
+    LOG_ERROR("Cannot find device set in XML tree element: " << ((*configRootElement).GetName()));
+    return PLUS_FAIL;
+  }
+
+  if (enhancer->ReadConfiguration(configRootElement) == PLUS_FAIL)
+  {
+    LOG_ERROR("Unable to read configuration from file " << configFileName.c_str());
+    std::cout << "Failed to read Config file" << std::endl;
+    return EXIT_FAILURE;
+  }
+  LOG_DEBUG("Reading config file finished.");
+  std::cout << "Done reading Config file." << std::endl;
+
+  //Process the frames for the input file
+  LOG_DEBUG("attempting to Process Frames.");
+  std::cout << "Processing Frame." << std::endl;
+  if (enhancer->Update() == PLUS_FAIL)
+  {
+    LOG_ERROR("Could not Process Frames.");
+    std::cout << "Failed processing frames." << std::endl;
+    return EXIT_FAILURE;
+  }
+  LOG_DEBUG("Processed Frames terminated successfully.");
+  std::cout << "Processing Frame successfully." << std::endl;
+
+  //write various outputs to their respective files
+  if (linesImageFileName.empty() == false)
+  {
+    enhancer->SetLinesImageFileName(linesImageFileName);
+    if (enhancer->GetLinesFrameList()->SaveToSequenceMetafile(linesImageFileName.c_str()) == PLUS_FAIL)
+    {
+      LOG_ERROR("An issue occured when trying to save the lines image to file: " << linesImageFileName.c_str());
+      return EXIT_FAILURE;
+    }
+  }
+  if (intermediateImageFileName.empty() == false)
+  {
+    enhancer->SetLinesImageFileName(intermediateImageFileName);
+    if (enhancer->GetLinesFrameList()->SaveToSequenceMetafile(intermediateImageFileName.c_str()) == PLUS_FAIL)
+    {
+      LOG_ERROR("An issue occured when trying to save the intermediate image to file: " << intermediateImageFileName.c_str());
+      return EXIT_FAILURE;
+    }
+  }
+  if (shadowImageFileName.empty() == false)
+  {
+    enhancer->SetLinesImageFileName(shadowImageFileName);
+    if (enhancer->GetLinesFrameList()->SaveToSequenceMetafile(shadowImageFileName.c_str()) == PLUS_FAIL)
+    {
+      LOG_ERROR("An issue occured when trying to save the shadow image to file: " << shadowImageFileName.c_str());
+      return EXIT_FAILURE;
+    }
+  }
+  if (processedLinesImageFileName.empty() == false)
+  {
+    enhancer->SetLinesImageFileName(processedLinesImageFileName);
+    if (enhancer->GetLinesFrameList()->SaveToSequenceMetafile(processedLinesImageFileName.c_str()) == PLUS_FAIL)
+    {
+      LOG_ERROR("An issue occured when trying to save the processed lines image to file: " << processedLinesImageFileName.c_str());
+      return EXIT_FAILURE;
+    }
+  }
+
+  enhancer->GetOutputFrames()->SaveToSequenceMetafile(outputFileName.c_str());
+
+
+  std::cout << "Completed Test Successfully." << std::endl;
+  return EXIT_SUCCESS;
 }

--- a/src/PlusImageProcessing/Testing/vtkPlusTransverseProcessEnhancerTest.cxx
+++ b/src/PlusImageProcessing/Testing/vtkPlusTransverseProcessEnhancerTest.cxx
@@ -6,7 +6,7 @@ See License.txt for details.
 
 /*!
 \file vtkPlusTransverseProcessEnhancerTest.cxx
-\brief TODO Give a one-liner explanation as to the basics of this test
+This is a program meant to test vtkPlusTransverseProcessEnhancer.cxx from the command line.
 */
 
 #include "PlusConfigure.h"
@@ -16,30 +16,263 @@ See License.txt for details.
 #include <vtkSmartPointer.h>
 #include <vtksys/CommandLineArguments.hxx>
 
+
+#include "PlusTrackedFrame.h"
+#include "vtkPlusTrackedFrameList.h"
+#include "vtkImageCast.h"
+
 //----------------------------------------------------------------------------
+
+
 
 int main(int argc, char **argv)
 {
-  int verboseLevel = vtkPlusLogger::LOG_LEVEL_UNDEFINED;
+	bool printHelp = false;
+	vtksys::CommandLineArguments args;
 
-  vtksys::CommandLineArguments args;
-  args.Initialize(argc, argv);
 
-  args.AddArgument("--verbose", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &verboseLevel, "Verbose level (1=error only, 2=warning, 3=info, 4=debug, 5=trace)");
+	//Set up variables for command line arguments
+	std::string inputFileName;
+	std::string configFileName;
+	std::string outputFileName;
+	std::string linesImageFileName;
+	std::string intermediateImageFileName;
+	std::string processedLinesImageFileName;
 
-  if (!args.Parse())
-  {
-    std::cerr << "Problem parsing arguments" << std::endl;
-    std::cout << "Help: " << args.GetHelp() << std::endl;
-    exit(EXIT_FAILURE);
-  }
+	double gaussianStdDev = NULL;
+	int gaussianKernelSize = NULL;
+	double thresholdInValue = NULL;
+	double thresholdOutValue = NULL;
+	double lowerThreshold = NULL;
+	double upperThreshold = NULL;
+	int islandAreaThreshold = NULL;
 
-  vtkPlusLogger::Instance()->SetLogLevel(verboseLevel);
+	bool convertToLinesImage = NULL;
+	bool thresholdingEnabled = NULL;
+	bool gaussianEnabled = NULL;
+	bool edgeDetectorEnabled = NULL;
+	bool islandRemovalEnabled = NULL;
+	bool erosionEnabled = NULL;
+	bool dilationEnabled = NULL;
+	bool reconvertBinaryToGreyscale = NULL;
+	bool returnToFanImage = NULL;
+		
+	int verboseLevel = vtkPlusLogger::LOG_LEVEL_UNDEFINED;
 
-  ///////////////
+	//Get command line arguments
+	args.Initialize(argc, argv);
+	args.AddArgument("--help", vtksys::CommandLineArguments::NO_ARGUMENT, &printHelp, "Print this help");
+	args.AddArgument("--input-seq-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &inputFileName, "The filename for the input ultrasound sequence to process.");
+	args.AddArgument("--config-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &configFileName, "The filename for input config file.");
+	args.AddArgument("--output-seq-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &outputFileName, "The filename to write the processed sequence to.");
+	args.AddArgument("--lines-image-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &linesImageFileName, "Optional output files for subsampled input image");
+	args.AddArgument("--intermediate-image-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &intermediateImageFileName, "Optional output file");
+	args.AddArgument("--processedlines-image-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &processedLinesImageFileName, "Optional output files for processed subsampled image");
 
-  // TODO : write code that tests the functionality of your tool here
-  vtkSmartPointer<vtkPlusTransverseProcessEnhancer> enhancer = vtkSmartPointer<vtkPlusTransverseProcessEnhancer>::New();
+	args.AddArgument("--gaussian-standard-deviation", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &gaussianStdDev, "Value for Gaussian Standard Deviation.");
+	args.AddArgument("--gaussian-kernel-size", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &gaussianKernelSize, "Size of the Gaussian kernel.");
+	args.AddArgument("--threshold-in-value", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &thresholdInValue, "The in value for the threshold.");
+	args.AddArgument("--threshold-out-value", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &thresholdOutValue, "The out value for the threshold.");
+	args.AddArgument("--lower-threshold", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &lowerThreshold, "The value of the lower bound threshold.");
+	args.AddArgument("--upper-threshold", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &upperThreshold, "The value of the upper bound threshold.");
+	args.AddArgument("--island-area-threshold", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &islandAreaThreshold, "Threshold for island area.");
 
-  return EXIT_SUCCESS;
+	args.AddArgument("--convert-to-lines-image", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &convertToLinesImage, "if lines should be converted to an image.");
+	args.AddArgument("--thresholding-enabled", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &thresholdingEnabled, "if thresholding should be enabled.");
+	args.AddArgument("--gaussian-enabled", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &gaussianEnabled, "if Gaussian Deviation should be enabled.");
+	args.AddArgument("--edge-detection", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &edgeDetectorEnabled, "if Edge Detecting should be enabled.");
+	args.AddArgument("--island-removal", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &islandRemovalEnabled, "if Island Removal should be enabled.");
+	args.AddArgument("--erosion-enabled", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &erosionEnabled, "if Erosion should be enabled.");
+	args.AddArgument("--dilation-enabled", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &dilationEnabled, "if Dilation should be enabled.");
+	args.AddArgument("--binary-to-greyscale", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &reconvertBinaryToGreyscale, "if Greyscale should be reconverted to Binary");
+	args.AddArgument("--return-to-fan-image", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &returnToFanImage, "if the Fan image should be returned to how it was on input.");
+
+	args.AddArgument("--verbose", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &verboseLevel, "Verbose level (1=error only, 2=warning, 3=info, 4=debug, 5=trace)");
+
+	if (!args.Parse())
+	{
+		std::cerr << "Problem parsing arguments" << std::endl;
+		std::cout << "Help: " << args.GetHelp() << std::endl;
+		exit(EXIT_FAILURE);
+	}
+
+	vtkPlusLogger::Instance()->SetLogLevel(verboseLevel);
+
+	//check for various non-optional command line arguments
+	int commandCheckStatus = NULL;
+
+	if (inputFileName.empty()){
+		std::cerr << "--input-seq-file not found!" << std::endl;
+		commandCheckStatus = EXIT_FAILURE;
+	}
+	if (outputFileName.empty()){
+		std::cerr << "--output-seq-file not found!" << std::endl;
+		commandCheckStatus = EXIT_FAILURE;
+	}
+	if (configFileName.empty()){
+		std::cerr << "--config-file not found!" << std::endl;
+		commandCheckStatus = EXIT_FAILURE;
+	}
+
+	if (commandCheckStatus == EXIT_FAILURE){
+		return EXIT_FAILURE;
+	}
+
+
+	// Read input and output sequence
+	vtkSmartPointer<vtkPlusTrackedFrameList> trackedFrameListIn = vtkSmartPointer<vtkPlusTrackedFrameList>::New();
+	trackedFrameListIn->ReadFromSequenceMetafile(inputFileName.c_str());
+
+	vtkSmartPointer<vtkPlusTrackedFrameList> trackedFrameListOut = vtkSmartPointer<vtkPlusTrackedFrameList>::New();
+	trackedFrameListOut->ReadFromSequenceMetafile(inputFileName.c_str());
+
+	vtkSmartPointer<vtkImageCast> castToUchar = vtkSmartPointer<vtkImageCast>::New();
+	castToUchar->SetOutputScalarTypeToUnsignedChar();
+
+	int numberOfFrames = trackedFrameListIn->GetNumberOfTrackedFrames();
+	std::cout << "Number of frames in input: " << numberOfFrames << std::endl;
+
+
+	//Begin working on vtkPlusTransverseProcessEnhancer tests
+	vtkSmartPointer<vtkPlusTransverseProcessEnhancer> enhancer = vtkSmartPointer<vtkPlusTransverseProcessEnhancer>::New();
+
+
+	//Set values given by command line arguments
+	if (linesImageFileName.empty() == false){
+		enhancer->SetLinesImageFileName(linesImageFileName);
+	}
+	if (intermediateImageFileName.empty()==false){
+		enhancer->SetIntermediateImageFileName(intermediateImageFileName);
+	}
+	if (processedLinesImageFileName.empty() == false){
+		enhancer->SetProcessedLinesImageFileName(processedLinesImageFileName);
+	}
+	if (gaussianStdDev != NULL){
+		enhancer->SetGaussianStdDev(gaussianStdDev);
+	}
+	if (gaussianKernelSize != NULL){
+		enhancer->SetGaussianKernelSize(gaussianKernelSize);
+	}
+	if (thresholdInValue != NULL){
+		enhancer->SetThresholdInValue(thresholdInValue);
+	}
+	if (thresholdOutValue != NULL){
+		enhancer->SetThresholdOutValue(thresholdOutValue);
+	}
+	if (lowerThreshold != NULL){
+		enhancer->SetLowerThreshold(lowerThreshold);
+	}
+	if (upperThreshold != NULL){
+		enhancer->SetUpperThreshold(upperThreshold);
+	}
+	if (islandAreaThreshold != NULL){
+		enhancer->SetIslandAreaThreshold(islandAreaThreshold);
+	}
+
+	if (convertToLinesImage != NULL){
+		enhancer->SetConvertToLinesImage(convertToLinesImage);
+	}
+
+	if (thresholdingEnabled != NULL){
+		enhancer->SetThresholdingEnabled(thresholdingEnabled);
+	}
+	if (gaussianEnabled != NULL){
+		enhancer->SetGaussianEnabled(gaussianEnabled);
+	}
+	if (edgeDetectorEnabled != NULL){
+		enhancer->SetEdgeDetectorEnabled(edgeDetectorEnabled);
+	}
+	if (islandRemovalEnabled != NULL){
+		enhancer->SetIslandRemovalEnabled(islandRemovalEnabled);
+	}
+	if (erosionEnabled != NULL){
+		enhancer->SetErosionEnabled(erosionEnabled);
+	}
+	if (dilationEnabled != NULL){
+		enhancer->SetDilationEnabled(dilationEnabled);
+	}
+	if (reconvertBinaryToGreyscale != NULL){
+		enhancer->SetReconvertBinaryToGreyscale(reconvertBinaryToGreyscale);
+	}
+	if (returnToFanImage != NULL){
+		enhancer->SetReturnToFanImage(returnToFanImage);
+	}
+
+	//Create the xml file that will be written to and read from.
+
+	//Create xml data for Processor
+	vtkSmartPointer<vtkXMLDataElement> xmlData = vtkSmartPointer<vtkXMLDataElement>::New();
+	xmlData->SetName("Processor");
+	xmlData->SetAttribute("NumberOfScanLines", "200");
+	xmlData->SetAttribute("NumberOfSamplesPerScanLine", "210");
+
+	//Create xml data for ScanConversion
+	XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(scanConversion, xmlData, "ScanConversion");
+	scanConversion->SetName("ScanConversion");
+	scanConversion->SetAttribute("TransducerName", "Ultrasonix_C5-2");
+	scanConversion->SetAttribute("TransducerGeometry", "CURVILINEAR");
+	scanConversion->SetAttribute("RadiusStartMm", "50.0");
+	scanConversion->SetAttribute("RadiusStopMm", "120.0");
+	scanConversion->SetAttribute("ThetaStartDeg", "-24");
+	scanConversion->SetAttribute("ThetaStopDeg", "24");
+	scanConversion->SetAttribute("OutputImageSizePixel", "820 616");
+	scanConversion->SetAttribute("TransducerCenterPixel", "410 110");
+	scanConversion->SetAttribute("OutputImageSpacingMmPerPixel", "0.1526 0.1526");
+	scanConversion->SetAttribute("NumberOfSamplesPerScanLine", "210");
+
+
+	//Checks methods of vtkPlusTransverseProcessEnhancer for failure
+
+	//test the abillity to Write to the config file
+	LOG_DEBUG("Writing to config file...");
+	std::cout << "Writing to Config file." << std::endl;
+	if (enhancer->WriteConfiguration(xmlData) == PLUS_FAIL){
+		std::cout << "Failed to write to Config file" << std::endl;
+		return EXIT_FAILURE;
+	}
+	PlusCommon::XML::PrintXML(configFileName, xmlData);
+	LOG_DEBUG("Writing to config file finished.");
+	std::cout << "Done Writing Config file." << std::endl;
+
+
+	//test the abillity to read to the config file that was just created
+	int configStatus = NULL;
+
+	LOG_DEBUG("Reading config file...");
+	std::cout << "Reading Config file." << std::endl;
+	vtkSmartPointer<vtkXMLDataElement> configRootElement = vtkSmartPointer<vtkXMLDataElement>::New();
+	if (PlusXmlUtils::ReadDeviceSetConfigurationFromFile(configRootElement, configFileName.c_str()) == PLUS_FAIL){
+		configStatus = EXIT_FAILURE;
+	}
+	if (configStatus != EXIT_FAILURE && enhancer->ReadConfiguration(configRootElement) == PLUS_FAIL){
+		configStatus = EXIT_FAILURE;
+	}
+	if (configStatus == EXIT_FAILURE){
+		LOG_ERROR("Unable to read configuration from file " << configFileName.c_str());
+		std::cout << "Failed to read Config file" << std::endl;
+		return EXIT_FAILURE;
+	}
+	LOG_DEBUG("Reading config file finished.");
+	std::cout << "Done reading Config file." << std::endl;
+
+
+	//test ProcessFrame()
+	LOG_DEBUG("Running ProcessFrame().");
+	std::cout << "Processing Frame." << std::endl;
+	for (int frameIndex = 0; frameIndex <numberOfFrames; frameIndex++){
+		PlusTrackedFrame* inputTrackedFrame = trackedFrameListIn->GetTrackedFrame(frameIndex);
+		PlusTrackedFrame* outputTrackedFrame = trackedFrameListOut->GetTrackedFrame(frameIndex);
+		if (enhancer->ProcessFrame(inputTrackedFrame, outputTrackedFrame) == PLUS_FAIL){
+			LOG_DEBUG("Could not run ProcessFrame().");
+			std::cout << "Failed processing frames" << std::endl;
+			return EXIT_FAILURE;
+		}
+	}
+	LOG_DEBUG("ProcessFrame() terminated successfully.");
+	std::cout << "Done processing frames" << std::endl;
+
+	trackedFrameListOut->SaveToSequenceMetafile(outputFileName.c_str());
+
+	std::cout << "Compleated Test Successfully." << std::endl;
+	return EXIT_SUCCESS;
 }

--- a/src/PlusImageProcessing/Testing/vtkPlusTransverseProcessEnhancerTest.cxx
+++ b/src/PlusImageProcessing/Testing/vtkPlusTransverseProcessEnhancerTest.cxx
@@ -21,43 +21,80 @@ This is a program meant to test vtkPlusTransverseProcessEnhancer.cxx from the co
 #include "vtkPlusTrackedFrameList.h"
 #include "vtkImageCast.h"
 
+
 //----------------------------------------------------------------------------
 
+//Global variables
+
+//Magic numbers, taken from PlusB-bin\PlusLibData\ConfigFiles\ImageProcessing\PlusDeviceSet_Server_TransverseProcessEnhancerConfig.xml
+const int numberOfScanLinesDefault = 200;
+const int numberOfSamplesPerScanLineDefault = 210;
+const double radiusStartMmDefault = 50.0;
+const double radiusStopMmDefault = 120.0;
+const int thetaStartDegDefault = -24;
+const int thetaStopDegDefault = 24;
+
+int argc;
+char **argv;
+
+//Variables that will be taken form command line arguments
+std::string inputFileName;
+std::string configFileName;
+std::string outputFileName;
+std::string linesImageFileName;
+std::string intermediateImageFileName;
+std::string processedLinesImageFileName;
+
+int numberOfScanLines = NULL;
+int numberOfSamplesPerScanLine = NULL;
+
+double radiusStartMm = NULL;
+double radiusStopMm = NULL;
+int thetaStartDeg = NULL;
+int thetaStopDeg = NULL;
+
+bool convertToLinesImage = NULL;
+bool thresholdingEnabled = NULL;
+bool gaussianEnabled = NULL;
+bool edgeDetectorEnabled = NULL;
+bool islandRemovalEnabled = NULL;
+bool erosionEnabled = NULL;
+bool dilationEnabled = NULL;
+bool reconvertBinaryToGreyscale = NULL;
+bool returnToFanImage = NULL;
+
+int gaussianStdDev = NULL;
+int gaussianKernelSize = NULL;
+int thresholdInValue = NULL;
+int thresholdOutValue = NULL;
+int lowerThreshold = NULL;
+int upperThreshold = NULL;
+int islandAreaThreshold = NULL;
 
 
-int main(int argc, char **argv)
-{
+int verboseLevel = vtkPlusLogger::LOG_LEVEL_UNDEFINED;
+
+//miscellaneous global variables 
+vtkSmartPointer<vtkPlusTransverseProcessEnhancer> enhancer;
+vtkSmartPointer<vtkXMLDataElement> xmlData;
+
+
+int readCommandLine(){
+	/*
+	readCommandLine() --> int
+
+	Sets things up so that command line arguments can be read. Estrablishes what the 
+	command line arguments are, and checks if the manditory arguments have been 
+	given.
+
+	Returns EXIT_FAILURE if an issue occured
+	Returns EXIT_SUCCESS if not problems were encountered
+	*/
+
 	bool printHelp = false;
 	vtksys::CommandLineArguments args;
 
 
-	//Set up variables for command line arguments
-	std::string inputFileName;
-	std::string configFileName;
-	std::string outputFileName;
-	std::string linesImageFileName;
-	std::string intermediateImageFileName;
-	std::string processedLinesImageFileName;
-
-	double gaussianStdDev = NULL;
-	int gaussianKernelSize = NULL;
-	double thresholdInValue = NULL;
-	double thresholdOutValue = NULL;
-	double lowerThreshold = NULL;
-	double upperThreshold = NULL;
-	int islandAreaThreshold = NULL;
-
-	bool convertToLinesImage = NULL;
-	bool thresholdingEnabled = NULL;
-	bool gaussianEnabled = NULL;
-	bool edgeDetectorEnabled = NULL;
-	bool islandRemovalEnabled = NULL;
-	bool erosionEnabled = NULL;
-	bool dilationEnabled = NULL;
-	bool reconvertBinaryToGreyscale = NULL;
-	bool returnToFanImage = NULL;
-		
-	int verboseLevel = vtkPlusLogger::LOG_LEVEL_UNDEFINED;
 
 	//Get command line arguments
 	args.Initialize(argc, argv);
@@ -70,12 +107,15 @@ int main(int argc, char **argv)
 	args.AddArgument("--processedlines-image-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &processedLinesImageFileName, "Optional output files for processed subsampled image");
 
 	args.AddArgument("--gaussian-standard-deviation", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &gaussianStdDev, "Value for Gaussian Standard Deviation.");
-	args.AddArgument("--gaussian-kernel-size", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &gaussianKernelSize, "Size of the Gaussian kernel.");
 	args.AddArgument("--threshold-in-value", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &thresholdInValue, "The in value for the threshold.");
 	args.AddArgument("--threshold-out-value", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &thresholdOutValue, "The out value for the threshold.");
 	args.AddArgument("--lower-threshold", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &lowerThreshold, "The value of the lower bound threshold.");
 	args.AddArgument("--upper-threshold", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &upperThreshold, "The value of the upper bound threshold.");
+
+	args.AddArgument("--gaussian-kernel-size", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &gaussianKernelSize, "Size of the Gaussian kernel.");
 	args.AddArgument("--island-area-threshold", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &islandAreaThreshold, "Threshold for island area.");
+	args.AddArgument("--number-of-scan-lines", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &numberOfScanLines, "The amount of scan lines to be used.");
+	args.AddArgument("--samples-per-scan-line", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &numberOfSamplesPerScanLine, "The amount of samples in each scan line.");
 
 	args.AddArgument("--convert-to-lines-image", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &convertToLinesImage, "if lines should be converted to an image.");
 	args.AddArgument("--thresholding-enabled", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &thresholdingEnabled, "if thresholding should be enabled.");
@@ -87,6 +127,11 @@ int main(int argc, char **argv)
 	args.AddArgument("--binary-to-greyscale", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &reconvertBinaryToGreyscale, "if Greyscale should be reconverted to Binary");
 	args.AddArgument("--return-to-fan-image", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &returnToFanImage, "if the Fan image should be returned to how it was on input.");
 
+	args.AddArgument("--radius-start", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &radiusStartMm, "Double for the starting point of the radius, measured in mm.");
+	args.AddArgument("--radius-stop", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &radiusStopMm, "Double for the stopping point of the radius, measured in mm.");
+	args.AddArgument("--theta-start", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &thetaStartDeg, "Int for the starting point of theta, measured in degrees.");
+	args.AddArgument("--theta-stop", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &thetaStopDeg, "Int for the stopping point of theta, measured in degrees.");
+
 	args.AddArgument("--verbose", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &verboseLevel, "Verbose level (1=error only, 2=warning, 3=info, 4=debug, 5=trace)");
 
 	if (!args.Parse())
@@ -97,6 +142,7 @@ int main(int argc, char **argv)
 	}
 
 	vtkPlusLogger::Instance()->SetLogLevel(verboseLevel);
+
 
 	//check for various non-optional command line arguments
 	int commandCheckStatus = NULL;
@@ -118,61 +164,57 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
+	return EXIT_SUCCESS;
+}
 
-	// Read input and output sequence
-	vtkSmartPointer<vtkPlusTrackedFrameList> trackedFrameListIn = vtkSmartPointer<vtkPlusTrackedFrameList>::New();
-	trackedFrameListIn->ReadFromSequenceMetafile(inputFileName.c_str());
+int setEnhancerVariables(){
+	/*
+	setEnhancerVariables() --> int
 
-	vtkSmartPointer<vtkPlusTrackedFrameList> trackedFrameListOut = vtkSmartPointer<vtkPlusTrackedFrameList>::New();
-	trackedFrameListOut->ReadFromSequenceMetafile(inputFileName.c_str());
+	Sets the variables of enhancer based on arguments given via the command line.
 
-	vtkSmartPointer<vtkImageCast> castToUchar = vtkSmartPointer<vtkImageCast>::New();
-	castToUchar->SetOutputScalarTypeToUnsignedChar();
+	Returns EXIT_FAILURE if an issue occured
+	returns EXIT_SUCCESS if no problems were encountered
+	*/
 
-	int numberOfFrames = trackedFrameListIn->GetNumberOfTrackedFrames();
-	std::cout << "Number of frames in input: " << numberOfFrames << std::endl;
-
-
-	//Begin working on vtkPlusTransverseProcessEnhancer tests
-	vtkSmartPointer<vtkPlusTransverseProcessEnhancer> enhancer = vtkSmartPointer<vtkPlusTransverseProcessEnhancer>::New();
-
-
-	//Set values given by command line arguments
 	if (linesImageFileName.empty() == false){
 		enhancer->SetLinesImageFileName(linesImageFileName);
 	}
-	if (intermediateImageFileName.empty()==false){
+	if (intermediateImageFileName.empty() == false){
 		enhancer->SetIntermediateImageFileName(intermediateImageFileName);
 	}
 	if (processedLinesImageFileName.empty() == false){
 		enhancer->SetProcessedLinesImageFileName(processedLinesImageFileName);
 	}
-	if (gaussianStdDev != NULL){
-		enhancer->SetGaussianStdDev(gaussianStdDev);
+
+	if (numberOfScanLines == NULL){
+		LOG_WARNING("--number-of-scan-lines not set. Setting to default value of " << numberOfScanLinesDefault);
+		numberOfScanLines = numberOfScanLinesDefault;
 	}
-	if (gaussianKernelSize != NULL){
-		enhancer->SetGaussianKernelSize(gaussianKernelSize);
+	enhancer->SetNumberOfScanLines(numberOfScanLines);
+
+	if (numberOfSamplesPerScanLine == NULL){
+		LOG_WARNING("--samples-per-scan-line not set. Setting to default value of " << numberOfSamplesPerScanLineDefault);
+		numberOfSamplesPerScanLine = numberOfSamplesPerScanLineDefault;
 	}
-	if (thresholdInValue != NULL){
-		enhancer->SetThresholdInValue(thresholdInValue);
+	enhancer->SetNumberOfSamplesPerScanLine(numberOfSamplesPerScanLine);
+
+	if (radiusStartMm == NULL){
+		radiusStartMm = radiusStartMmDefault;
 	}
-	if (thresholdOutValue != NULL){
-		enhancer->SetThresholdOutValue(thresholdOutValue);
+	if (radiusStopMm == NULL){
+		radiusStopMm = radiusStopMmDefault;
 	}
-	if (lowerThreshold != NULL){
-		enhancer->SetLowerThreshold(lowerThreshold);
+	if (thetaStartDeg == NULL){
+		thetaStartDeg = thetaStartDegDefault;
 	}
-	if (upperThreshold != NULL){
-		enhancer->SetUpperThreshold(upperThreshold);
-	}
-	if (islandAreaThreshold != NULL){
-		enhancer->SetIslandAreaThreshold(islandAreaThreshold);
+	if (thetaStopDeg == NULL){
+		thetaStopDeg = thetaStopDegDefault;
 	}
 
 	if (convertToLinesImage != NULL){
 		enhancer->SetConvertToLinesImage(convertToLinesImage);
 	}
-
 	if (thresholdingEnabled != NULL){
 		enhancer->SetThresholdingEnabled(thresholdingEnabled);
 	}
@@ -198,28 +240,99 @@ int main(int argc, char **argv)
 		enhancer->SetReturnToFanImage(returnToFanImage);
 	}
 
-	//Create the xml file that will be written to and read from.
+	if (gaussianStdDev != NULL){
+		enhancer->SetGaussianStdDev(gaussianStdDev);
+	}
+	if (gaussianKernelSize != NULL){
+		enhancer->SetGaussianKernelSize(gaussianKernelSize);
+	}
+	if (thresholdInValue != NULL){
+		enhancer->SetThresholdInValue(thresholdInValue);
+	}
+	if (thresholdOutValue != NULL){
+		enhancer->SetThresholdOutValue(thresholdOutValue);
+	}
+	if (lowerThreshold != NULL){
+		enhancer->SetLowerThreshold(lowerThreshold);
+	}
+	if (upperThreshold != NULL){
+		enhancer->SetUpperThreshold(upperThreshold);
+	}
+	if (islandAreaThreshold != NULL){
+		enhancer->SetIslandAreaThreshold(islandAreaThreshold);
+	}
+
+	
+
+	return EXIT_SUCCESS;
+}
+
+
+PlusStatus makeProcessXmlData(){
+	/*
+	makeProcessXmlData() --> PlusStatus
+
+	Creates the XML data that will be used when testing the ReadConfiguration and
+	WriteConfiguration mothods for enhancer.
+
+	The data is saved to the global variable xmlData.
+	*/
 
 	//Create xml data for Processor
-	vtkSmartPointer<vtkXMLDataElement> xmlData = vtkSmartPointer<vtkXMLDataElement>::New();
+
+	xmlData = vtkSmartPointer<vtkXMLDataElement>::New();
 	xmlData->SetName("Processor");
-	xmlData->SetAttribute("NumberOfScanLines", "200");
-	xmlData->SetAttribute("NumberOfSamplesPerScanLine", "210");
+	xmlData->SetAttribute("Type", "vtkPlusTransverseProcessEnhancer");
+	xmlData->SetIntAttribute("NumberOfScanLines", numberOfScanLines);
+	xmlData->SetIntAttribute("NumberOfSamplesPerScanLine", numberOfSamplesPerScanLine);
 
 	//Create xml data for ScanConversion
 	XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(scanConversion, xmlData, "ScanConversion");
-	scanConversion->SetName("ScanConversion");
 	scanConversion->SetAttribute("TransducerName", "Ultrasonix_C5-2");
 	scanConversion->SetAttribute("TransducerGeometry", "CURVILINEAR");
-	scanConversion->SetAttribute("RadiusStartMm", "50.0");
-	scanConversion->SetAttribute("RadiusStopMm", "120.0");
-	scanConversion->SetAttribute("ThetaStartDeg", "-24");
-	scanConversion->SetAttribute("ThetaStopDeg", "24");
+	scanConversion->SetDoubleAttribute("RadiusStartMm", radiusStartMm);
+	scanConversion->SetDoubleAttribute("RadiusStopMm", radiusStopMm);
+	scanConversion->SetIntAttribute("ThetaStartDeg", thetaStartDeg);
+	scanConversion->SetIntAttribute("ThetaStopDeg", thetaStopDeg);
 	scanConversion->SetAttribute("OutputImageSizePixel", "820 616");
 	scanConversion->SetAttribute("TransducerCenterPixel", "410 110");
 	scanConversion->SetAttribute("OutputImageSpacingMmPerPixel", "0.1526 0.1526");
-	scanConversion->SetAttribute("NumberOfSamplesPerScanLine", "210");
 
+
+	return PLUS_SUCCESS;
+}
+
+
+int main(int Argc, char **Argv)
+{
+	argc = Argc;
+	argv = Argv;
+
+	if (readCommandLine() == EXIT_FAILURE){
+		return EXIT_FAILURE;
+	}
+	
+	enhancer = vtkSmartPointer<vtkPlusTransverseProcessEnhancer>::New();
+	if (setEnhancerVariables() == EXIT_FAILURE){
+		return EXIT_FAILURE;
+	}
+
+	// Read input and output sequence
+	vtkSmartPointer<vtkPlusTrackedFrameList> trackedFrameListIn = vtkSmartPointer<vtkPlusTrackedFrameList>::New();
+	trackedFrameListIn->ReadFromSequenceMetafile(inputFileName.c_str());
+
+	vtkSmartPointer<vtkPlusTrackedFrameList> trackedFrameListOut = vtkSmartPointer<vtkPlusTrackedFrameList>::New();
+	trackedFrameListOut->ReadFromSequenceMetafile(inputFileName.c_str());
+
+	vtkSmartPointer<vtkImageCast> castToUchar = vtkSmartPointer<vtkImageCast>::New();
+	castToUchar->SetOutputScalarTypeToUnsignedChar();
+
+	int numberOfFrames = trackedFrameListIn->GetNumberOfTrackedFrames();
+	std::cout << "Number of frames in input: " << numberOfFrames << std::endl;
+
+	if (makeProcessXmlData()==PLUS_FAIL){
+		return EXIT_FAILURE;
+	}
 
 	//Checks methods of vtkPlusTransverseProcessEnhancer for failure
 
@@ -227,6 +340,7 @@ int main(int argc, char **argv)
 	LOG_DEBUG("Writing to config file...");
 	std::cout << "Writing to Config file." << std::endl;
 	if (enhancer->WriteConfiguration(xmlData) == PLUS_FAIL){
+		LOG_DEBUG("Unable to write to config file.");
 		std::cout << "Failed to write to Config file" << std::endl;
 		return EXIT_FAILURE;
 	}
@@ -235,7 +349,7 @@ int main(int argc, char **argv)
 	std::cout << "Done Writing Config file." << std::endl;
 
 
-	//test the abillity to read to the config file that was just created
+	//test the abillity to read to the config file that was just writen/created
 	int configStatus = NULL;
 
 	LOG_DEBUG("Reading config file...");
@@ -256,19 +370,19 @@ int main(int argc, char **argv)
 	std::cout << "Done reading Config file." << std::endl;
 
 
-	//test ProcessFrame()
-	LOG_DEBUG("Running ProcessFrame().");
+	//test ProcessFrame method
+	LOG_DEBUG("attempting to Process Frames.");
 	std::cout << "Processing Frame." << std::endl;
 	for (int frameIndex = 0; frameIndex <numberOfFrames; frameIndex++){
 		PlusTrackedFrame* inputTrackedFrame = trackedFrameListIn->GetTrackedFrame(frameIndex);
 		PlusTrackedFrame* outputTrackedFrame = trackedFrameListOut->GetTrackedFrame(frameIndex);
 		if (enhancer->ProcessFrame(inputTrackedFrame, outputTrackedFrame) == PLUS_FAIL){
-			LOG_DEBUG("Could not run ProcessFrame().");
-			std::cout << "Failed processing frames" << std::endl;
+			LOG_DEBUG("Could not Process Frames. Failed on frame " << frameIndex);
+			std::cout << "Failed processing frames. Failed on frame " << frameIndex << std::endl;
 			return EXIT_FAILURE;
 		}
 	}
-	LOG_DEBUG("ProcessFrame() terminated successfully.");
+	LOG_DEBUG("Processed Frames successfully.");
 	std::cout << "Done processing frames" << std::endl;
 
 	trackedFrameListOut->SaveToSequenceMetafile(outputFileName.c_str());

--- a/src/PlusImageProcessing/vtkPlusTransverseProcessEnhancer.cxx
+++ b/src/PlusImageProcessing/vtkPlusTransverseProcessEnhancer.cxx
@@ -337,49 +337,93 @@ PlusStatus vtkPlusTransverseProcessEnhancer::ReadConfiguration(vtkXMLDataElement
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusTransverseProcessEnhancer::WriteConfiguration(vtkXMLDataElement* processingElement)
 {
-  XML_VERIFY_ELEMENT(processingElement, this->GetTagName());
+	XML_VERIFY_ELEMENT(processingElement, this->GetTagName());
 
-  XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(imageProcessingOperations, processingElement, "ImageProcessingOperations");
-  if (this->GaussianEnabled)
-  {
-    XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(gaussianParameters, processingElement, "GaussianSmoothing");
-    gaussianParameters->SetDoubleAttribute("GaussianStdDev", this->GaussianStdDev);
-    gaussianParameters->SetDoubleAttribute("GaussianKernelSize", this->GaussianKernelSize);
-  }
+	XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(imageProcessingOperations, processingElement, "ImageProcessingOperations");
 
-  if (this->ThresholdingEnabled)
-  {
-    XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(thresholdingParameters, processingElement, "Thresholding");
-    thresholdingParameters->SetDoubleAttribute("ThresholdInValue", ThresholdInValue);
-    thresholdingParameters->SetDoubleAttribute("ThresholdOutValue", ThresholdOutValue);
-    thresholdingParameters->SetDoubleAttribute("LowerThreshold", LowerThreshold);
-    thresholdingParameters->SetDoubleAttribute("UpperThreshold", UpperThreshold);
-  }
+	if (this->ConvertToLinesImage){
+		imageProcessingOperations->SetAttribute("ConvertToLinesImage", "True");
+	}
+	else{
+		imageProcessingOperations->SetAttribute("ConvertToLinesImage", "False");
+	}
 
-  if (this->EdgeDetectorEnabled)
-  {
-    processingElement->SetAttribute("EdgeDetectorEnabled", "TRUE");
-  }
+	if (this->GaussianEnabled)
+	{
+		imageProcessingOperations->SetAttribute("GaussianEnabled", "True");
+		XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(gaussianParameters, imageProcessingOperations, "GaussianSmoothing");
+		gaussianParameters->SetDoubleAttribute("GaussianStdDev", this->GaussianStdDev);
+		gaussianParameters->SetDoubleAttribute("GaussianKernelSize", this->GaussianKernelSize);
+	}
+	else{
+		imageProcessingOperations->SetAttribute("GaussianEnabled", "False");
+	}
 
-  if (this->IslandRemovalEnabled)
-  {
-    XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(islandRemovalParameters, processingElement, "IslandRemoval");
-    islandRemovalParameters->SetIntAttribute("IslandAreaThreshold", IslandAreaThreshold);
-  }
+	if (this->ThresholdingEnabled)
+	{
+		imageProcessingOperations->SetAttribute("ThresholdingEnabled", "True");
+		XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(thresholdingParameters, imageProcessingOperations, "Thresholding");
+		thresholdingParameters->SetDoubleAttribute("ThresholdInValue", ThresholdInValue);
+		thresholdingParameters->SetDoubleAttribute("ThresholdOutValue", ThresholdOutValue);
+		thresholdingParameters->SetDoubleAttribute("LowerThreshold", LowerThreshold);
+		thresholdingParameters->SetDoubleAttribute("UpperThreshold", UpperThreshold);
+	}
+	else{
+		imageProcessingOperations->SetAttribute("ThresholdingEnabled", "False");
+	}
 
-  if (this->ErosionEnabled)
-  {
-    XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(erosionParameters, processingElement, "Erosion");
-    erosionParameters->SetVectorAttribute("ErosionKernelSize", 2, this->ErosionKernelSize);
-  }
+	if (this->EdgeDetectorEnabled)
+	{
+		imageProcessingOperations->SetAttribute("EdgeDetectorEnabled", "True");
+	}
+	else{
+		imageProcessingOperations->SetAttribute("EdgeDetectorEnabled", "False");
+	}
 
-  if (this->DilationEnabled)
-  {
-    XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(dilationParameters, processingElement, "Dilation");
-    dilationParameters->SetVectorAttribute("DilationKernelSize", 2, this->DilationKernelSize);
-  }
+	if (this->IslandRemovalEnabled){
+		imageProcessingOperations->SetAttribute("IslandRemovalEnabled", "True");
+		XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(islandRemovalParameters, imageProcessingOperations, "IslandRemoval");
+		islandRemovalParameters->SetIntAttribute("IslandAreaThreshold", IslandAreaThreshold);
+	}
+	else{
+		imageProcessingOperations->SetAttribute("IslandRemovalEnabled", "False");
+	}
 
-  return PLUS_SUCCESS;
+	if (this->ErosionEnabled)
+	{
+		imageProcessingOperations->SetAttribute("ErosionEnabled", "True");
+		XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(erosionParameters, imageProcessingOperations, "Erosion");
+		erosionParameters->SetVectorAttribute("ErosionKernelSize", 2, this->ErosionKernelSize);
+	}
+	else{
+		imageProcessingOperations->SetAttribute("ErosionEnabled", "False");
+	}
+
+	if (this->DilationEnabled)
+	{
+		imageProcessingOperations->SetAttribute("DilationEnabled", "True");
+		XML_FIND_NESTED_ELEMENT_CREATE_IF_MISSING(dilationParameters, imageProcessingOperations, "Dilation");
+		dilationParameters->SetVectorAttribute("DilationKernelSize", 2, this->DilationKernelSize);
+	}
+	else{
+		imageProcessingOperations->SetAttribute("DilationEnabled", "False");
+	}
+
+	if (this->ReconvertBinaryToGreyscale){
+		imageProcessingOperations->SetAttribute("ReconvertBinaryToGreyscale", "True");
+	}
+	else{
+		imageProcessingOperations->SetAttribute("ReconvertBinaryToGreyscale", "False");
+	}
+
+	if (this->ReturnToFanImage){
+		imageProcessingOperations->SetAttribute("ReturnToFanImage", "True");
+	}
+	else{
+		imageProcessingOperations->SetAttribute("ReturnToFanImage", "False");
+	}
+
+	return PLUS_SUCCESS;
 }
 
 //----------------------------------------------------------------------------

--- a/src/PlusImageProcessing/vtkPlusTransverseProcessEnhancer.h
+++ b/src/PlusImageProcessing/vtkPlusTransverseProcessEnhancer.h
@@ -71,6 +71,29 @@ public:
   vtkSetMacro(NumberOfSamplesPerScanLine, int);
   vtkGetMacro(NumberOfSamplesPerScanLine, int);
 
+  vtkSetMacro(RadiusStartMm, int);
+  vtkGetMacro(RadiusStartMm, int);
+
+  vtkSetMacro(RadiusStopMm, int);
+  vtkGetMacro(RadiusStopMm, int);
+
+  vtkSetMacro(ThetaStartDeg, int);
+  vtkGetMacro(ThetaStartDeg, int);
+
+  vtkSetMacro(ThetaStopDeg, int);
+  vtkGetMacro(ThetaStopDeg, int);
+
+  vtkSetVector2Macro(OutputImageSizePixel, int);
+  vtkGetVector2Macro(OutputImageSizePixel, int);
+
+  vtkSetVector2Macro(TransducerCenterPixel, int);
+  vtkGetVector2Macro(TransducerCenterPixel, int);
+
+  vtkSetVector2Macro(OutputImageSpacingMmPerPixel, double);
+  vtkGetVector2Macro(OutputImageSpacingMmPerPixel, double);
+
+
+
   vtkSetMacro(GaussianEnabled, bool);
   vtkGetMacro(GaussianEnabled, bool);
   vtkBooleanMacro(GaussianEnabled, bool);
@@ -180,6 +203,16 @@ protected:
   double CurrentFrameStDev;
   float CurrentFrameMax;
   float CurrentFrameMin;
+
+  // Scan Conversion parameters, defined in config file
+  int RadiusStartMm;
+  int RadiusStopMm;
+  int ThetaStartDeg;
+  int ThetaStopDeg;
+
+  int OutputImageSizePixel[2];
+  int TransducerCenterPixel[2];
+  double OutputImageSpacingMmPerPixel[2];
 
   // Image processing parameters, defined in config file
   bool GaussianEnabled;


### PR DESCRIPTION
Recommitting all changes under new branch

Built file vtkPlusTransverseProcessEnhancerTest.cxx so that it may be used to test vtkPlusTransverseProcessEnhancer.cxx with greater ease.

Tests can be done via the command line by giving a config file, an input file, and an output file. Optional additional files for additional output data include a shadow image file, a lines image file, a processed lines image file, and an intermediate image file. Note, the previously mentioned optional output files may not work due to them not functioning well enough in vtkPlusTransverseProcessEnhancer.cxx

vtkPlusTransverseProcessEnhancer.cxx has also been changed so that it may better write to the config file it is given in the method WriteConfiguration()
vtkPlusTransverseProcessEnhancer.h has also been changed to allow for this to occur