### PR TITLE
USDigitalEncoders xy position to use Plus Image coordinate system

### DIFF
--- a/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.cxx
+++ b/src/PlusDataCollection/USDigitalEncodersTracking/vtkPlusUSDigitalEncodersTracker.cxx
@@ -302,8 +302,8 @@ PlusStatus vtkPlusUSDigitalEncodersTracker::InternalUpdate()
 
       double secondEnc = encoderValue * it->PulseSpacing2;
     
-      double firstAxis = firstEnc + secondEnc;
-      double secondAxis = firstEnc - secondEnc;
+      double firstAxis = secondEnc + firstEnc;
+      double secondAxis = secondEnc - firstEnc;
     
       //now make a transform matrix out of this translation and add it into PLUS system
       vtkMath::MultiplyScalar(localmovement.GetData(), firstAxis);


### PR DESCRIPTION
I've updated the XY positioning math within USDigitalEncoders so that it uses the same coordinate system as the normal Plus image coordinate system.  Previously when capturing encoder position in the XZ plane and the image frame captured in XY, the Z coordinate had opposite signs between the two. This flips the Z coordinate to match.