### PR TITLE
Do not swamp the log with the exact same message

### DIFF
--- a/src/PlusCommon/PlusCommon.cxx
+++ b/src/PlusCommon/PlusCommon.cxx
@@ -20,14 +20,14 @@ See License.txt for details.
 #include <string>
 
 //-------------------------------------------------------
-bool vtkPlusLogHelper::shouldWeLog(bool errorPresent)
+bool vtkPlusLogHelper::ShouldWeLog(bool errorPresent)
 {
   if (errorPresent)
   {
     ++m_Count;
     double timeStamp = vtkPlusAccurateTimer::GetSystemTime();
-    if (timeStamp - m_LastError > m_MinimumTimeBetweenLogging
-        || m_Count > m_MinimumCountBetweenLogging)
+    if (timeStamp - m_LastError > this->MinimumTimeBetweenLogging
+        || m_Count > this->MinimumCountBetweenLogging)
     {
       //log the error this time
       m_LastError = timeStamp;
@@ -41,7 +41,7 @@ bool vtkPlusLogHelper::shouldWeLog(bool errorPresent)
   }
   else //error has just been removed, reset to initial state
   {
-    m_LastError = -DBL_MAX / 2;
+    m_LastError = -std::numeric_limits<double>::max() / 2;
     m_Count = -2;
     return false;
   }

--- a/src/PlusCommon/PlusCommon.cxx
+++ b/src/PlusCommon/PlusCommon.cxx
@@ -26,8 +26,8 @@ bool vtkPlusLogHelper::ShouldWeLog(bool errorPresent)
   {
     ++m_Count;
     double timeStamp = vtkPlusAccurateTimer::GetSystemTime();
-    if (timeStamp - m_LastError > this->MinimumTimeBetweenLogging
-        || m_Count > this->MinimumCountBetweenLogging)
+    if (timeStamp - m_LastError > m_MinimumTimeBetweenLoggingSec
+        || m_Count > m_MinimumCountBetweenLogging)
     {
       //log the error this time
       m_LastError = timeStamp;

--- a/src/PlusCommon/PlusCommon.cxx
+++ b/src/PlusCommon/PlusCommon.cxx
@@ -20,6 +20,34 @@ See License.txt for details.
 #include <string>
 
 //-------------------------------------------------------
+bool vtkPlusLogHelper::shouldWeLog(bool errorPresent)
+{
+  if (errorPresent)
+  {
+    ++m_Count;
+    double timeStamp = vtkPlusAccurateTimer::GetSystemTime();
+    if (timeStamp - m_LastError > m_MinimumTimeBetweenLogging
+        || m_Count > m_MinimumCountBetweenLogging)
+    {
+      //log the error this time
+      m_LastError = timeStamp;
+      m_Count = 0;
+      return true;
+    }
+    else
+    {
+      return false;
+    }
+  }
+  else //error has just been removed, reset to initial state
+  {
+    m_LastError = -DBL_MAX / 2;
+    m_Count = -2;
+    return false;
+  }
+}
+
+//-------------------------------------------------------
 PlusTransformName::PlusTransformName()
 {
 }

--- a/src/PlusCommon/PlusCommon.h
+++ b/src/PlusCommon/PlusCommon.h
@@ -104,6 +104,30 @@ enum PlusImagingMode
   vtkPlusLogger::Instance()->LogMessage(logLevel, msgStream.str().c_str(), __FILE__, __LINE__); \
   }
 
+// If condition is satisfied, logs error only the first time
+// and returns PLUS_FAIL each time
+#define ERROR_FAIL_IF(condition, msg) \
+  { \
+  static bool messagePrinted = false; \
+  if (condition) \
+  { \
+    if (!messagePrinted) \
+    { \
+      LOG_ERROR(msg); \
+      messagePrinted = true; \
+    } \
+    return PLUS_FAIL; \
+  } \
+  else \
+  { \
+    if (messagePrinted) \
+    { \
+      LOG_INFO("The following error has just been resolved: " << msg); \
+    } \
+    messagePrinted = false; \
+  } \
+  }
+
 #define LOG_ERROR_W(msg) \
   { \
   std::wostringstream msgStream; \
@@ -147,6 +171,30 @@ enum PlusImagingMode
   std::wostringstream msgStream; \
   msgStream << msg << std::ends; \
   vtkPlusLogger::Instance()->LogMessage(logLevel, msgStream.str(), __FILE__, __LINE__); \
+  }
+
+// If condition is satisfied, logs error only the first time
+// and returns PLUS_FAIL each time
+#define ERROR_FAIL_IF_W(condition, msg) \
+  { \
+  static bool messagePrinted = false; \
+  if (condition) \
+  { \
+    if (!messagePrinted) \
+    { \
+      LOG_ERROR_W(msg); \
+      messagePrinted = true; \
+    } \
+    return PLUS_FAIL; \
+  } \
+  else \
+  { \
+    if (messagePrinted) \
+    { \
+      LOG_INFO_W("The following error has just been resolved: " << msg); \
+    } \
+    messagePrinted = false; \
+  } \
   }
 
 ///////////////////////////////////////////////////////////////////

--- a/src/PlusCommon/PlusCommon.h
+++ b/src/PlusCommon/PlusCommon.h
@@ -62,17 +62,17 @@ enum PlusImagingMode
 class vtkPlusLogHelper
 {
 public:
-  double MinimumTimeBetweenLogging = 60.0;
-  unsigned long MinimumCountBetweenLogging = 5000;
-  vtkPlusLogger::LogLevelType LogLevel = vtkPlusLogger::LOG_LEVEL_ERROR;
+  double m_MinimumTimeBetweenLoggingSec = 60.0;
+  unsigned long m_MinimumCountBetweenLogging = 5000;
+  vtkPlusLogger::LogLevelType m_LogLevel = vtkPlusLogger::LOG_LEVEL_ERROR;
 
-  // the parameters provide the maximum frequently the messages should be logged
-  vtkPlusLogHelper(double minimumTimeBetweenLogging = 60.0,
+  // the parameters provide the maximum frequency of logging
+  vtkPlusLogHelper(double minimumTimeBetweenLoggingSec = 60.0,
       unsigned long minimumCountBetweenLogging = 5000,
       vtkPlusLogger::LogLevelType logLevel = vtkPlusLogger::LOG_LEVEL_ERROR)
-      :MinimumTimeBetweenLogging(minimumTimeBetweenLogging),
-      MinimumCountBetweenLogging(minimumCountBetweenLogging),
-      LogLevel(logLevel)
+      :m_MinimumTimeBetweenLoggingSec(minimumTimeBetweenLoggingSec),
+      m_MinimumCountBetweenLogging(minimumCountBetweenLogging),
+      m_LogLevel(logLevel)
   {}
   bool ShouldWeLog(bool errorPresent); //should the error be logged this time?
 private:

--- a/src/PlusCommon/PlusCommon.h
+++ b/src/PlusCommon/PlusCommon.h
@@ -62,21 +62,21 @@ enum PlusImagingMode
 class vtkPlusLogHelper
 {
 public:
-  double m_MinimumTimeBetweenLogging = 60.0;
-  unsigned long m_MinimumCountBetweenLogging = 5000;
-  vtkPlusLogger::LogLevelType m_LogLevel = vtkPlusLogger::LOG_LEVEL_ERROR;
+  double MinimumTimeBetweenLogging = 60.0;
+  unsigned long MinimumCountBetweenLogging = 5000;
+  vtkPlusLogger::LogLevelType LogLevel = vtkPlusLogger::LOG_LEVEL_ERROR;
 
   // the parameters provide the maximum frequently the messages should be logged
   vtkPlusLogHelper(double minimumTimeBetweenLogging = 60.0,
       unsigned long minimumCountBetweenLogging = 5000,
       vtkPlusLogger::LogLevelType logLevel = vtkPlusLogger::LOG_LEVEL_ERROR)
-      :m_MinimumTimeBetweenLogging(minimumTimeBetweenLogging),
-      m_MinimumCountBetweenLogging(minimumCountBetweenLogging),
-      m_LogLevel(logLevel)
+      :MinimumTimeBetweenLogging(minimumTimeBetweenLogging),
+      MinimumCountBetweenLogging(minimumCountBetweenLogging),
+      LogLevel(logLevel)
   {}
-  bool shouldWeLog(bool errorPresent); //should the error be logged this time?
+  bool ShouldWeLog(bool errorPresent); //should the error be logged this time?
 private:
-  double m_LastError = -DBL_MAX / 2; //last time an error was logged
+  double m_LastError = -std::numeric_limits<double>::max() / 2; //last time an error was logged
   unsigned long m_Count = -2; //how many times the error was encountered
 
 };
@@ -132,7 +132,7 @@ private:
   { \
   static vtkPlusLogHelper logHelper; \
   bool result = condition; \
-  if (logHelper.shouldWeLog(result)) \
+  if (logHelper.ShouldWeLog(result)) \
   { \
     LOG_ERROR(msg); \
   } \
@@ -153,7 +153,7 @@ private:
 #define CUSTOM_RETURN_WITH_FAIL_IF(condition, msg) \
   { \
   bool result = condition; \
-  if (logHelper.shouldWeLog(result)) \
+  if (logHelper.ShouldWeLog(result)) \
   { \
     LOG_ERROR(msg); \
   } \
@@ -219,7 +219,7 @@ private:
   { \
   static vtkPlusLogHelper logHelper; \
   bool result = condition; \
-  if (logHelper.shouldWeLog(result)) \
+  if (logHelper.ShouldWeLog(result)) \
   { \
     LOG_ERROR_W(msg); \
   } \
@@ -240,7 +240,7 @@ private:
 #define CUSTOM_RETURN_WITH_FAIL_IF_W(condition, msg) \
   { \
   bool result = condition; \
-  if (logHelper.shouldWeLog(result)) \
+  if (logHelper.ShouldWeLog(result)) \
   { \
     LOG_ERROR_W(msg); \
   } \

--- a/src/PlusCommon/PlusCommon.h
+++ b/src/PlusCommon/PlusCommon.h
@@ -59,6 +59,28 @@ enum PlusImagingMode
 ///////////////////////////////////////////////////////////////////
 // Logging
 
+class vtkPlusLogHelper
+{
+public:
+  double m_MinimumTimeBetweenLogging = 60.0;
+  unsigned long m_MinimumCountBetweenLogging = 5000;
+  vtkPlusLogger::LogLevelType m_LogLevel = vtkPlusLogger::LOG_LEVEL_ERROR;
+
+  // the parameters provide the maximum frequently the messages should be logged
+  vtkPlusLogHelper(double minimumTimeBetweenLogging = 60.0,
+      unsigned long minimumCountBetweenLogging = 5000,
+      vtkPlusLogger::LogLevelType logLevel = vtkPlusLogger::LOG_LEVEL_ERROR)
+      :m_MinimumTimeBetweenLogging(minimumTimeBetweenLogging),
+      m_MinimumCountBetweenLogging(minimumCountBetweenLogging),
+      m_LogLevel(logLevel)
+  {}
+  bool shouldWeLog(bool errorPresent); //should the error be logged this time?
+private:
+  double m_LastError = -DBL_MAX / 2; //last time an error was logged
+  unsigned long m_Count = -2; //how many times the error was encountered
+
+};
+
 #define LOG_ERROR(msg) \
   { \
   std::ostringstream msgStream; \
@@ -104,27 +126,45 @@ enum PlusImagingMode
   vtkPlusLogger::Instance()->LogMessage(logLevel, msgStream.str().c_str(), __FILE__, __LINE__); \
   }
 
-// If condition is satisfied, logs error only the first time
+// If condition is satisfied, logs error periodically
 // and returns PLUS_FAIL each time
-#define ERROR_FAIL_IF(condition, msg) \
+#define RETURN_WITH_FAIL_IF(condition, msg) \
   { \
-  static bool messagePrinted = false; \
-  if (condition) \
+  static vtkPlusLogHelper logHelper; \
+  bool result = condition; \
+  if (logHelper.shouldWeLog(result)) \
   { \
-    if (!messagePrinted) \
-    { \
-      LOG_ERROR(msg); \
-      messagePrinted = true; \
-    } \
-    return PLUS_FAIL; \
+    LOG_ERROR(msg); \
   } \
   else \
   { \
-    if (messagePrinted) \
-    { \
-      LOG_INFO("The following error has just been resolved: " << msg); \
-    } \
-    messagePrinted = false; \
+    LOG_TRACE(msg); \
+  } \
+  \
+  if (result) \
+  { \
+    return PLUS_FAIL; \
+  } \
+  }
+
+// If condition is satisfied, logs error periodically
+// and returns PLUS_FAIL each time. Uses a vtkPlusLogHelper logHelper,
+// which needs to be available in current scope.
+#define CUSTOM_RETURN_WITH_FAIL_IF(condition, msg) \
+  { \
+  bool result = condition; \
+  if (logHelper.shouldWeLog(result)) \
+  { \
+    LOG_ERROR(msg); \
+  } \
+  else \
+  { \
+    LOG_TRACE(msg); \
+  } \
+  \
+  if (result) \
+  { \
+    return PLUS_FAIL; \
   } \
   }
 
@@ -173,27 +213,45 @@ enum PlusImagingMode
   vtkPlusLogger::Instance()->LogMessage(logLevel, msgStream.str(), __FILE__, __LINE__); \
   }
 
-// If condition is satisfied, logs error only the first time
+// If condition is satisfied, logs error periodically
 // and returns PLUS_FAIL each time
-#define ERROR_FAIL_IF_W(condition, msg) \
+#define RETURN_WITH_FAIL_IF_W(condition, msg) \
   { \
-  static bool messagePrinted = false; \
-  if (condition) \
+  static vtkPlusLogHelper logHelper; \
+  bool result = condition; \
+  if (logHelper.shouldWeLog(result)) \
   { \
-    if (!messagePrinted) \
-    { \
-      LOG_ERROR_W(msg); \
-      messagePrinted = true; \
-    } \
-    return PLUS_FAIL; \
+    LOG_ERROR_W(msg); \
   } \
   else \
   { \
-    if (messagePrinted) \
-    { \
-      LOG_INFO_W("The following error has just been resolved: " << msg); \
-    } \
-    messagePrinted = false; \
+    LOG_TRACE_W(msg); \
+  } \
+  \
+  if (result) \
+  { \
+    return PLUS_FAIL; \
+  } \
+  }
+
+// If condition is satisfied, logs error periodically
+// and returns PLUS_FAIL each time. Uses a vtkPlusLogHelper logHelper,
+// which needs to be available in current scope.
+#define CUSTOM_RETURN_WITH_FAIL_IF_W(condition, msg) \
+  { \
+  bool result = condition; \
+  if (logHelper.shouldWeLog(result)) \
+  { \
+    LOG_ERROR_W(msg); \
+  } \
+  else \
+  { \
+    LOG_TRACE_W(msg); \
+  } \
+  \
+  if (result) \
+  { \
+    return PLUS_FAIL; \
   } \
   }
 

--- a/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
+++ b/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
@@ -1141,7 +1141,7 @@ PlusStatus vtkPlusCapistranoVideoSource::InternalUpdate()
   GetObject(this->Internal->DataHandle, sizeof(BITMAP), &this->Internal->Bitmap);
 
   vtkPlusDataSource* aSource=NULL;
-  ERROR_FAIL_IF(this->GetFirstActiveOutputVideoSource(aSource) != PLUS_SUCCESS,
+  RETURN_WITH_FAIL_IF(this->GetFirstActiveOutputVideoSource(aSource) != PLUS_SUCCESS,
       "Unable to retrieve the video source in the Capistrano device.");
 
   std::vector<int> frameSizeInPx = this->Internal->ImagingParameters->GetImageSize();
@@ -1175,7 +1175,7 @@ PlusStatus vtkPlusCapistranoVideoSource::InternalUpdate()
   //PlusTrackedFrame::FieldMapType customFields;
   const double unfilteredTimestamp = vtkPlusAccurateTimer::GetSystemTime();
 
-  ERROR_FAIL_IF(aSource->AddItem((void*)this->Internal->Bitmap.bmBits,
+  RETURN_WITH_FAIL_IF(aSource->AddItem((void*)this->Internal->Bitmap.bmBits,
                                  aSource->GetInputImageOrientation(),
                                  frameSize, VTK_UNSIGNED_CHAR,
                                  1, US_IMG_BRIGHTNESS, 0,
@@ -1194,9 +1194,9 @@ PlusStatus vtkPlusCapistranoVideoSource::InternalUpdate()
 // ----------------------------------------------------------------------------
 PlusStatus vtkPlusCapistranoVideoSource::FreezeDevice(bool freeze)
 {
-  ERROR_FAIL_IF(this->Internal->ProbeHandle == NULL,
+  RETURN_WITH_FAIL_IF(this->Internal->ProbeHandle == NULL,
       "vtkPlusIntersonVideoSource::FreezeDevice failed: device not connected");
-  ERROR_FAIL_IF(!usbHardwareDetected(),
+  RETURN_WITH_FAIL_IF(!usbHardwareDetected(),
       "Freeze failed, no hardware is detected");
 
   if (this->Frozen == freeze) //already in desired mode
@@ -1213,7 +1213,7 @@ PlusStatus vtkPlusCapistranoVideoSource::FreezeDevice(bool freeze)
   {
     usbClearCineBuffers();
     this->FrameNumber = 0;
-    ERROR_FAIL_IF(this->UpdateUSParameters() == PLUS_FAIL,
+    RETURN_WITH_FAIL_IF(this->UpdateUSParameters() == PLUS_FAIL,
         "Failed to update US parameters");
     usbProbe(RUN);
   }
@@ -1582,9 +1582,9 @@ PlusStatus vtkPlusCapistranoVideoSource::SetDepthMm(float depthMm)
 // ----------------------------------------------------------------------------
 PlusStatus vtkPlusCapistranoVideoSource::UpdateUSParameters()
 {
-  ERROR_FAIL_IF(this->UpdateUSProbeParameters() == PLUS_FAIL,
+  RETURN_WITH_FAIL_IF(this->UpdateUSProbeParameters() == PLUS_FAIL,
       "Failed to Update US probe parameters");
-  ERROR_FAIL_IF(this->UpdateUSBModeParameters() == PLUS_FAIL,
+  RETURN_WITH_FAIL_IF(this->UpdateUSBModeParameters() == PLUS_FAIL,
       "Failed to Update US BMode parameters");
   return PLUS_SUCCESS;
 }

--- a/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.cxx
+++ b/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.cxx
@@ -282,11 +282,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::InternalUpdate()
 
   for (auto it = EncoderList.begin(); it != EncoderList.end(); ++it)
   {
-    if (!it->Connected)
-    {
-      LOG_ERROR("USDigital encoder(s) not connected!");
-      return PLUS_FAIL;
-    }
+    ERROR_FAIL_IF(!it->Connected, "USDigital encoder(s) not connected!");
     
     long encoderValue;
     long errorCode;
@@ -294,11 +290,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::InternalUpdate()
     
     // Read encoder positions and transform it into XY position in mm
     errorCode = ::A2GetPosition(it->Addr, &encoderValue);
-    if (errorCode)
-    {
-      LOG_ERROR("Unable to read position of first encoder with address: " << it->Addr);
-      return PLUS_FAIL;
-    }
+    ERROR_FAIL_IF(errorCode, "Unable to read position of first encoder with address: " << it->Addr);
     vtkVector3d localmovement = it->LocalAxis;
 
     if (it->Addr2 != 0) //coreXY
@@ -306,11 +298,8 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::InternalUpdate()
       double firstEnc = encoderValue * it->PulseSpacing;
     
       errorCode = ::A2GetPosition(it->Addr2, &encoderValue);
-      if (errorCode)
-      {
-        LOG_ERROR("Unable to read position of second encoder with address: " << it->Addr2);
-        return PLUS_FAIL;
-      }
+      ERROR_FAIL_IF(errorCode, "Unable to read position of second encoder with address: " << it->Addr2);
+
       double secondEnc = encoderValue * it->PulseSpacing2;
     
       double firstAxis = firstEnc + secondEnc;
@@ -545,45 +534,28 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::WriteConfiguration(vtkXMLDataElement
 PlusStatus vtkPlusUSDigitalEncodersTracker::IsStepperAlive()
 {
   long r = ::IsInitialized();
-  if (r != 1)
-  {
-    // Device not yet initialized
-    return PLUS_FAIL;
-  }
-
+  ERROR_FAIL_IF(r != 1, "Device not yet initialized!");
   return PLUS_SUCCESS;
 }
 
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncodersStrobeMode()
 {
-  if (::A2SetStrobe() != 0)
-  {
-    LOG_ERROR("Failed to set US digital A2 Encoders as Strobe mode.");
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(::A2SetStrobe() != 0, "Failed to set US digital A2 Encoders as Strobe mode.");
   return PLUS_SUCCESS;
 }
 
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncodersSleep()
 {
-  if (::A2SetSleep() != 0)
-  {
-    LOG_ERROR("Failed to set US digital A2 Encoders as Sleep mode.");
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(::A2SetSleep() != 0, "Failed to set US digital A2 Encoders as Sleep mode.");
   return PLUS_SUCCESS;
 }
 
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncodersWakeup()
 {
-  if (::A2SetWakeup() != 0)
-  {
-    LOG_ERROR("Failed to set US digital A2 Encoders as Wakeup mode.");
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(::A2SetWakeup() != 0, "Failed to set US digital A2 Encoders as Wakeup mode.");
   return PLUS_SUCCESS;
 }
 
@@ -591,17 +563,9 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncodersWakeup()
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderOriginWithID(long id)
 {
   IDtoAddressType::iterator enc = this->IdAddress.find(id);
-  if (enc == this->IdAddress.end())
-  {
-    LOG_ERROR("Non-existent device ID: " << id);
-    return PLUS_FAIL;
-  }
-
-  if (::A2SetOrigin(enc->second) != 0)
-  {
-    LOG_ERROR("Failed to set US digital A2 Encoder's origin point as current position.");
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
+  ERROR_FAIL_IF(::A2SetOrigin(enc->second) != 0,
+      "Failed to set US digital A2 Encoder's origin point as current position.");
   return PLUS_SUCCESS;
 }
 
@@ -631,17 +595,9 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetAllUSDigitalA2EncoderOrigin()
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderModeWithID(long id, long mode)
 {
   IDtoAddressType::iterator enc = this->IdAddress.find(id);
-  if (enc == this->IdAddress.end())
-  {
-    LOG_ERROR("Non-existent device ID: " << id);
-    return PLUS_FAIL;
-  }
-
-  if (::A2SetMode(enc->second, mode) != 0)
-  {
-    LOG_ERROR("Failed to set the mode of an US digital A2 Encoder.");
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
+  ERROR_FAIL_IF(::A2SetMode(enc->second, mode) != 0,
+      "Failed to set the mode of an US digital A2 Encoder.");
   return PLUS_SUCCESS;
 }
 
@@ -649,17 +605,9 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderModeWithID(long
 PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderModeWithID(long id, long* mode)
 {
   IDtoAddressType::iterator enc = this->IdAddress.find(id);
-  if (enc == this->IdAddress.end())
-  {
-    LOG_ERROR("Non-existent device ID: " << id);
-    return PLUS_FAIL;
-  }
-
-  if (::A2GetMode(enc->second, mode) != 0)
-  {
-    LOG_ERROR("Failed to get the mode of an US digital A2 Encoder.");
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
+  ERROR_FAIL_IF(::A2GetMode(enc->second, mode) != 0,
+      "Failed to get the mode of an US digital A2 Encoder.");
   return PLUS_SUCCESS;
 }
 
@@ -667,17 +615,10 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderModeWithID(long
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderResoultionWithID(long id, long res)
 {
   IDtoAddressType::iterator enc = this->IdAddress.find(id);
-  if (enc == this->IdAddress.end())
-  {
-    LOG_ERROR("Non-existent device ID: " << id);
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
 
-  if (::A2SetResolution(enc->second, res) != 0)
-  {
-    LOG_ERROR("Failed to set the resoultion of an US digital A2 Encoder.");
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(::A2SetResolution(enc->second, res) != 0,
+      "Failed to set the resoultion of an US digital A2 Encoder.");
   return PLUS_SUCCESS;
 }
 
@@ -685,17 +626,10 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderResoultionWithI
 PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderResoultionWithID(long id, long* res)
 {
   IDtoAddressType::iterator enc = this->IdAddress.find(id);
-  if (enc == this->IdAddress.end())
-  {
-    LOG_ERROR("Non-existent device ID: " << id);
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
 
-  if (::A2GetResolution(enc->second, res) != 0)
-  {
-    LOG_ERROR("Failed to get the resoultion of an US digital A2 Encoder.");
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(::A2GetResolution(enc->second, res) != 0,
+     "Failed to get the resoultion of an US digital A2 Encoder.");
   return PLUS_SUCCESS;
 }
 
@@ -703,17 +637,10 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderResoultionWithI
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderPositionWithID(long id, long pos)
 {
   IDtoAddressType::iterator enc = this->IdAddress.find(id);
-  if (enc == this->IdAddress.end())
-  {
-    LOG_ERROR("Non-existent device ID: " << id);
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
 
-  if (::A2SetPosition(enc->second, pos) != 0)
-  {
-    LOG_ERROR("Failed to set the position of an US digital A2 Encoder.");
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(::A2SetPosition(enc->second, pos) != 0,
+      "Failed to set the position of an US digital A2 Encoder.");
   return PLUS_SUCCESS;
 }
 
@@ -721,16 +648,9 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderPositionWithID(
 PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderPositionWithID(long id, long* pos)
 {
   IDtoAddressType::iterator enc = this->IdAddress.find(id);
-  if (enc == this->IdAddress.end())
-  {
-    LOG_ERROR("Non-existent device ID: " << id);
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
 
-  if (::A2GetPosition(enc->second, pos) != 0)
-  {
-    LOG_ERROR("Failed to get the position of an US digital A2 Encoder.");
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(::A2GetPosition(enc->second, pos) != 0,
+     "Failed to get the position of an US digital A2 Encoder.");
   return PLUS_SUCCESS;
 }

--- a/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.cxx
+++ b/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.cxx
@@ -282,7 +282,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::InternalUpdate()
 
   for (auto it = EncoderList.begin(); it != EncoderList.end(); ++it)
   {
-    ERROR_FAIL_IF(!it->Connected, "USDigital encoder(s) not connected!");
+    RETURN_WITH_FAIL_IF(!it->Connected, "USDigital encoder(s) not connected!");
     
     long encoderValue;
     long errorCode;
@@ -290,7 +290,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::InternalUpdate()
     
     // Read encoder positions and transform it into XY position in mm
     errorCode = ::A2GetPosition(it->Addr, &encoderValue);
-    ERROR_FAIL_IF(errorCode, "Unable to read position of first encoder with address: " << it->Addr);
+    RETURN_WITH_FAIL_IF(errorCode, "Unable to read position of first encoder with address: " << it->Addr);
     vtkVector3d localmovement = it->LocalAxis;
 
     if (it->Addr2 != 0) //coreXY
@@ -298,7 +298,7 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::InternalUpdate()
       double firstEnc = encoderValue * it->PulseSpacing;
     
       errorCode = ::A2GetPosition(it->Addr2, &encoderValue);
-      ERROR_FAIL_IF(errorCode, "Unable to read position of second encoder with address: " << it->Addr2);
+      RETURN_WITH_FAIL_IF(errorCode, "Unable to read position of second encoder with address: " << it->Addr2);
 
       double secondEnc = encoderValue * it->PulseSpacing2;
     
@@ -534,28 +534,28 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::WriteConfiguration(vtkXMLDataElement
 PlusStatus vtkPlusUSDigitalEncodersTracker::IsStepperAlive()
 {
   long r = ::IsInitialized();
-  ERROR_FAIL_IF(r != 1, "Device not yet initialized!");
+  RETURN_WITH_FAIL_IF(r != 1, "Device not yet initialized!");
   return PLUS_SUCCESS;
 }
 
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncodersStrobeMode()
 {
-  ERROR_FAIL_IF(::A2SetStrobe() != 0, "Failed to set US digital A2 Encoders as Strobe mode.");
+  RETURN_WITH_FAIL_IF(::A2SetStrobe() != 0, "Failed to set US digital A2 Encoders as Strobe mode.");
   return PLUS_SUCCESS;
 }
 
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncodersSleep()
 {
-  ERROR_FAIL_IF(::A2SetSleep() != 0, "Failed to set US digital A2 Encoders as Sleep mode.");
+  RETURN_WITH_FAIL_IF(::A2SetSleep() != 0, "Failed to set US digital A2 Encoders as Sleep mode.");
   return PLUS_SUCCESS;
 }
 
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncodersWakeup()
 {
-  ERROR_FAIL_IF(::A2SetWakeup() != 0, "Failed to set US digital A2 Encoders as Wakeup mode.");
+  RETURN_WITH_FAIL_IF(::A2SetWakeup() != 0, "Failed to set US digital A2 Encoders as Wakeup mode.");
   return PLUS_SUCCESS;
 }
 
@@ -563,8 +563,8 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncodersWakeup()
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderOriginWithID(long id)
 {
   IDtoAddressType::iterator enc = this->IdAddress.find(id);
-  ERROR_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
-  ERROR_FAIL_IF(::A2SetOrigin(enc->second) != 0,
+  RETURN_WITH_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
+  RETURN_WITH_FAIL_IF(::A2SetOrigin(enc->second) != 0,
       "Failed to set US digital A2 Encoder's origin point as current position.");
   return PLUS_SUCCESS;
 }
@@ -595,8 +595,8 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetAllUSDigitalA2EncoderOrigin()
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderModeWithID(long id, long mode)
 {
   IDtoAddressType::iterator enc = this->IdAddress.find(id);
-  ERROR_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
-  ERROR_FAIL_IF(::A2SetMode(enc->second, mode) != 0,
+  RETURN_WITH_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
+  RETURN_WITH_FAIL_IF(::A2SetMode(enc->second, mode) != 0,
       "Failed to set the mode of an US digital A2 Encoder.");
   return PLUS_SUCCESS;
 }
@@ -605,8 +605,8 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderModeWithID(long
 PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderModeWithID(long id, long* mode)
 {
   IDtoAddressType::iterator enc = this->IdAddress.find(id);
-  ERROR_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
-  ERROR_FAIL_IF(::A2GetMode(enc->second, mode) != 0,
+  RETURN_WITH_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
+  RETURN_WITH_FAIL_IF(::A2GetMode(enc->second, mode) != 0,
       "Failed to get the mode of an US digital A2 Encoder.");
   return PLUS_SUCCESS;
 }
@@ -615,9 +615,9 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderModeWithID(long
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderResoultionWithID(long id, long res)
 {
   IDtoAddressType::iterator enc = this->IdAddress.find(id);
-  ERROR_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
+  RETURN_WITH_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
 
-  ERROR_FAIL_IF(::A2SetResolution(enc->second, res) != 0,
+  RETURN_WITH_FAIL_IF(::A2SetResolution(enc->second, res) != 0,
       "Failed to set the resoultion of an US digital A2 Encoder.");
   return PLUS_SUCCESS;
 }
@@ -626,9 +626,9 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderResoultionWithI
 PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderResoultionWithID(long id, long* res)
 {
   IDtoAddressType::iterator enc = this->IdAddress.find(id);
-  ERROR_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
+  RETURN_WITH_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
 
-  ERROR_FAIL_IF(::A2GetResolution(enc->second, res) != 0,
+  RETURN_WITH_FAIL_IF(::A2GetResolution(enc->second, res) != 0,
      "Failed to get the resoultion of an US digital A2 Encoder.");
   return PLUS_SUCCESS;
 }
@@ -637,9 +637,9 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderResoultionWithI
 PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderPositionWithID(long id, long pos)
 {
   IDtoAddressType::iterator enc = this->IdAddress.find(id);
-  ERROR_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
+  RETURN_WITH_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
 
-  ERROR_FAIL_IF(::A2SetPosition(enc->second, pos) != 0,
+  RETURN_WITH_FAIL_IF(::A2SetPosition(enc->second, pos) != 0,
       "Failed to set the position of an US digital A2 Encoder.");
   return PLUS_SUCCESS;
 }
@@ -648,9 +648,9 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::SetUSDigitalA2EncoderPositionWithID(
 PlusStatus vtkPlusUSDigitalEncodersTracker::GetUSDigitalA2EncoderPositionWithID(long id, long* pos)
 {
   IDtoAddressType::iterator enc = this->IdAddress.find(id);
-  ERROR_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
+  RETURN_WITH_FAIL_IF(enc == this->IdAddress.end(), "Non-existent device ID: " << id);
 
-  ERROR_FAIL_IF(::A2GetPosition(enc->second, pos) != 0,
+  RETURN_WITH_FAIL_IF(::A2GetPosition(enc->second, pos) != 0,
      "Failed to get the position of an US digital A2 Encoder.");
   return PLUS_SUCCESS;
 }

--- a/src/PlusDataCollection/vtkPlusChannel.cxx
+++ b/src/PlusDataCollection/vtkPlusChannel.cxx
@@ -705,11 +705,8 @@ PlusStatus vtkPlusChannel::GetTrackedFrame(double timestamp, PlusTrackedFrame& a
 PlusStatus vtkPlusChannel::GetTrackedFrame(PlusTrackedFrame& trackedFrame)
 {
   double mostRecentFrameTimestamp(0);
-  if (this->GetMostRecentTimestamp(mostRecentFrameTimestamp) != PLUS_SUCCESS)
-  {
-    LOG_ERROR("Failed to get most recent timestamp from the buffer!");
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(this->GetMostRecentTimestamp(mostRecentFrameTimestamp) != PLUS_SUCCESS,
+      "Failed to get most recent timestamp from the buffer!");
 
   return this->GetTrackedFrame(mostRecentFrameTimestamp, trackedFrame);
 }
@@ -752,11 +749,8 @@ PlusStatus vtkPlusChannel::GetTrackedFrameList(double& aTimestampOfLastFrameAlre
 
   // Get latest and oldest timestamp
   double mostRecentTimestamp(0);
-  if (this->GetMostRecentTimestamp(mostRecentTimestamp) != PLUS_SUCCESS)
-  {
-    LOG_ERROR("Unable to get most recent timestamp!");
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(this->GetMostRecentTimestamp(mostRecentTimestamp) != PLUS_SUCCESS,
+      "Unable to get most recent timestamp!");
 
   PlusStatus status = PLUS_SUCCESS;
   double oldestTimestamp(0);
@@ -1065,11 +1059,8 @@ PlusStatus vtkPlusChannel::GetTrackedFrameListSampled(double& aTimestampOfLastFr
   double startTimeSec = vtkPlusAccurateTimer::GetSystemTime();
 
   double mostRecentTimestamp(0);
-  if (this->GetMostRecentTimestamp(mostRecentTimestamp) != PLUS_SUCCESS)
-  {
-    LOG_ERROR("vtkPlusChannel::GetTrackedFrameListSampled failed: unable to get most recent timestamp. Probably no frames have been acquired yet.");
-    return PLUS_FAIL;
-  }
+  ERROR_FAIL_IF(this->GetMostRecentTimestamp(mostRecentTimestamp) != PLUS_SUCCESS,
+      "vtkPlusChannel::GetTrackedFrameListSampled failed: unable to get most recent timestamp. Probably no frames have been acquired yet.");
 
   PlusStatus status = PLUS_SUCCESS;
   // Add frames to input trackedFrameList
@@ -1277,11 +1268,8 @@ PlusStatus vtkPlusChannel::GetMostRecentTimestamp(double& ts)
   if (this->GetVideoDataAvailable())
   {
     // Get the most recent timestamp from the buffer
-    if (this->VideoSource->GetLatestTimeStamp(latestVideoTimestamp) != ITEM_OK)
-    {
-      LOG_WARNING("Unable to get latest timestamp from video buffer!");
-      return PLUS_FAIL;
-    }
+    ERROR_FAIL_IF(this->VideoSource->GetLatestTimeStamp(latestVideoTimestamp) != ITEM_OK,
+        "Unable to get latest timestamp from video buffer!");
   }
 
   double latestTrackerTimestamp(0); // the latest tracker timestamp that is available for all tools
@@ -1431,16 +1419,10 @@ PlusStatus vtkPlusChannel::GetMostRecentTimestamp(double& ts)
   {
     // Get the timestamp of the video item that is closest to the latest tracker item
     BufferItemUidType videoUid(0);
-    if (this->VideoSource->GetItemUidFromTime(latestTrackerTimestamp, videoUid) != ITEM_OK)
-    {
-      LOG_ERROR("Failed to get video buffer item UID from time: " << std::fixed << latestVideoTimestamp);
-      return PLUS_FAIL;
-    }
-    if (this->VideoSource->GetTimeStamp(videoUid, latestVideoTimestamp) != ITEM_OK)
-    {
-      LOG_ERROR("Failed to get video buffer timestamp from UID: " << videoUid);
-      return PLUS_FAIL;
-    }
+    ERROR_FAIL_IF(this->VideoSource->GetItemUidFromTime(latestTrackerTimestamp, videoUid) != ITEM_OK,
+        "Failed to get video buffer item UID from time: " << std::fixed << latestVideoTimestamp);
+    ERROR_FAIL_IF(this->VideoSource->GetTimeStamp(videoUid, latestVideoTimestamp) != ITEM_OK,
+        "Failed to get video buffer timestamp from UID: " << videoUid);
     if (latestVideoTimestamp > latestTrackerTimestamp)
     {
       // the closest video timestamp is still larger than the last tracking data,
@@ -1469,16 +1451,10 @@ PlusStatus vtkPlusChannel::GetMostRecentTimestamp(double& ts)
   {
     // Get the timestamp of the video item that is closest to the latest field data item
     BufferItemUidType videoUid(0);
-    if (this->VideoSource->GetItemUidFromTime(latestFieldDataTimestamp, videoUid) != ITEM_OK)
-    {
-      LOG_ERROR("Failed to get video buffer item UID from time: " << std::fixed << latestVideoTimestamp);
-      return PLUS_FAIL;
-    }
-    if (this->VideoSource->GetTimeStamp(videoUid, latestVideoTimestamp) != ITEM_OK)
-    {
-      LOG_ERROR("Failed to get video buffer timestamp from UID: " << videoUid);
-      return PLUS_FAIL;
-    }
+    ERROR_FAIL_IF(this->VideoSource->GetItemUidFromTime(latestFieldDataTimestamp, videoUid) != ITEM_OK,
+        "Failed to get video buffer item UID from time: " << std::fixed << latestVideoTimestamp);
+    ERROR_FAIL_IF(this->VideoSource->GetTimeStamp(videoUid, latestVideoTimestamp) != ITEM_OK,
+        "Failed to get video buffer timestamp from UID: " << videoUid);
     if (latestVideoTimestamp > latestFieldDataTimestamp)
     {
       // the closest video timestamp is still larger than the last field data,

--- a/src/PlusDataCollection/vtkPlusChannel.cxx
+++ b/src/PlusDataCollection/vtkPlusChannel.cxx
@@ -705,7 +705,7 @@ PlusStatus vtkPlusChannel::GetTrackedFrame(double timestamp, PlusTrackedFrame& a
 PlusStatus vtkPlusChannel::GetTrackedFrame(PlusTrackedFrame& trackedFrame)
 {
   double mostRecentFrameTimestamp(0);
-  ERROR_FAIL_IF(this->GetMostRecentTimestamp(mostRecentFrameTimestamp) != PLUS_SUCCESS,
+  RETURN_WITH_FAIL_IF(this->GetMostRecentTimestamp(mostRecentFrameTimestamp) != PLUS_SUCCESS,
       "Failed to get most recent timestamp from the buffer!");
 
   return this->GetTrackedFrame(mostRecentFrameTimestamp, trackedFrame);
@@ -749,7 +749,7 @@ PlusStatus vtkPlusChannel::GetTrackedFrameList(double& aTimestampOfLastFrameAlre
 
   // Get latest and oldest timestamp
   double mostRecentTimestamp(0);
-  ERROR_FAIL_IF(this->GetMostRecentTimestamp(mostRecentTimestamp) != PLUS_SUCCESS,
+  RETURN_WITH_FAIL_IF(this->GetMostRecentTimestamp(mostRecentTimestamp) != PLUS_SUCCESS,
       "Unable to get most recent timestamp!");
 
   PlusStatus status = PLUS_SUCCESS;
@@ -1059,7 +1059,7 @@ PlusStatus vtkPlusChannel::GetTrackedFrameListSampled(double& aTimestampOfLastFr
   double startTimeSec = vtkPlusAccurateTimer::GetSystemTime();
 
   double mostRecentTimestamp(0);
-  ERROR_FAIL_IF(this->GetMostRecentTimestamp(mostRecentTimestamp) != PLUS_SUCCESS,
+  RETURN_WITH_FAIL_IF(this->GetMostRecentTimestamp(mostRecentTimestamp) != PLUS_SUCCESS,
       "vtkPlusChannel::GetTrackedFrameListSampled failed: unable to get most recent timestamp. Probably no frames have been acquired yet.");
 
   PlusStatus status = PLUS_SUCCESS;
@@ -1268,7 +1268,7 @@ PlusStatus vtkPlusChannel::GetMostRecentTimestamp(double& ts)
   if (this->GetVideoDataAvailable())
   {
     // Get the most recent timestamp from the buffer
-    ERROR_FAIL_IF(this->VideoSource->GetLatestTimeStamp(latestVideoTimestamp) != ITEM_OK,
+    RETURN_WITH_FAIL_IF(this->VideoSource->GetLatestTimeStamp(latestVideoTimestamp) != ITEM_OK,
         "Unable to get latest timestamp from video buffer!");
   }
 
@@ -1419,9 +1419,9 @@ PlusStatus vtkPlusChannel::GetMostRecentTimestamp(double& ts)
   {
     // Get the timestamp of the video item that is closest to the latest tracker item
     BufferItemUidType videoUid(0);
-    ERROR_FAIL_IF(this->VideoSource->GetItemUidFromTime(latestTrackerTimestamp, videoUid) != ITEM_OK,
+    RETURN_WITH_FAIL_IF(this->VideoSource->GetItemUidFromTime(latestTrackerTimestamp, videoUid) != ITEM_OK,
         "Failed to get video buffer item UID from time: " << std::fixed << latestVideoTimestamp);
-    ERROR_FAIL_IF(this->VideoSource->GetTimeStamp(videoUid, latestVideoTimestamp) != ITEM_OK,
+    RETURN_WITH_FAIL_IF(this->VideoSource->GetTimeStamp(videoUid, latestVideoTimestamp) != ITEM_OK,
         "Failed to get video buffer timestamp from UID: " << videoUid);
     if (latestVideoTimestamp > latestTrackerTimestamp)
     {
@@ -1451,9 +1451,9 @@ PlusStatus vtkPlusChannel::GetMostRecentTimestamp(double& ts)
   {
     // Get the timestamp of the video item that is closest to the latest field data item
     BufferItemUidType videoUid(0);
-    ERROR_FAIL_IF(this->VideoSource->GetItemUidFromTime(latestFieldDataTimestamp, videoUid) != ITEM_OK,
+    RETURN_WITH_FAIL_IF(this->VideoSource->GetItemUidFromTime(latestFieldDataTimestamp, videoUid) != ITEM_OK,
         "Failed to get video buffer item UID from time: " << std::fixed << latestVideoTimestamp);
-    ERROR_FAIL_IF(this->VideoSource->GetTimeStamp(videoUid, latestVideoTimestamp) != ITEM_OK,
+    RETURN_WITH_FAIL_IF(this->VideoSource->GetTimeStamp(videoUid, latestVideoTimestamp) != ITEM_OK,
         "Failed to get video buffer timestamp from UID: " << videoUid);
     if (latestVideoTimestamp > latestFieldDataTimestamp)
     {

--- a/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
+++ b/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
@@ -407,7 +407,7 @@ PlusStatus vtkPlusOpenIGTLinkServer::SendLatestFramesToClients(vtkPlusOpenIGTLin
           LOG_INFO("OpenIGTLink broadcasting started. No data was available between " << self.LastSentTrackedFrameTimestamp << "-" << oldestDataTimestamp << "sec, therefore no data were broadcasted during this time period.");
           self.LastSentTrackedFrameTimestamp = oldestDataTimestamp + SAMPLING_SKIPPING_MARGIN_SEC;
         }
-        ERROR_FAIL_IF(self.BroadcastChannel->GetTrackedFrameList(self.LastSentTrackedFrameTimestamp, trackedFrameList, numberOfFramesToGet) != PLUS_SUCCESS,
+        RETURN_WITH_FAIL_IF(self.BroadcastChannel->GetTrackedFrameList(self.LastSentTrackedFrameTimestamp, trackedFrameList, numberOfFramesToGet) != PLUS_SUCCESS,
             "Failed to get tracked frame list from data collector (last recorded timestamp: " << std::fixed << self.LastSentTrackedFrameTimestamp);
       }
     }

--- a/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
+++ b/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
@@ -407,11 +407,8 @@ PlusStatus vtkPlusOpenIGTLinkServer::SendLatestFramesToClients(vtkPlusOpenIGTLin
           LOG_INFO("OpenIGTLink broadcasting started. No data was available between " << self.LastSentTrackedFrameTimestamp << "-" << oldestDataTimestamp << "sec, therefore no data were broadcasted during this time period.");
           self.LastSentTrackedFrameTimestamp = oldestDataTimestamp + SAMPLING_SKIPPING_MARGIN_SEC;
         }
-        if (self.BroadcastChannel->GetTrackedFrameList(self.LastSentTrackedFrameTimestamp, trackedFrameList, numberOfFramesToGet) != PLUS_SUCCESS)
-        {
-          LOG_ERROR("Failed to get tracked frame list from data collector (last recorded timestamp: " << std::fixed << self.LastSentTrackedFrameTimestamp);
-          vtkPlusAccurateTimer::Delay(DELAY_ON_SENDING_ERROR_SEC);
-        }
+        ERROR_FAIL_IF(self.BroadcastChannel->GetTrackedFrameList(self.LastSentTrackedFrameTimestamp, trackedFrameList, numberOfFramesToGet) != PLUS_SUCCESS,
+            "Failed to get tracked frame list from data collector (last recorded timestamp: " << std::fixed << self.LastSentTrackedFrameTimestamp);
       }
     }
   }


### PR DESCRIPTION
A new macro is introduced which eases avoidance of repeating error messages in the log. It is applied in US Digital encoders, Capistrano ultrasound, and a few key places in PlusChannel and OpenIGTLinkServer. Closes #256.