### PR TITLE
Allow images to be downloaded from StealthStation when registration is not found

### DIFF
--- a/src/Documentation/UserManual/DeviceStealthLink.dox
+++ b/src/Documentation/UserManual/DeviceStealthLink.dox
@@ -37,6 +37,9 @@ No need to install any extra software. The StealthStation needs to be connected 
 
 - \xmlAtt \b ServerAddress. IP address of the StealthStation. \RequiredAtt
 - \xmlAtt \b ServerPort. Port number of the StealthStation. \RequiredAtt
+- \xmlAtt \b ImageTransferRequiresPatientRegistration \OptionalAtt{TRUE}
+  - If TRUE, the process of downloading an image from the StealthStation will fail if there is no registration.
+  - If FALSE, the process of downloading an image from the StealthStation will continue using a default transform if there is no registration.
 
 - \xmlElem \ref DataSources One \c DataSource child element is required for each tool or reference marker \RequiredAtt
    - \xmlElem \ref DataSource \RequiredAtt

--- a/src/PlusDataCollection/StealthLink/vtkPlusStealthLinkTracker.h
+++ b/src/PlusDataCollection/StealthLink/vtkPlusStealthLinkTracker.h
@@ -62,6 +62,10 @@ public:
   /*! Set StealthStation IP address */
   void SetServerAddress( const char* serverAddress );
 
+  /*Set ImageTransferRequiresPatientRegistration */
+  bool ImageTransferRequiresPatientRegistration;
+  vtkSetMacro(ImageTransferRequiresPatientRegistration, bool);
+
   /*! Set StealthStation IP port number */
   void SetServerPort( const char* serverPort );
 


### PR DESCRIPTION
By setting the device attribute: ImageTransferRequiresPatientRegistration to FALSE, images can be downloaded from the StealthStation, even without a registration, in which case the default transform will be used.