### PR TITLE
re #283: Fixing CMake update to build first time with 3.8 and above

### DIFF
--- a/src/PlusWidgets/CMakeLists.txt
+++ b/src/PlusWidgets/CMakeLists.txt
@@ -45,16 +45,14 @@ SET(${PROJECT_NAME}_INCLUDE_DIRS
 IF(NOT (CMAKE_VERSION VERSION_LESS "3.8"))
   # CMake 3.8 and later puts generated headers (such as ui_QPlusDeviceSetSelectorWidget.h) into
   # .../PlusLib-bin/src/PlusWidgets/PlusWidgets_autogen/include
-  IF(IS_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include)
-    LIST(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include)
-  ENDIF()
-  
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include)
+  LIST(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include)
+
   # CMake 3.10 puts generated headers (such as ui_QPlusDeviceSetSelectorWidget.h) into
   # .../PlusLib-bin/src/PlusWidgets/PlusWidgets_autogen/include_<Config>
   FOREACH(CONFIG_TYPE ${CMAKE_CONFIGURATION_TYPES})
-    IF(IS_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include_${CONFIG_TYPE})
-      LIST(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include_${CONFIG_TYPE})
-    ENDIF()
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include_${CONFIG_TYPE})
+    LIST(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include_${CONFIG_TYPE})
   ENDFOREACH()
 ENDIF()
 


### PR DESCRIPTION
Tested and confirmed successful first time builds for CMake 3.7.2, 3.9.6, 3.10.0 and newly release 3.10.1.