### PR TITLE
re #246: Disable PlusServerOpenIGTLinkCommandsTest on Linux

### DIFF
--- a/src/PlusServer/Testing/CMakeLists.txt
+++ b/src/PlusServer/Testing/CMakeLists.txt
@@ -15,16 +15,20 @@ IF(PLUSBUILD_BUILD_PlusLib_TOOLS)
   SET_TESTS_PROPERTIES( PlusServer PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR;WARNING" )
 
   #--------------------------------------------------------------------------------------------
-  ADD_TEST(PlusServerOpenIGTLinkCommandsTest
-    ${PLUS_EXECUTABLE_OUTPUT_PATH}/PlusServerRemoteControl
-    --server-config-file=${ConfigFilesDir}/Testing/PlusDeviceSet_OpenIGTLinkCommandsTest.xml
-    --run-tests
-    )
+  # Even with the timeout, the test still fails on Linux.
+  #   - The test is disabled on Linux for now
+  IF(NOT ${PLUSLIB_PLATFORM} MATCHES "Linux")
+    ADD_TEST(PlusServerOpenIGTLinkCommandsTest
+      ${PLUS_EXECUTABLE_OUTPUT_PATH}/PlusServerRemoteControl
+      --server-config-file=${ConfigFilesDir}/Testing/PlusDeviceSet_OpenIGTLinkCommandsTest.xml
+      --run-tests
+      )
 
-  # The timeout of 90 is added because this test does not seem to exit properly on Linux
-  SET_TESTS_PROPERTIES(PlusServerOpenIGTLinkCommandsTest 
-    PROPERTIES 
-      FAIL_REGULAR_EXPRESSION "ERROR;WARNING" 
-      TIMEOUT 90
-    )
+    # The timeout of 90 is added because this test does not seem to exit properly on Linux
+    SET_TESTS_PROPERTIES(PlusServerOpenIGTLinkCommandsTest 
+      PROPERTIES 
+        FAIL_REGULAR_EXPRESSION "ERROR;WARNING" 
+        TIMEOUT 90
+      )
+  ENDIF()
 ENDIF()


### PR DESCRIPTION
The test hangs on Linux waiting for mutex locks in vtkPlusOpenIGTLinkClient::SendCommand() and vtkPlusOpenIGTLinkClient::SendMessage().
This only happens when the PlusServer process is launched from PlusServerRemoteControl, but not when it's started separately.
For now, the conclusion is that we will disable the test on Linux, and potentially try to fix this at a later time.

Relevant issue: https://github.com/PlusToolkit/PlusLib/issues/246