### PR TITLE
Use device IDs instead of device addresses

### DIFF
--- a/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.cxx
+++ b/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.cxx
@@ -578,12 +578,12 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncodersWakeup()
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderOriginWithAddr(long address)
+PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderOriginWithID(long id)
 {
-  IDtoAddressType::iterator enc = IdAddress.find(address);
+  IDtoAddressType::iterator enc = IdAddress.find(id);
   if (enc == this->IdAddress.end())
   {
-    LOG_ERROR("Non-existent device ID: " << address);
+    LOG_ERROR("Non-existent device ID: " << id);
     return PLUS_FAIL;
   }
 
@@ -618,12 +618,12 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetAllUSDigitalA2EncoderOrigin()
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderModeWithAddr(long address, long mode)
+PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderModeWithID(long id, long mode)
 {
-  IDtoAddressType::iterator enc = IdAddress.find(address);
+  IDtoAddressType::iterator enc = IdAddress.find(id);
   if (enc == this->IdAddress.end())
   {
-    LOG_ERROR("Non-existent device ID: " << address);
+    LOG_ERROR("Non-existent device ID: " << id);
     return PLUS_FAIL;
   }
 
@@ -636,12 +636,12 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderModeWithAddr(lo
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderModeWithAddr(long address, long* mode)
+PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderModeWithID(long id, long* mode)
 {
-  IDtoAddressType::iterator enc = IdAddress.find(address);
+  IDtoAddressType::iterator enc = IdAddress.find(id);
   if (enc == this->IdAddress.end())
   {
-    LOG_ERROR("Non-existent device ID: " << address);
+    LOG_ERROR("Non-existent device ID: " << id);
     return PLUS_FAIL;
   }
 
@@ -654,12 +654,12 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderModeWithAddr(lo
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderResoultionWithAddr(long address, long res)
+PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderResoultionWithID(long id, long res)
 {
-  IDtoAddressType::iterator enc = IdAddress.find(address);
+  IDtoAddressType::iterator enc = IdAddress.find(id);
   if (enc == this->IdAddress.end())
   {
-    LOG_ERROR("Non-existent device ID: " << address);
+    LOG_ERROR("Non-existent device ID: " << id);
     return PLUS_FAIL;
   }
 
@@ -672,12 +672,12 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderResoultionWithA
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderResoultionWithAddr(long address, long* res)
+PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderResoultionWithID(long id, long* res)
 {
-  IDtoAddressType::iterator enc = IdAddress.find(address);
+  IDtoAddressType::iterator enc = IdAddress.find(id);
   if (enc == this->IdAddress.end())
   {
-    LOG_ERROR("Non-existent device ID: " << address);
+    LOG_ERROR("Non-existent device ID: " << id);
     return PLUS_FAIL;
   }
 
@@ -690,12 +690,12 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderResoultionWithA
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderPositionWithAddr(long address, long pos)
+PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderPositionWithID(long id, long pos)
 {
-  IDtoAddressType::iterator enc = IdAddress.find(address);
+  IDtoAddressType::iterator enc = IdAddress.find(id);
   if (enc == this->IdAddress.end())
   {
-    LOG_ERROR("Non-existent device ID: " << address);
+    LOG_ERROR("Non-existent device ID: " << id);
     return PLUS_FAIL;
   }
 
@@ -708,12 +708,12 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderPositionWithAdd
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderPositionWithAddr(long address, long* pos)
+PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderPositionWithID(long id, long* pos)
 {
-  IDtoAddressType::iterator enc = IdAddress.find(address);
+  IDtoAddressType::iterator enc = IdAddress.find(id);
   if (enc == this->IdAddress.end())
   {
-    LOG_ERROR("Non-existent device ID: " << address);
+    LOG_ERROR("Non-existent device ID: " << id);
     return PLUS_FAIL;
   }
 

--- a/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.cxx
+++ b/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.cxx
@@ -134,6 +134,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::InternalConnect()
     LOG_ERROR("Failed to initialize SEI!");
     return PLUS_FAIL;
   }
+  IdAddress.clear();
 
   long numberofConnectedEncoders = ::GetNumberOfDevices();
   EncoderInfoMapType::iterator encoderInfoPos;
@@ -190,6 +191,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::InternalConnect()
           LOG_WARNING("Could not establish configuration address to deviceID correspondence");
         }
       }
+      IdAddress[deviceID] = address;
     }
   }
 
@@ -578,7 +580,14 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncodersWakeup()
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderOriginWithAddr(long address)
 {
-  if (::A2SetOrigin(address) != 0)
+  IDtoAddressType::iterator enc = IdAddress.find(address);
+  if (enc == this->IdAddress.end())
+  {
+    LOG_ERROR("Non-existent device ID: " << address);
+    return PLUS_FAIL;
+  }
+
+  if (::A2SetOrigin(enc->second) != 0)
   {
     LOG_ERROR("Failed to set US digital A2 Encoder's origin point as current position.");
     return PLUS_FAIL;
@@ -592,14 +601,14 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetAllUSDigitalA2EncoderOrigin()
   EncoderListType::iterator it;
   for (it = this->EncoderList.begin(); it != this->EncoderList.end(); ++it)
   {
-    if (this->SetUSDigitalA2EncoderOriginWithAddr(it->Addr) == PLUS_FAIL)
+    if (::A2SetOrigin(it->Addr) != 0)
     {
       return PLUS_FAIL;
     }
 
     if (it->Addr2 != 0) //coreXY
     {
-      if (this->SetUSDigitalA2EncoderOriginWithAddr(it->Addr2) == PLUS_FAIL)
+      if (::A2SetOrigin(it->Addr2) != 0)
       {
         return PLUS_FAIL;
       }
@@ -611,7 +620,14 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetAllUSDigitalA2EncoderOrigin()
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderModeWithAddr(long address, long mode)
 {
-  if (::A2SetMode(address, mode) != 0)
+  IDtoAddressType::iterator enc = IdAddress.find(address);
+  if (enc == this->IdAddress.end())
+  {
+    LOG_ERROR("Non-existent device ID: " << address);
+    return PLUS_FAIL;
+  }
+
+  if (::A2SetMode(enc->second, mode) != 0)
   {
     LOG_ERROR("Failed to set the mode of an US digital A2 Encoder.");
     return PLUS_FAIL;
@@ -622,7 +638,14 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderModeWithAddr(lo
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderModeWithAddr(long address, long* mode)
 {
-  if (::A2GetMode(address, mode) != 0)
+  IDtoAddressType::iterator enc = IdAddress.find(address);
+  if (enc == this->IdAddress.end())
+  {
+    LOG_ERROR("Non-existent device ID: " << address);
+    return PLUS_FAIL;
+  }
+
+  if (::A2GetMode(enc->second, mode) != 0)
   {
     LOG_ERROR("Failed to get the mode of an US digital A2 Encoder.");
     return PLUS_FAIL;
@@ -633,7 +656,14 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderModeWithAddr(lo
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderResoultionWithAddr(long address, long res)
 {
-  if (::A2SetResolution(address, res) != 0)
+  IDtoAddressType::iterator enc = IdAddress.find(address);
+  if (enc == this->IdAddress.end())
+  {
+    LOG_ERROR("Non-existent device ID: " << address);
+    return PLUS_FAIL;
+  }
+
+  if (::A2SetResolution(enc->second, res) != 0)
   {
     LOG_ERROR("Failed to set the resoultion of an US digital A2 Encoder.");
     return PLUS_FAIL;
@@ -644,7 +674,14 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderResoultionWithA
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderResoultionWithAddr(long address, long* res)
 {
-  if (::A2GetResolution(address, res) != 0)
+  IDtoAddressType::iterator enc = IdAddress.find(address);
+  if (enc == this->IdAddress.end())
+  {
+    LOG_ERROR("Non-existent device ID: " << address);
+    return PLUS_FAIL;
+  }
+
+  if (::A2GetResolution(enc->second, res) != 0)
   {
     LOG_ERROR("Failed to get the resoultion of an US digital A2 Encoder.");
     return PLUS_FAIL;
@@ -655,7 +692,14 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderResoultionWithA
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderPositionWithAddr(long address, long pos)
 {
-  if (::A2SetPosition(address, pos) != 0)
+  IDtoAddressType::iterator enc = IdAddress.find(address);
+  if (enc == this->IdAddress.end())
+  {
+    LOG_ERROR("Non-existent device ID: " << address);
+    return PLUS_FAIL;
+  }
+
+  if (::A2SetPosition(enc->second, pos) != 0)
   {
     LOG_ERROR("Failed to set the position of an US digital A2 Encoder.");
     return PLUS_FAIL;
@@ -666,7 +710,14 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderPositionWithAdd
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderPositionWithAddr(long address, long* pos)
 {
-  if (::A2GetPosition(address, pos) != 0)
+  IDtoAddressType::iterator enc = IdAddress.find(address);
+  if (enc == this->IdAddress.end())
+  {
+    LOG_ERROR("Non-existent device ID: " << address);
+    return PLUS_FAIL;
+  }
+
+  if (::A2GetPosition(enc->second, pos) != 0)
   {
     LOG_ERROR("Failed to get the position of an US digital A2 Encoder.");
     return PLUS_FAIL;

--- a/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.cxx
+++ b/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.cxx
@@ -547,7 +547,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncodersStrobeMode()
 {
   if (::A2SetStrobe() != 0)
   {
-    LOG_ERROR("Failed to set US digital A2 Encodrs as Strobe mode.");
+    LOG_ERROR("Failed to set US digital A2 Encoders as Strobe mode.");
     return PLUS_FAIL;
   }
   return PLUS_SUCCESS;
@@ -558,7 +558,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncodersSleep()
 {
   if (::A2SetSleep() != 0)
   {
-    LOG_ERROR("Failed to set US digital A2 Encodrs as Sleep mode.");
+    LOG_ERROR("Failed to set US digital A2 Encoders as Sleep mode.");
     return PLUS_FAIL;
   }
   return PLUS_SUCCESS;
@@ -569,7 +569,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncodersWakeup()
 {
   if (::A2SetWakeup() != 0)
   {
-    LOG_ERROR("Failed to set US digital A2 Encodrs as Wakeup mode.");
+    LOG_ERROR("Failed to set US digital A2 Encoders as Wakeup mode.");
     return PLUS_FAIL;
   }
   return PLUS_SUCCESS;
@@ -613,7 +613,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderModeWithAddr(lo
 {
   if (::A2SetMode(address, mode) != 0)
   {
-    LOG_ERROR("Failed to set the mode of an US digital A2 Encodr.");
+    LOG_ERROR("Failed to set the mode of an US digital A2 Encoder.");
     return PLUS_FAIL;
   }
   return PLUS_SUCCESS;
@@ -624,7 +624,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderModeWithAddr(lo
 {
   if (::A2GetMode(address, mode) != 0)
   {
-    LOG_ERROR("Failed to get the mode of an US digital A2 Encodr.");
+    LOG_ERROR("Failed to get the mode of an US digital A2 Encoder.");
     return PLUS_FAIL;
   }
   return PLUS_SUCCESS;
@@ -635,7 +635,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderResoultionWithA
 {
   if (::A2SetResolution(address, res) != 0)
   {
-    LOG_ERROR("Failed to set the resoultion of an US digital A2 Encodr.");
+    LOG_ERROR("Failed to set the resoultion of an US digital A2 Encoder.");
     return PLUS_FAIL;
   }
   return PLUS_SUCCESS;
@@ -646,7 +646,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderResoultionWithA
 {
   if (::A2GetResolution(address, res) != 0)
   {
-    LOG_ERROR("Failed to get the resoultion of an US digital A2 Encodr.");
+    LOG_ERROR("Failed to get the resoultion of an US digital A2 Encoder.");
     return PLUS_FAIL;
   }
   return PLUS_SUCCESS;
@@ -657,7 +657,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderPositionWithAdd
 {
   if (::A2SetPosition(address, pos) != 0)
   {
-    LOG_ERROR("Failed to set the position of an US digital A2 Encodr.");
+    LOG_ERROR("Failed to set the position of an US digital A2 Encoder.");
     return PLUS_FAIL;
   }
   return PLUS_SUCCESS;
@@ -668,7 +668,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderPositionWithAdd
 {
   if (::A2GetPosition(address, pos) != 0)
   {
-    LOG_ERROR("Failed to get the position of an US digital A2 Encodr.");
+    LOG_ERROR("Failed to get the position of an US digital A2 Encoder.");
     return PLUS_FAIL;
   }
   return PLUS_SUCCESS;

--- a/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.cxx
+++ b/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.cxx
@@ -152,7 +152,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::InternalConnect()
       return PLUS_FAIL;
     }
 
-    encoderInfoPos = this->EncoderMap.find(address);
+    encoderInfoPos = this->EncoderMap.find(deviceID);
 
     if (encoderInfoPos == this->EncoderMap.end())
     {
@@ -174,6 +174,21 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::InternalConnect()
       {
         LOG_ERROR("Failed to set initial position for SEI device SN: " << serialNumber << ", address: " << address);
         return PLUS_FAIL;
+      }
+      if (deviceID != address) //update address in encoderInfo
+      {
+        if (encoderInfoPos->second->Addr == deviceID)
+        {
+          encoderInfoPos->second->Addr = address;
+        }
+        else if (encoderInfoPos->second->Addr2 == deviceID)
+        {
+          encoderInfoPos->second->Addr2 = address;
+        }
+        else
+        {
+          LOG_WARNING("Could not establish configuration address to deviceID correspondence");
+        }
       }
     }
   }
@@ -344,7 +359,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::ReadConfiguration(vtkXMLDataElement*
   this->TransformRepository->Clear();
   this->EncoderMap.clear();
   this->EncoderList.clear();
-  long address = 0;
+  long deviceID = 0;
 
   for (int encoderIndex = 0; encoderIndex < dataSourcesElement->GetNumberOfNestedElements(); encoderIndex++)
   {
@@ -490,15 +505,15 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::ReadConfiguration(vtkXMLDataElement*
     }
     encoderInfo.Resolution = atol(resolution);
 
-    encoderInfo.Addr = address++;
+    encoderInfo.Addr = deviceID++;
     if (coreXY)
     {
-        encoderInfo.Addr2 = address++;
+        encoderInfo.Addr2 = deviceID++;
     }
     EncoderList.push_back(encoderInfo);
 
     this->EncoderMap[encoderInfo.Addr] = &EncoderList.back();
-    if (coreXY) //enter this encoderInfo twice (once for each address)
+    if (coreXY) //enter this encoderInfo twice (once for each deviceID)
     {
       this->EncoderMap[encoderInfo.Addr2] = &EncoderList.back();
     }

--- a/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.h
+++ b/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.h
@@ -127,6 +127,8 @@ protected:
   EncoderInfoMapType EncoderMap;
   typedef std::list<vtkPlusUSDigitalEncoderInfo> EncoderListType;
   EncoderListType EncoderList;
+  typedef std::map<long, long> IDtoAddressType;
+  IDtoAddressType IdAddress;
 
 
 private:

--- a/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.h
+++ b/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.h
@@ -19,6 +19,8 @@ See License.txt for details.
 
    This class communicates with multiple US Digital encoders through SEI (Serial Encoder Interface Bus) provided by US Digital.
 
+   IDs are assigned to devices based on serial numbers: lower SN -> lower ID. IDs start at 0.
+
    \ingroup PlusLibDataCollection
  */
 
@@ -73,36 +75,29 @@ public:
   /*! Function: wakes up all A2's on the SEI bus, wait at least 5mSec before sending the next command */
   PlusStatus SetUSDigitalA2EncodersWakeup();
 
-  /*! Sets the absolute zero to the current position, in single-turn mode the new position is stored in EEPROM
-      address: SEI address 0-15*/
-  PlusStatus SetUSDigitalA2EncoderOriginWithAddr(long address);
+  /*! Sets the absolute zero to the current position, in single-turn mode the new position is stored in EEPROM */
+  PlusStatus SetUSDigitalA2EncoderOriginWithID(long id);
 
   /*! Sets the absolute zero to the current position of all connected US Digital A2 Encoders*/
   PlusStatus SetAllUSDigitalA2EncoderOrigin();
 
-  /*! Sets the mode of an A2 Encoder
-      address: SEI address 0-14*/
-  PlusStatus SetUSDigitalA2EncoderModeWithAddr(long address, long mode);
+  /*! Sets the mode of an A2 Encoder */
+  PlusStatus SetUSDigitalA2EncoderModeWithID(long id, long mode);
 
-  /*! Gets the mode of an A2 Encoder
-      address: SEI address 0-14*/
-  PlusStatus GetUSDigitalA2EncoderModeWithAddr(long address, long* mode);
+  /*! Gets the mode of an A2 Encoder */
+  PlusStatus GetUSDigitalA2EncoderModeWithID(long id, long* mode);
 
-  /*! Sets the resolution of an A2 Encoder
-      address: SEI address 0-14*/
-  PlusStatus SetUSDigitalA2EncoderResoultionWithAddr(long address, long res);
+  /*! Sets the resolution of an A2 Encoder */
+  PlusStatus SetUSDigitalA2EncoderResoultionWithID(long id, long res);
 
-  /*! Gets the resolution of an A2 Encoder
-      address: SEI address 0-14*/
-  PlusStatus GetUSDigitalA2EncoderResoultionWithAddr(long address, long* res);
+  /*! Gets the resolution of an A2 Encoder */
+  PlusStatus GetUSDigitalA2EncoderResoultionWithID(long id, long* res);
 
-  /*! Sets the Position of an A2 Encoder
-      address: SEI address 0-14*/
-  PlusStatus SetUSDigitalA2EncoderPositionWithAddr(long address, long pos);
+  /*! Sets the Position of an A2 Encoder */
+  PlusStatus SetUSDigitalA2EncoderPositionWithID(long id, long pos);
 
-  /*! Gets the Position of an A2 Encoder
-      address: SEI address 0-14*/
-  PlusStatus GetUSDigitalA2EncoderPositionWithAddr(long address, long* pos);
+  /*! Gets the Position of an A2 Encoder */
+  PlusStatus GetUSDigitalA2EncoderPositionWithID(long id, long* pos);
 
 protected:
   vtkPlusUSDigitalEncodersTracker();


### PR DESCRIPTION
This handles the case of addresses assigned not starting at 0, which happens when connecting and then disconnecting additional encoders.