### PR TITLE
re #259 Changed LOG_ERROR message under help call to std::cout, like …

### DIFF
--- a/src/PlusImageProcessing/Tools/EnhanceUsTrpSequence.cxx
+++ b/src/PlusImageProcessing/Tools/EnhanceUsTrpSequence.cxx
@@ -41,8 +41,8 @@ int main(int argc, char **argv)
 
   if (printHelp)
   {
-    //std::cout << args.GetHelp() << std::endl;
-    LOG_ERROR(args.GetHelp());
+    std::cout << args.GetHelp() << std::endl;
+    //LOG_ERROR(args.GetHelp());
     return EXIT_SUCCESS;
   }
 


### PR DESCRIPTION
…in the rest of the tools' source files, help text no longer returned as error