### PR TITLE
re #1194 Fixing initialization bug and VS2013 compile error

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -211,12 +211,12 @@ vtkPlusWinProbeVideoSource::vtkPlusWinProbeVideoSource()
 {
     this->RequireImageOrientationInConfiguration = true;
 
-	for (int i = 1; i < 8; i++)
+	for (int i = 0; i < 8; i++)
 	{
 		m_timeGainCompensation[i] = 0.0;
 	}
 
-    for (int i = 1; i < 4; i++)
+    for (int i = 0; i < 4; i++)
     {
         m_focalPointDepth[i] = 0.0f;
     }

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -134,8 +134,8 @@ protected:
     PlusTrackedFrame::FieldMapType m_customFields;
     std::thread * m_watchdog32 = nullptr;
     double m_lastTimestamp = 0.0; //for watchdog
-    double m_timeGainCompensation[8] = { 0 };
-    float m_focalPointDepth[4] = { 0 };
+    double m_timeGainCompensation[8];
+    float m_focalPointDepth[4];
 
 private:
     vtkPlusWinProbeVideoSource(const vtkPlusWinProbeVideoSource &); // Not implemented


### PR DESCRIPTION
Due to initialization bug in constructor, I thought these arrays were not initialized - hence fiddling with it in the previous commit.