### PR TITLE
re #209: Replace Assembla links with appropriate GitHub links

### DIFF
--- a/src/Documentation/ApiReference/PlusMainPage.dox
+++ b/src/Documentation/ApiReference/PlusMainPage.dox
@@ -6,7 +6,7 @@
 
 Plus (Public software Library for UltraSound) is an open-source software package for tracked ultrasound image acquisition, calibration, and processing. PlusLib contains the basic framework and algorithm classes.
 
-See the <a href="https://www.assembla.com/spaces/plus/wiki">Plus Wiki</a> for more information.
+See the <a href="https://plustoolkit.github.io/">Plus Website</a> for more information.
 
 \defgroup PlusLibCalibrationAlgorithm CalibrationAlgorithm
 \defgroup PlusLibDataCollection DataCollection

--- a/src/Documentation/UserManual/AlgorithmProbeCalibration.dox
+++ b/src/Documentation/UserManual/AlgorithmProbeCalibration.dox
@@ -52,7 +52,7 @@ This algorithm determines the transformation between the ultrasound image and a 
 
 \section AlgorithmProbeCalibrationPhantomDefinition Phantom definition
 
-We recommend using 3 N-wires as we have found this to be more robust and accurate than using just 2 N-wires but still can be robustly detected and kept in the field of view. Specification of the wire pattern is available at https://app.assembla.com/spaces/plus/subversion/source/HEAD/trunk/doc/tutorials/PlusTutorialBuildingfCalPrintedPhantom.pptx?_format=raw. XML description can be found in the example device set configuration files. 
+We recommend using 3 N-wires as we have found this to be more robust and accurate than using just 2 N-wires but still can be robustly detected and kept in the field of view. Specification of the wire pattern is available at https://github.com/PlusToolkit/PlusDoc/raw/master/tutorials/PlusTutorialBuildingfCalPrintedPhantom.pptx. XML description can be found in the example device set configuration files. 
 
 You can add any number of N-wires with any angles between the side and middle wires (angle can be different for each N-wire) with the following conditions:
 - all N-wires shall be completely visible at the same time in the ultrasound image

--- a/src/Documentation/UserManual/ApplicationVolumeReconstructor.dox
+++ b/src/Documentation/UserManual/ApplicationVolumeReconstructor.dox
@@ -10,9 +10,9 @@ See description of volume reconstruction parameters on the \ref AlgorithmVolumeR
     VolumeReconstructor.exe --config-file=PlusConfiguration_SpinePhantomFreehandReconstructionOnly.xml --source-seq-file=SpinePhantomFreehand.mha --output-volume-file=vtkPlusVolumeReconstructorWithHoleFillingTest1Output.mha --image-to-reference-transform=ImageToReference
 
 Files:
-- Device set config file: https://subversion.assembla.com/svn/plus/trunk/PlusLibData/ConfigFiles/Testing/PlusDeviceSet_SpinePhantomFreehandReconstructionOnly.xml
-- Input frames: https://subversion.assembla.com/svn/plus/trunk/PlusLibData/TestImages/SpinePhantomFreehand.mha
-- Sample reconstructed volume: https://subversion.assembla.com/svn/plus/trunk/PlusLibData/TestImages/SpinePhantomFreehandReconstructed.mha
+- Device set config file: https://github.com/PlusToolkit/PlusLibData/blob/master/ConfigFiles/Testing/PlusDeviceSet_SpinePhantomFreehandReconstructionOnly.xml
+- Input frames: https://github.com/PlusToolkit/PlusLibData/blob/master/TestImages/SpinePhantomFreehand.mha
+- Sample reconstructed volume: https://github.com/PlusToolkit/PlusLibData/blob/master/TestImages/SpinePhantomFreehandReconstructed.mha
 
 See more examples on the <a href="http://perkdata.cs.queensu.ca/CDash/index.php?project=PlusLib">dashboard</a> (all the test cases starting with "vtkPlusVolumeReconstructor" perform volume reconstruction or verify volume reconstruction results).
 

