### PR TITLE
re #249: Fix crash caused by importing images from StealthStation

### DIFF
--- a/src/PlusOpenIGTLink/vtkPlusIgtlMessageFactory.cxx
+++ b/src/PlusOpenIGTLink/vtkPlusIgtlMessageFactory.cxx
@@ -94,9 +94,9 @@ igtl::MessageBase::Pointer vtkPlusIgtlMessageFactory::CreateReceiveMessage(const
   {
     aMessageBase = this->IgtlFactory->CreateReceiveMessage(aIgtlMessageHdr);
   }
-  catch (std::invalid_argument* e)
+  catch (std::invalid_argument& e)
   {
-    LOG_ERROR("Unable to create message: " << e);
+    LOG_ERROR("Unable to create message: " << e.what());
     return NULL;
   }
 
@@ -117,9 +117,9 @@ igtl::MessageBase::Pointer vtkPlusIgtlMessageFactory::CreateSendMessage(const st
   {
     aMessageBase = this->IgtlFactory->CreateSendMessage(messageType, headerVersion);
   }
-  catch (std::invalid_argument* e)
+  catch (std::invalid_argument& e)
   {
-    LOG_ERROR("Unable to create message: " << e);
+    LOG_ERROR("Unable to create message: " << e.what());
     return NULL;
   }
   return aMessageBase;
@@ -145,9 +145,9 @@ PlusStatus vtkPlusIgtlMessageFactory::PackMessages(const PlusIgtlClientInfo& cli
     {
       igtlMessage = this->IgtlFactory->CreateSendMessage(messageType, clientInfo.ClientHeaderVersion);
     }
-    catch (std::invalid_argument* e)
+    catch (std::invalid_argument& e)
     {
-      LOG_ERROR("Unable to create message: " << e);
+      LOG_ERROR("Unable to create message: " << e.what());
       continue;
     }
 

--- a/src/PlusServer/vtkPlusCommandProcessor.cxx
+++ b/src/PlusServer/vtkPlusCommandProcessor.cxx
@@ -317,6 +317,41 @@ PlusStatus vtkPlusCommandProcessor::QueueCommandResponse(PlusStatus status, cons
 }
 
 //------------------------------------------------------------------------------
+PlusStatus vtkPlusCommandProcessor::QueueGetImageMetaData(unsigned int clientId, const std::string &deviceName)
+{
+
+  vtkSmartPointer<vtkPlusGetImageCommand> cmdGetImage = vtkSmartPointer<vtkPlusGetImageCommand>::New();
+  cmdGetImage->SetCommandProcessor(this);
+  cmdGetImage->SetClientId(clientId);
+  cmdGetImage->SetDeviceName(deviceName.c_str());
+  cmdGetImage->SetNameToGetImageMeta();
+  cmdGetImage->SetImageId(deviceName.c_str());
+  {
+    // Add command to the execution queue
+    PlusLockGuard<vtkPlusRecursiveCriticalSection> updateMutexGuardedLock(this->Mutex);
+    this->CommandQueue.push_back(cmdGetImage);
+  }
+  return PLUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+PlusStatus vtkPlusCommandProcessor::QueueGetImage(unsigned int clientId, const std::string &deviceName)
+{
+  vtkSmartPointer<vtkPlusGetImageCommand> cmdGetImage = vtkSmartPointer<vtkPlusGetImageCommand>::New();
+  cmdGetImage->SetCommandProcessor(this);
+  cmdGetImage->SetClientId(clientId);
+  cmdGetImage->SetDeviceName(deviceName.c_str());
+  cmdGetImage->SetNameToGetImage();
+  cmdGetImage->SetImageId(deviceName.c_str());
+  {
+    // Add command to the execution queue
+    PlusLockGuard<vtkPlusRecursiveCriticalSection> updateMutexGuardedLock(this->Mutex);
+    this->CommandQueue.push_back(cmdGetImage);
+  }
+  return PLUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
 void vtkPlusCommandProcessor::PopCommandResponses(PlusCommandResponseList& responses)
 {
   PlusLockGuard<vtkPlusRecursiveCriticalSection> updateMutexGuardedLock(this->Mutex);

--- a/src/PlusServer/vtkPlusCommandProcessor.h
+++ b/src/PlusServer/vtkPlusCommandProcessor.h
@@ -72,6 +72,16 @@ public:
   virtual PlusStatus QueueCommandResponse(PlusStatus status, const std::string& deviceName, unsigned int clientId, const std::string& commandName, uint32_t uid, const std::string& replyString, const std::string& errorString);
 
   /*!
+  Adds a command to the queue for execution of the vtkGetImageCommand with the name GET_IMGMETA
+  !*/
+  PlusStatus QueueGetImageMetaData(unsigned int clientId, const std::string &deviceName);
+
+  /*!
+  Adds a command to the queue for execution of the vtkGetImageCommand with the name GET_IMAGE
+  !*/
+  PlusStatus QueueGetImage(unsigned int clientId, const std::string &deviceName);
+
+  /*!
     Return the queued command responses and removes the items from the queue (so that each item is returned only once) and clears the response queue.
     The caller is responsible for deleting the returned response objects.
     Can be called from any thread.

--- a/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
+++ b/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
@@ -805,6 +805,34 @@ void* vtkPlusOpenIGTLinkServer::DataReceiverThread(vtkMultiThreader::ThreadInfo*
       // status message is used as a keep-alive, don't do anything
       clientSocket->Skip(headerMsg->GetBodySizeToRead(), 0);
     }
+    else if (typeid(*bodyMessage) == typeid(igtl::GetImageMetaMessage))
+    {
+
+      // Image meta message
+      std::string deviceName("");
+      if (headerMsg->GetDeviceName() != NULL)
+      {
+        deviceName = headerMsg->GetDeviceName();
+      }
+      self->PlusCommandProcessor->QueueGetImageMetaData(clientId, deviceName);
+    }
+    else if (typeid(*bodyMessage) == typeid(igtl::GetImageMessage))
+    {
+
+      // Image meta message
+      std::string deviceName("");
+      if (headerMsg->GetDeviceName() != NULL)
+      {
+        deviceName = headerMsg->GetDeviceName();
+      }
+      else
+      {
+        LOG_ERROR("Please select the image you want to acquire");
+        return NULL;
+      }
+      self->PlusCommandProcessor->QueueGetImage(clientId, deviceName);
+
+    }
     else
     {
       // if the device type is unknown, skip reading.


### PR DESCRIPTION
Restore previous functionality that allowed images to be imported from the StealthStation through OpenIGTLink.

Relevant issue: https://github.com/PlusToolkit/PlusLib/issues/249