### PR TITLE
Supporting WinProbeSDK 2.1

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -247,7 +247,7 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
     WPSetTransducerID(this->m_transducerID.c_str());
     m_ADCfrequency = GetADCSamplingRate();
     m_transducerCount = GetSSElementCount();
-    SetCompoundAngleCount(0);
+    SetSCCompoundAngleCount(0);
     SetPendingRecreateTables(true);
 
     return PLUS_SUCCESS;


### PR DESCRIPTION
Some functions got renamed, one of them was being called from Plus wrapper. @jamesobutler can you test whether this is still working correctly with the latest SDK?