--- a/src/Documentation/UserManual/CommonCoordinateSystems.dox
+++ b/src/Documentation/UserManual/CommonCoordinateSystems.dox
@@ -14,7 +14,7 @@ StylusTip | Tip of the stylus | mm  | X axis: aligned with the Stylus coordinate
 Image     | Position of the pixel that is in the origin of the MF oriented image  | pixel | X axis: towards the marked side of the transducer <br/> Y axis: towards the direction that points away (far) from the transducer <br/> Z axis: cross product of X and Y
 Transducer| Center of the transducer crystal array | mm | X axis: towards the marked side of the transducer <br/> Y axis: towards the direction that points away (far) from the transducer <br/> Z axis: cross product of X and Y
 
-Coordinate systems overview sketch (3D Slicer compatible interactive 3D model of the figure below is available <a href="https://subversion.assembla.com/svn/plus/trunk/doc/specifications/CoordinateSystems/CoordinateSystems.mrb" target="_blank">here</a>):
+Coordinate systems overview sketch (3D Slicer compatible interactive 3D model of the figure below is available <a href="https://github.com/PlusToolkit/PlusDoc/blob/master/specifications/CoordinateSystems/CoordinateSystems.mrb" target="_blank">here</a>):
 
 \image html CoordinateSystemDefinitionsfCal.png
 

--- a/src/Documentation/UserManual/DeviceAscension3DG.dox
+++ b/src/Documentation/UserManual/DeviceAscension3DG.dox
@@ -14,7 +14,7 @@
 
 Support for medSAFE models is not included in any of the standard packages, as they use different versions of the same DLLs as non-medSAFE trackers.
 
-To support medSAFE models Plus have to be built with PLUS_USE_Ascension3DGm configuration option enabled as described at https://www.assembla.com/spaces/plus/wiki/Windows_Build_Instructions.
+To support medSAFE models Plus have to be built with PLUS_USE_Ascension3DGm configuration option enabled as described at https://github.com/PlusToolkit/PlusBuild/blob/master/Docs/BuildInstructionsWindows.md.
 
 \section Ascension3DGInstallation Installation
 

--- a/src/Documentation/UserManual/DeviceBkProFocus.dox
+++ b/src/Documentation/UserManual/DeviceBkProFocus.dox
@@ -13,14 +13,14 @@
 - \ref PackageWin64
 
 - This device is not included in any of the standard packages, as it requires license from BK.
-- If the license is obtained from BK then Plus have to be built with PLUS_USE_BKPROFOCUS_VIDEO and optionally with PLUS_USE_BKPROFOCUS_CAMERALINK configuration options enabled as described at https://www.assembla.com/spaces/plus/wiki/Windows_Build_Instructions.
+- If the license is obtained from BK then Plus have to be built with PLUS_USE_BKPROFOCUS_VIDEO and optionally with PLUS_USE_BKPROFOCUS_CAMERALINK configuration options enabled as described at https://github.com/PlusToolkit/PlusBuild/blob/master/Docs/BuildInstructionsWindows.md.
 - The device is tested on Windows, but may also work on other platforms.
 
 \section BkProFocusInstallation Installation
 
 - Turn off "CRC Check" and "Require Acknowledge" on the BK scanner
 - To use \b ContinuousStreamingEnabled: lock image size on the BK scanner (customize dialog -> Split/Size -> check "Lock Image Size" checkbox)
