### PR TITLE
re #283: Updating PlusLib for CMake 3.10.0

### DIFF
--- a/src/PlusWidgets/CMakeLists.txt
+++ b/src/PlusWidgets/CMakeLists.txt
@@ -45,8 +45,19 @@ SET(${PROJECT_NAME}_INCLUDE_DIRS
 IF(NOT (CMAKE_VERSION VERSION_LESS "3.8"))
   # CMake 3.8 and later puts generated headers (such as ui_QPlusDeviceSetSelectorWidget.h) into
   # .../PlusLib-bin/src/PlusWidgets/PlusWidgets_autogen/include
-  LIST(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include)
+  IF(IS_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include)
+    LIST(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include)
+  ENDIF()
+  
+  # CMake 3.10 puts generated headers (such as ui_QPlusDeviceSetSelectorWidget.h) into
+  # .../PlusLib-bin/src/PlusWidgets/PlusWidgets_autogen/include_<Config>
+  FOREACH(CONFIG_TYPE ${CMAKE_CONFIGURATION_TYPES})
+    IF(IS_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include_${CONFIG_TYPE})
+      LIST(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include_${CONFIG_TYPE})
+    ENDIF()
+  ENDFOREACH()
 ENDIF()
+
 GENERATE_EXPORT_DIRECTIVE_FILE(${PROJECT_NAME})
 ADD_LIBRARY(${PROJECT_NAME}
   ${${PROJECT_NAME}_SRCS}


### PR DESCRIPTION
CMake 3.10.0 automoc puts generated files in ..../include_<Config> whereas 3.8-3.9.6 put them in ..../include.