### PR TITLE
re #1138 improving Plus command response to also properly populate me…

### DIFF
--- a/src/PlusServer/Commands/vtkPlusCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusCommand.cxx
@@ -246,7 +246,7 @@ void vtkPlusCommand::PopCommandResponses(PlusCommandResponseList& responses)
 //------------------------------------------------------------------------------
 void vtkPlusCommand::QueueCommandResponse(PlusStatus status, const std::string& message, const std::string& error, const std::map<std::string, std::string>* values)
 {
-  vtkSmartPointer<vtkPlusCommandCommandResponse> commandResponse = vtkSmartPointer<vtkPlusCommandCommandResponse>::New();
+  vtkSmartPointer<vtkPlusCommandRTSCommandResponse> commandResponse = vtkSmartPointer<vtkPlusCommandRTSCommandResponse>::New();
   commandResponse->SetClientId(this->ClientId);
   commandResponse->SetOriginalId(this->Id);
   commandResponse->SetDeviceName(this->DeviceName);

--- a/src/PlusServer/vtkPlusCommandProcessor.cxx
+++ b/src/PlusServer/vtkPlusCommandProcessor.cxx
@@ -4,10 +4,8 @@ Copyright (c) Laboratory for Percutaneous Surgery. All rights reserved.
 See License.txt for details.
 =========================================================Plus=header=end*/
 
+// Local includes
 #include "PlusConfigure.h"
-#include "vtkImageData.h"
-#include "vtkMatrix4x4.h"
-#include "vtkObjectFactory.h"
 #include "vtkPlusCommand.h"
 #include "vtkPlusCommandProcessor.h"
 #include "vtkPlusGetImageCommand.h"
@@ -20,6 +18,7 @@ See License.txt for details.
 #endif
 #include "igtl_header.h"
 #include "vtkPlusGetTransformCommand.h"
+#include "vtkPlusGetPolydataCommand.h"
 #include "vtkPlusRecursiveCriticalSection.h"
 #include "vtkPlusRequestIdsCommand.h"
 #include "vtkPlusSaveConfigCommand.h"
@@ -27,7 +26,12 @@ See License.txt for details.
 #include "vtkPlusStartStopRecordingCommand.h"
 #include "vtkPlusUpdateTransformCommand.h"
 #include "vtkPlusVersionCommand.h"
-#include "vtkXMLUtilities.h"
+
+// VTK includes
+#include <vtkImageData.h>
+#include <vtkMatrix4x4.h>
+#include <vtkObjectFactory.h>
+#include <vtkXMLUtilities.h>
 
 vtkStandardNewMacro(vtkPlusCommandProcessor);
 
@@ -41,6 +45,7 @@ vtkPlusCommandProcessor::vtkPlusCommandProcessor()
 {
   // Register default commands
   RegisterPlusCommand(vtkSmartPointer<vtkPlusGetImageCommand>::New());
+  RegisterPlusCommand(vtkSmartPointer<vtkPlusGetPolydataCommand>::New());
   RegisterPlusCommand(vtkSmartPointer<vtkPlusGetTransformCommand>::New());
   RegisterPlusCommand(vtkSmartPointer<vtkPlusReconstructVolumeCommand>::New());
   RegisterPlusCommand(vtkSmartPointer<vtkPlusRequestIdsCommand>::New());
@@ -251,7 +256,7 @@ PlusStatus vtkPlusCommandProcessor::QueueCommand(bool respondUsingIGTLCommand, u
     }
     else
     {
-      this->QueueCommandResponse(PLUS_FAIL, deviceName, clientId, commandName, uid, std::string("Error attempting to process command."));
+      this->QueueCommandResponse(PLUS_FAIL, deviceName, clientId, commandName, uid, "Error attempting to process command.", "Unknown command type requested.");
     }
     return PLUS_FAIL;
   }
@@ -270,7 +275,7 @@ PlusStatus vtkPlusCommandProcessor::QueueCommand(bool respondUsingIGTLCommand, u
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusCommandProcessor::QueueStringResponse(const PlusStatus& status, const std::string& deviceName, const std::string& replyString)
+PlusStatus vtkPlusCommandProcessor::QueueStringResponse(PlusStatus status, const std::string& deviceName, const std::string& replyString)
 {
   vtkSmartPointer<vtkPlusCommandStringResponse> response = vtkSmartPointer<vtkPlusCommandStringResponse>::New();
   response->SetDeviceName(deviceName);
@@ -294,19 +299,15 @@ PlusStatus vtkPlusCommandProcessor::QueueStringResponse(const PlusStatus& status
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusCommandProcessor::QueueCommandResponse(const PlusStatus& status, const std::string& deviceName, unsigned int clientId, const std::string& commandName, uint32_t uid, const std::string& replyString)
+PlusStatus vtkPlusCommandProcessor::QueueCommandResponse(PlusStatus status, const std::string& deviceName, unsigned int clientId, const std::string& commandName, uint32_t uid, const std::string& replyString, const std::string& errorString)
 {
-  // TODO : determine error string syntax/standard
-  std::string errorMessage = commandName + std::string(": failure");
-  LOG_ERROR(errorMessage);
-
-  vtkSmartPointer<vtkPlusCommandCommandResponse> response = vtkSmartPointer<vtkPlusCommandCommandResponse>::New();
+  vtkSmartPointer<vtkPlusCommandRTSCommandResponse> response = vtkSmartPointer<vtkPlusCommandRTSCommandResponse>::New();
   response->SetClientId(clientId);
   response->SetDeviceName(deviceName);
   response->SetOriginalId(uid);
   response->SetRespondWithCommandMessage(true);
-  response->SetErrorString(errorMessage);
-  response->SetStatus(PLUS_FAIL);
+  response->SetErrorString(errorString);
+  response->SetStatus(status);
 
   // Add response to the command response queue
   PlusLockGuard<vtkPlusRecursiveCriticalSection> updateMutexGuardedLock(this->Mutex);

--- a/src/PlusServer/vtkPlusCommandProcessor.h
+++ b/src/PlusServer/vtkPlusCommandProcessor.h
@@ -63,13 +63,13 @@ public:
     Adds a response to the response queue for reply. Can be called from any thread.
     Adds support for receiving commands to be rejected without processing but send an error reply
   */
-  virtual PlusStatus QueueStringResponse(const PlusStatus& status, const std::string& deviceName, const std::string& replyString);
+  virtual PlusStatus QueueStringResponse(PlusStatus status, const std::string& deviceName, const std::string& replyString);
 
   /*!
   Adds a response to the response queue for reply. Can be called from any thread.
   Adds support for receiving commands to be rejected without processing but send an error reply
   */
-  virtual PlusStatus QueueCommandResponse(const PlusStatus& status, const std::string& deviceName, unsigned int clientId, const std::string& commandName, uint32_t uid, const std::string& replyString);
+  virtual PlusStatus QueueCommandResponse(PlusStatus status, const std::string& deviceName, unsigned int clientId, const std::string& commandName, uint32_t uid, const std::string& replyString, const std::string& errorString);
 
   /*!
     Return the queued command responses and removes the items from the queue (so that each item is returned only once) and clears the response queue.

--- a/src/PlusServer/vtkPlusCommandResponse.cxx
+++ b/src/PlusServer/vtkPlusCommandResponse.cxx
@@ -7,7 +7,7 @@ See License.txt for details.
 #include "PlusConfigure.h"
 #include "vtkPlusCommandResponse.h"
 
-vtkStandardNewMacro(vtkPlusCommandCommandResponse);
+vtkStandardNewMacro(vtkPlusCommandRTSCommandResponse);
 vtkStandardNewMacro(vtkPlusCommandImageMetaDataResponse);
 vtkStandardNewMacro(vtkPlusCommandImageResponse);
 vtkStandardNewMacro(vtkPlusCommandPolydataResponse);
@@ -15,13 +15,13 @@ vtkStandardNewMacro(vtkPlusCommandResponse);
 vtkStandardNewMacro(vtkPlusCommandStringResponse);
 
 //----------------------------------------------------------------------------
-void vtkPlusCommandCommandResponse::SetParameters(const std::map<std::string, std::string>& values)
+void vtkPlusCommandRTSCommandResponse::SetParameters(const std::map<std::string, std::string>& values)
 {
   this->Parameters = values;
 }
 
 //----------------------------------------------------------------------------
-const std::map<std::string, std::string>& vtkPlusCommandCommandResponse::GetParameters() const
+const std::map<std::string, std::string>& vtkPlusCommandRTSCommandResponse::GetParameters() const
 {
   return Parameters;
 }

--- a/src/PlusServer/vtkPlusCommandResponse.h
+++ b/src/PlusServer/vtkPlusCommandResponse.h
@@ -78,11 +78,11 @@ private:
 };
 
 //----------------------------------------------------------------------------
-class vtkPlusCommandCommandResponse : public vtkPlusCommandResponse
+class vtkPlusCommandRTSCommandResponse : public vtkPlusCommandResponse
 {
 public:
-  static vtkPlusCommandCommandResponse* New();
-  vtkTypeMacro(vtkPlusCommandCommandResponse, vtkPlusCommandResponse);
+  static vtkPlusCommandRTSCommandResponse* New();
+  vtkTypeMacro(vtkPlusCommandRTSCommandResponse, vtkPlusCommandResponse);
 
   vtkGetMacro(OriginalId, uint32_t);
   vtkSetMacro(OriginalId, uint32_t);
@@ -97,7 +97,7 @@ public:
   const std::map<std::string, std::string>& GetParameters() const;
 
 protected:
-  vtkPlusCommandCommandResponse()
+  vtkPlusCommandRTSCommandResponse()
   {
   }
   uint32_t OriginalId;
@@ -107,8 +107,8 @@ protected:
   std::map<std::string, std::string> Parameters;
 
 private:
-  vtkPlusCommandCommandResponse(const vtkPlusCommandCommandResponse&);
-  void operator=(const vtkPlusCommandCommandResponse&);
+  vtkPlusCommandRTSCommandResponse(const vtkPlusCommandRTSCommandResponse&);
+  void operator=(const vtkPlusCommandRTSCommandResponse&);
 };
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
…tadata fields relating to command responses

fixing minor bugs in command response values being hardcoded

renaming vtkPlusCommandCommandResponse to vtkPlusCommandRTSCommandResponse for clarity about classes intended purpose (send RTS_COMMAND back to client)