-- Limitation of B-mode image acquisition through the OEM interface: the application crashes on disconnect (see <a href="https://www.assembla.com/spaces/plus/tickets/753">#753</a>)
+- Limitation of B-mode image acquisition through the OEM interface: the application crashes on disconnect (see <a href="https://plustoolkit.github.io/legacytickets">#753</a>)
 - RF acquisition through TeledyneDalsa CameraLink interface card is supported, using Sapera API.
   - B-mode acquisition (using the internal RF->B-mode conversion algorithm) is available for the BK 8848 transducer (http://www.bkmed.com/8848_en.htm).
   - Need to install the DALSA Sapera package, otherwise the applications will not start because of missing the SapClassBasic72.dll. This dll can only be used with 64-bit Plus build on 64-bit OS and 32-bit Plus build on a 32-bit OS. Therefore the bitness of the Plus package shall match the bitness of the operating system.

--- a/src/Documentation/UserManual/DeviceInterson.dox
+++ b/src/Documentation/UserManual/DeviceInterson.dox
@@ -13,7 +13,7 @@
 \section IntersonInstallation Installation
 
 - Requires SDK provided by Interson for compilation and USB drivers provided by Interson for running (otherwise Plus application will not start due to missing WDAPI1010.dll).
-- Limitations: imaging parameters are hardcoded, makeing them configurable is a work in progress, see details in <a href="https://www.assembla.com/spaces/plus/tickets/866">#866 </a>, <a href="https://www.assembla.com/spaces/plus/tickets/867">#867 </a> and <a href="https://www.assembla.com/spaces/plus/tickets/868">#868 </a>
+- Limitations: imaging parameters are hardcoded, makeing them configurable is a work in progress, see details in <a href="https://plustoolkit.github.io/legacytickets">#866 </a>, <a href="https://plustoolkit.github.io/legacytickets">#867 </a> and <a href="https://plustoolkit.github.io/legacytickets">#868 </a>
 
 \section IntersonConfigSettings Device configuration settings
 

--- a/src/Documentation/UserManual/DeviceOpenIGTLinkTracker.dox
+++ b/src/Documentation/UserManual/DeviceOpenIGTLinkTracker.dox
@@ -10,7 +10,7 @@
 - BrainLab surgical navigation system
   - BrainLab OpenIGTLink interface may be purchased as a license option with VectorVision Cranial 2.1.
   - Contact BrainLab for information about licensing and for supported OpenIGTLink options.
-  - For tracking data, the BrainLab OpenIGTLink interface uses the <a href="http://www.na-mic.org/Wiki/index.php/OpenIGTLink/ProtocolV2/Type/TrackingData">TDATA</a> message type, which is supported by PLUS 2.0 as of <a href="https://www.assembla.com/code/plus/subversion/changesets/2337">r2337</a>
+  - For tracking data, the BrainLab OpenIGTLink interface uses the <a href="http://www.na-mic.org/Wiki/index.php/OpenIGTLink/ProtocolV2/Type/TrackingData">TDATA</a> message type, which is supported by PLUS 2.0 as of r2337
   - In the configuration section for OpenIGTLinkTracker Device, set \b MessageType \c ="TDATA" and \b ReconnectOnReceiveTimeout \c ="FALSE" (to avoid reconnects, as BrainLab asks for manual confirmation on each connect request)
   - See ConfigFiles/BWH directory for example configurations using BrainLab tracking.
 

--- a/src/Documentation/UserManual/DeviceOpticalMarkerTracker.dox
+++ b/src/Documentation/UserManual/DeviceOpticalMarkerTracker.dox
@@ -14,7 +14,7 @@ OpticalMarkerTracker is virtual device that provides position tracking of marker
 \section DeviceOpticalMarkerTrackerInstallation Installation
 
 To get started, print a set of markers and create a configuration file. It is recommended to use "PlusServer: Optical marker tracker using MMF video" configuration file that is included in your Plus installation package (see also at the bottom of this page) and print this sheet that contains a number of markers with different sizes (make sure to print in actual size: scaling should be 100%):
-<a href="https://app.assembla.com/spaces/plus/subversion/source/HEAD/trunk/PlusLibData/ConfigFiles/OpticalMarkerTracker/marker_sheet_36h12.pdf?_format=raw">marker_sheet_36h12.pdf</a>. If you put the sheet in the field of view of your camera, the device will detect position and orientation of the markers.
+<a href="https://github.com/PlusToolkit/PlusLibData/raw/master/ConfigFiles/OpticalMarkerTracker/marker_sheet_36h12.pdf">marker_sheet_36h12.pdf</a>. If you put the sheet in the field of view of your camera, the device will detect position and orientation of the markers.
 
 To improve tracking accuracy, you need to create a calibration file for your camera as described below.  If you need more tracking markers, you can print more by following instructions below.
 
@@ -23,7 +23,7 @@ To improve tracking accuracy, you need to create a calibration file for your cam
 Camera calibration determines optical properties of your camera (distortion, focal length, etc) to improve tracking accuracy.
 
 - <strong>WARNING: Camera calibration uses an external application, which uses meters as unit for length. This is the ONLY place length should be specified in meters.  Everywhere else in Plus it is millimeter.</strong>
-- Print the <a href="https://subversion.assembla.com/svn/plus/trunk/PlusLibData/ConfigFiles/OpticalMarkerTracker/aruco_calibration_board_a4.pdf">aruco calibration chessboard</a> and measure the side length of the markers.
+- Print the <a href="https://github.com/PlusToolkit/PlusLibData/blob/master/ConfigFiles/OpticalMarkerTracker/aruco_calibration_board_a4.pdf">aruco calibration chessboard</a> and measure the side length of the markers.
 - To generate a calibration file, run aruco_calibration.exe \n
   Example: \n
   \code aruco_calibration.exe live:0 camera_calibration.yml -size 0.03556 \endcode
@@ -49,9 +49,9 @@ Camera calibration determines optical properties of your camera (distortion, foc
 
 \subsection DeviceOpticalMarkerTrackerMarkerGeneration Creating printable marker images
 - A premade sheet of ARUCO_36h12 markers in three standard sizes (80mm, 50mm, and 30mm) is located at
-  <a href="https://subversion.assembla.com/svn/plus/trunk/PlusLibData/ConfigFiles/OpticalMarkerTracker/marker_sheet_36h12.pdf">/ConfigFiles/OpticalMarkerTracker/marker_sheet_36h12.pdf</a>.
+  <a href="https://github.com/PlusToolkit/PlusLibData/blob/master/ConfigFiles/OpticalMarkerTracker/marker_sheet_36h12.pdf">/ConfigFiles/OpticalMarkerTracker/marker_sheet_36h12.pdf</a>.
 - Some pre-generated marker images from the ARUCO_MIP_36h12 dictionary are included at
-  <a href="https://subversion.assembla.com/svn/plus/trunk/PlusLibData/ConfigFiles/OpticalMarkerTracker/markers">/ConfigFiles/OpticalMarkerTracker/markers</a>.
+  <a href="https://github.com/PlusToolkit/PlusLibData/tree/master/ConfigFiles/OpticalMarkerTracker/markers">/ConfigFiles/OpticalMarkerTracker/markers</a>.
 - To generate a \b single \b image for printing, run aruco_print_marker.exe \n
   Example: \n
   \code aruco_print_marker.exe 0 marker0.png -bs 75 -d ARUCO_MIP_36h12 \endcode
@@ -75,7 +75,7 @@ Camera calibration determines optical properties of your camera (distortion, foc
 \section DeviceOpticalMarkerTrackerConfigSettings Device configuration settings
 - Calibration files can be generated as above, under Calibration.
 - An example calibration file generated using a RealSense Gen2 camera unit is found at
-  <a href="https://subversion.assembla.com/svn/plus/trunk/PlusLibData/ConfigFiles/OpticalMarkerTracker/realsense_gen2_calibration.yml">/ConfigFiles/OpticalMarkerTracker/realsense_gen2_calibration.yml</a>
+  <a href="https://github.com/PlusToolkit/PlusLibData/blob/master/ConfigFiles/OpticalMarkerTracker/realsense_gen2_calibration.yml">/ConfigFiles/OpticalMarkerTracker/realsense_gen2_calibration.yml</a>
 - The creation of a custom calibration file for your camera is \b strongly recommended.  Failure to do so can result in erroneous and/or unstable measurements. \n \n
 - \xmlAtt \ref DeviceType "Type" = \c "OpticalMarkerTracker" \RequiredAtt
 - \xmlAtt \b CameraCalibrationFile Camera calibration file containing device-specific parameters measured by the camera calibration utility. Path is relative to \ref FileApplicationConfiguration "DeviceSetConfigurationDirectory". \RequiredAtt
@@ -85,7 +85,7 @@ Camera calibration determines optical properties of your camera (distortion, foc
     - \c OPTICAL_AND_DEPTH uses depth data and RGB video (work in progress).
 - \xmlAtt \b MarkerDictionary The dictionary whose markers are being used. \RequiredAtt
     - \c \b ARUCO_MIP_36h12 Use of this dictionary is recommended. Some pre-generated marker images are included at
-  <a href="https://subversion.assembla.com/svn/plus/trunk/PlusLibData/ConfigFiles/OpticalMarkerTracker/markers">/ConfigFiles/OpticalMarkerTracker/markers</a>.
+  <a href="https://github.com/PlusToolkit/PlusLibData/tree/master/ConfigFiles/OpticalMarkerTracker/markers">/ConfigFiles/OpticalMarkerTracker/markers</a>.
     - \c ARUCO
     - \c ARUCO_MIP_16h3
     - \c ARUCO_MIP_25h7
@@ -104,7 +104,7 @@ Camera calibration determines optical properties of your camera (distortion, foc
 
 \section DeviceOpticalMarkerTrackerExampleConfigFile Example configuration file PlusDeviceSet_Server_OpticalMarkerTracker_Mmf.xml
 
-This configuration file can be used with this example 3D Slicer scene: <a href="https://app.assembla.com/spaces/plus/subversion/source/HEAD/trunk/PlusLibData/ConfigFiles/OpticalMarkerTracker/OpticalMarkerTracker_Scene.mrb?_format=raw">OpticalMarkerTracker_Scene.mrb</a>
+This configuration file can be used with this example 3D Slicer scene: <a href="https://github.com/PlusToolkit/PlusLibData/raw/master/ConfigFiles/OpticalMarkerTracker/OpticalMarkerTracker_Scene.mrb">OpticalMarkerTracker_Scene.mrb</a>
 
 \include "ConfigFiles/PlusDeviceSet_Server_OpticalMarkerTracker_Mmf.xml"
 

--- a/src/Documentation/UserManual/DeviceStealthLink.dox
+++ b/src/Documentation/UserManual/DeviceStealthLink.dox
@@ -20,7 +20,7 @@ Nomenclature:
 - \ref PackageLinux
 
 This device is not included in any of the standard packages, as it requires StealthLink library from Medtronic.
-If the StealthLink library is obtained from Medtronic then Plus have to be built with the StealthLink option enabled as described at https://www.assembla.com/spaces/plus/wiki/Windows_Build_Instructions.
+If the StealthLink library is obtained from Medtronic then Plus have to be built with the StealthLink option enabled as described at https://github.com/PlusToolkit/PlusBuild/blob/master/Docs/BuildInstructionsWindows.md.
 The device is tested on Windows, but should also work on other platforms.
 
 \section StealthLinkInstallation Installation

--- a/src/Documentation/UserManual/FileSequenceFile.dox
+++ b/src/Documentation/UserManual/FileSequenceFile.dox
@@ -50,8 +50,8 @@ NRRD file stores additional information in custom fields similar to those used i
 
 \section FileSequenceFileMatlab Reading/writing in Matlab
 
-- Sequence metafiles can be read/written by mha_read_transforms.m, mha_read_volume.m, and mha_write_volume.m functions, available from: https://www.assembla.com/spaces/plus/subversion/source/HEAD/trunk/MatlabUtils
-- Sequence NRRD files can be read/written by readdnrrd.m and writenrrd.m files available here: https://app.assembla.com/spaces/slicerrt/subversion/source/HEAD/trunk/MatlabBridge/src/MatlabCommander/commandserver
+- Sequence metafiles can be read/written by mha_read_transforms.m, mha_read_volume.m, and mha_write_volume.m functions, available from: https://github.com/PlusToolkit/PlusMatlabUtils
+- Sequence NRRD files can be read/written by readdnrrd.m and writenrrd.m files available here: https://github.com/PerkLab/SlicerMatlabBridge/tree/master/MatlabCommander/commandserver
 
 
 \section FileSequenceFileSlicer Reading/writing in 3D Slicer

--- a/src/PlusCalibration/PatternLocAlgo/PlusFidLabeling.cxx
+++ b/src/PlusCalibration/PatternLocAlgo/PlusFidLabeling.cxx
@@ -642,7 +642,7 @@ void PlusFidLabeling::FindPattern()
       }
 
       // Sort result lines according to middlePoint Y's
-      // TODO: If the wire pattern is asymmetric then use the pattern geometry to match the lines to the intersection points instead of just sort them by Y value (https://www.assembla.com/spaces/plus/tickets/435)
+      // TODO: If the wire pattern is asymmetric then use the pattern geometry to match the lines to the intersection points instead of just sort them by Y value (https://plustoolkit.github.io/legacytickets #435)
       std::vector<double>::iterator middlePointYsBeginIt = resultLineMiddlePointYs.begin();
       for ( int i = 0; i < numberOfLines; ++i )
       {

--- a/src/PlusDataCollection/SonixVideo/vtkPlusSonixVideoSource.cxx
+++ b/src/PlusDataCollection/SonixVideo/vtkPlusSonixVideoSource.cxx
@@ -648,7 +648,7 @@ PlusStatus vtkPlusSonixVideoSource::WriteConfiguration(vtkXMLDataElement* rootCo
   {
     deviceConfig->SetAttribute("ImagingMode", "BMode");
   }
-#if (PLUS_ULTRASONIX_SDK_MAJOR_VERSION < 6) // RF acquisition mode is not supported on Ultrasonix SDK 6.x and above - see https://www.assembla.com/spaces/plus/tickets/489-add-rf-image-acquisition-support-on-ulterius-6-x
+#if (PLUS_ULTRASONIX_SDK_MAJOR_VERSION < 6) // RF acquisition mode is not supported on Ultrasonix SDK 6.x and above - see #489 in https://plustoolkit.github.io/legacytickets
   else if (this->ImagingMode == RfMode)
   {
     deviceConfig->SetAttribute("ImagingMode", "RfMode");

--- a/src/PlusVolumeReconstruction/vtkPlusFillHolesInVolume.h
+++ b/src/PlusVolumeReconstruction/vtkPlusFillHolesInVolume.h
@@ -186,7 +186,7 @@ public:
 
   Warning: The class was part of the SynchroGrab library and ported into
   Plus, but has not been tested and probably needs some work to fill the holes correctly.
-  See https://www.assembla.com/spaces/plus/tickets/285-hole-filling-after-volume-reconstruction-doesn-t-seem-to-be-effective
+  See #285 in https://plustoolkit.github.io/legacytickets
 
   \sa vtkPlusPasteSliceIntoVolume
   \ingroup PlusLibVolumeReconstruction

--- a/src/UsePlusLib.cmake.in
+++ b/src/UsePlusLib.cmake.in
@@ -35,7 +35,7 @@ IF(NOT PLUSLIB_USE_FILE_INCLUDED)
   IF(ITK_FOUND)
     INCLUDE("@ITK_USE_FILE@")
   ELSE()
-    MESSAGE(FATAL_ERROR "ITK not found in UsePlusLib.cmake. Please report this to the developers at https://app.assembla.com/spaces/plus/wiki.")
+    MESSAGE(FATAL_ERROR "ITK not found in UsePlusLib.cmake. Please report this to the developers at https://github.com/PlusToolkit/PlusLib.")
   ENDIF()
 
   ## Find VTK
@@ -43,7 +43,7 @@ IF(NOT PLUSLIB_USE_FILE_INCLUDED)
   IF (VTK_FOUND)
     INCLUDE("@VTK_USE_FILE@")
   ELSE()
-    MESSAGE(FATAL_ERROR "VTK not found in UsePlusLib.cmake. Please report this to the developers at https://app.assembla.com/spaces/plus/wiki.")
+    MESSAGE(FATAL_ERROR "VTK not found in UsePlusLib.cmake. Please report this to the developers at https://github.com/PlusToolkit/PlusLib.")
   ENDIF()
 
   SET(PLUS_USE_OpenIGTLink @PLUS_USE_OpenIGTLink@)


### PR DESCRIPTION
Update documentation and references to Assembla to reference the corresponding GitHub locations.

Relevant issue: https://github.com/PlusToolkit/PlusLib/issues/209