### PR TITLE
Fix for connection issues with NDI Polaris

### DIFF
--- a/src/Documentation/UserManual/DeviceNDI.dox
+++ b/src/Documentation/UserManual/DeviceNDI.dox
@@ -25,7 +25,7 @@ Any NDI tracking device is supported that uses the common API, such as <a href="
 - \xmlAtt \ref ToolReferenceFrame \OptionalAtt{Tracker}
 
 - \xmlAtt \b SerialPort parameter must correlate to the com port number used by the NDI SCU Port. This port number was determined during driver installation, to check its value go to control panel->Device Manager->Ports(COM&LPT) and you should see an icon labelled NDI Polaris Spectra SCU Port(COMx), with x representing the COM port number you need to specify in the config file. If \b SerialPort \c = -1 or not specified, then probe the first 20 serial ports. \OptionalAtt{-1}
-- \xmlAtt \b BaudRate specifies the speed of the COM port, the recommended value is 115200. Valid values: <tt> 9600, 14400, 19200, 38400, 5760, 115200, 921600, 1228739 </tt>\OptionalAtt{9600}
+- \xmlAtt \b BaudRate specifies the speed of the COM port, the recommended value is 115200. Valid values: <tt> 9600, 14400, 19200, 38400, 5760, 115200, 921600, 1228739. </tt> Values of 14400 and 19200 have been known to cause issues and are not recommended \OptionalAtt{9600}
 - \xmlAtt \b NetworkHostname this is the hostname of a network enabled NDI device (NDI Vega). If this attribute is specified, all serial port fucntionality is disabled \OptionalAtt{""}
 - \xmlAtt \b NetworkPort the port number for API connections (not the camera port!) \OptionalAtt{8765}
 

--- a/src/PlusDataCollection/NDICAPITracking/vtkPlusNDITracker.cxx
+++ b/src/PlusDataCollection/NDICAPITracking/vtkPlusNDITracker.cxx
@@ -1008,7 +1008,7 @@ PlusStatus vtkPlusNDITracker::ReadConfiguration(vtkXMLDataElement* rootConfigEle
 
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(unsigned long, SerialPort, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(unsigned long, BaudRate, deviceConfig);
-  if (vtkPlusNDITracker::ConvertBaudToNDIEnum(this->BaudRate) == -1)
+  if (deviceConfig->GetAttribute("BaudRate") != NULL && vtkPlusNDITracker::ConvertBaudToNDIEnum(this->BaudRate) == -1)
   {
     LOG_WARNING("Invalid baud rate specified, reverting to auto-select.");
     this->BaudRate = 0;

--- a/src/PlusDataCollection/NDICAPITracking/vtkPlusNDITracker.cxx
+++ b/src/PlusDataCollection/NDICAPITracking/vtkPlusNDITracker.cxx
@@ -959,17 +959,19 @@ PlusStatus vtkPlusNDITracker::SendSromToTracker(const NdiToolDescriptor& toolDes
   char hexbuffer[TRANSFER_BLOCK_SIZE * 2];
   for (int i = 0; i < VIRTUAL_SROM_SIZE; i += TRANSFER_BLOCK_SIZE)
   {
-    this->Command("PVWR:%02X%04X%.128s", toolDescriptor.PortHandle, i,
-                  ndiHexEncode(hexbuffer, &(toolDescriptor.VirtualSROM[i]), TRANSFER_BLOCK_SIZE));
-  }
+    RETRY_UNTIL_TRUE(
+      strcmp(this->Command("PVWR:%02X%04X%.128s", toolDescriptor.PortHandle, i,
+                           ndiHexEncode(hexbuffer, &(toolDescriptor.VirtualSROM[i]), TRANSFER_BLOCK_SIZE)).c_str(), "OKAY") == 0,
+      10, 0.1);
 
-  int errnum = ndiGetError(this->Device);
-  if (errnum)
-  {
-    std::stringstream ss;
-    ss << "Failed to send SROM to NDI tracker: " << ndiErrorString(errnum);
-    LOG_ERROR(ss.str());
-    return PLUS_FAIL;
+    int errnum = ndiGetError(this->Device);
+    if (errnum)
+    {
+      std::stringstream ss;
+      ss << "Failed to send SROM to NDI tracker: " << ndiErrorString(errnum);
+      LOG_ERROR(ss.str());
+      return PLUS_FAIL;
+    }
   }
 
   return PLUS_SUCCESS;

--- a/src/PlusDataCollection/NDICAPITracking/vtkPlusNDITracker.h
+++ b/src/PlusDataCollection/NDICAPITracking/vtkPlusNDITracker.h
@@ -272,6 +272,9 @@ protected:
   */
   PlusStatus SelectMeasurementVolumeDeprecated();
 
+  /*! Lookup table function to convert from baudrate to enum */
+  static int ConvertBaudToNDIEnum(int baudRate);
+
 #if _MSC_VER >= 1700
   PlusStatus ProbeSerialInternal();
 #endif


### PR DESCRIPTION
Fixed or Irrelevant Issues:
  - Connecting with a baud rate of 19200 always fails with Device->host communication timeout [(Line 973](https://github.com/Sunderlandkyl/PlusLib/blob/e6bc96cd4038613975df002ef27afdb82cd7bd19/src/PlusDataCollection/NDICAPITracking/vtkPlusNDITracker.cxx#L973)) - probably due to this baud rate is reused for indicating higher speed => document that we do not recommend this baud rate
  - Connecting with a baud rate of 14400 results in a "Command is invalid in current mode" error => document that we do not recommend this baud rate
  - Frequent errors caused by the Probe() function.
    - Fixed in https://github.com/PlusToolkit/ndicapi/pull/7
  - Frame number is incorrect: => test if it is a parsing issue
    - The frame number returned at [Line 542](https://github.com/Sunderlandkyl/PlusLib/blob/e6bc96cd4038613975df002ef27afdb82cd7bd19/src/PlusDataCollection/NDICAPITracking/vtkPlusNDITracker.cxx#L542) switches between a small and large number every couple seconds. (ex 16767 and 4294967170).
    - Fixed in: https://github.com/Sunderlandkyl/ndicapi/commit/bef0e4400f626eae42e43ddadcda62ed436abb80
  - Infrequent failure (1 in 5 times) in vtkPlusNDITracker::EnableToolPorts() with some baud rates: (1228739, 921600, 230400) => investigate a bit more to see if delays or retries can fix it
    - Error returned at [Line 684](https://github.com/Sunderlandkyl/PlusLib/blob/e6bc96cd4038613975df002ef27afdb82cd7bd19/src/PlusDataCollection/NDICAPITracking/vtkPlusNDITracker.cxx#L684)
      -  0x40: Tool definition file error
    - **FIXED**: Errors were occurring during the SROM file upload. The error was only being checked at the end, ignoring potential timeout issues during the upload.
  - Connecting with a baud rate of 230400 fails as Polaris responds with an error (probably the firmware does not support this speed), so Plus tries to automatically find the highest baud rate => no action needed, just make auto-select robust