### PR TITLE
Enable a configurable option to toggle send blocking on client sockets.

### DIFF
--- a/src/PlusCommon/PlusXmlUtils.h
+++ b/src/PlusCommon/PlusXmlUtils.h
@@ -591,7 +591,7 @@ public:
     } \
   }
 
-#define XML_REMOVE_ATTRIBUTE(xmlElementVar, attributeName)  xmlElementVar->RemoveAttribute(attributeName);
+#define XML_REMOVE_ATTRIBUTE(attributeName, xmlElementVar)  xmlElementVar->RemoveAttribute(attributeName);
 
 #define XML_WRITE_STRING_ATTRIBUTE(memberVar, xmlElementVar)  \
   xmlElementVar->SetAttribute(#memberVar, this->Get##memberVar().c_str()); \
@@ -615,7 +615,7 @@ public:
   } \
   else \
   { \
-    XML_REMOVE_ATTRIBUTE(xmlElementVar, memberVar.c_str()); \
+    XML_REMOVE_ATTRIBUTE(memberVar.c_str(), xmlElementVar); \
   }
 
 #define XML_WRITE_CSTRING_ATTRIBUTE_REMOVE_IF_NULL(memberVar, xmlElementVar)  \
@@ -625,7 +625,7 @@ public:
   } \
   else \
   { \
-    XML_REMOVE_ATTRIBUTE(xmlElementVar, #memberVar); \
+    XML_REMOVE_ATTRIBUTE(#memberVar, xmlElementVar); \
   }
 
 #define XML_WRITE_BOOL_ATTRIBUTE(memberVar, xmlElementVar)  \

--- a/src/PlusDataCollection/Epiphan/vtkPlusEpiphanVideoSource.cxx
+++ b/src/PlusDataCollection/Epiphan/vtkPlusEpiphanVideoSource.cxx
@@ -411,7 +411,7 @@ PlusStatus vtkPlusEpiphanVideoSource::WriteConfiguration(vtkXMLDataElement* root
   XML_WRITE_CSTRING_ATTRIBUTE_REMOVE_IF_NULL(GrabberLocation, imageAcquisitionConfig);
 
   // SerialNumber is an obsolete attribute, the information is stored now in GrabberLocation
-  XML_REMOVE_ATTRIBUTE(imageAcquisitionConfig, "SerialNumber");
+  XML_REMOVE_ATTRIBUTE("SerialNumber", imageAcquisitionConfig);
 
   // Epiphan hardware clipping parameters
   imageAcquisitionConfig->SetVectorAttribute("ClipRectangleOrigin", 2, this->GetClipRectangleOrigin());

--- a/src/PlusDataCollection/MicrosoftMediaFoundation/vtkPlusMmfVideoSource.cxx
+++ b/src/PlusDataCollection/MicrosoftMediaFoundation/vtkPlusMmfVideoSource.cxx
@@ -516,7 +516,7 @@ PlusStatus vtkPlusMmfVideoSource::WriteConfiguration(vtkXMLDataElement* rootConf
   }
   else
   {
-    XML_REMOVE_ATTRIBUTE(deviceConfig, "CaptureStreamIndex");
+    XML_REMOVE_ATTRIBUTE("CaptureStreamIndex", deviceConfig);
   }
   int frameSize[2] = { static_cast<int>(this->RequestedVideoFormat.FrameSize[0]), static_cast<int>(this->RequestedVideoFormat.FrameSize[1]) };
   deviceConfig->SetVectorAttribute("FrameSize", 2, frameSize);

--- a/src/PlusOpenIGTLink/PlusIgtlClientInfo.cxx
+++ b/src/PlusOpenIGTLink/PlusIgtlClientInfo.cxx
@@ -16,6 +16,7 @@ PlusIgtlClientInfo::PlusIgtlClientInfo()
   , Resolution(0)
   , TDATARequested(false)
   , LastTDATASentTimeStamp(-1)
+  , SendBlocking(false)
 {
 
 }
@@ -53,12 +54,19 @@ PlusStatus PlusIgtlClientInfo::SetClientInfoFromXmlData(vtkXMLDataElement* xmlda
 
   if (xmldata->GetAttribute("TDATARequested") != NULL)
   {
-    clientInfo.TDATARequested = STRCASECMP(xmldata->GetAttribute("TDATARequested"), "TRUE") == 0;
+    clientInfo.SetTDATARequested(STRCASECMP(xmldata->GetAttribute("TDATARequested"), "TRUE") == 0);
   }
 
   if (xmldata->GetAttribute("Resolution") != NULL)
   {
-    xmldata->GetScalarAttribute("Resolution", clientInfo.Resolution);
+    int resolution;
+    xmldata->GetScalarAttribute("Resolution", resolution);
+    clientInfo.SetResolution(resolution);
+  }
+
+  if (xmldata->GetAttribute("SendBlocking") != NULL)
+  {
+    clientInfo.SetSendBlocking(STRCASECMP(xmldata->GetAttribute("SendBlocking"), "TRUE") == 0);
   }
 
   // Get message types
@@ -170,7 +178,8 @@ void PlusIgtlClientInfo::GetClientInfoInXmlData(std::string& strXmlData)
 {
   vtkSmartPointer<vtkXMLDataElement> xmldata = vtkSmartPointer<vtkXMLDataElement>::New();
   xmldata->SetName("ClientInfo");
-  xmldata->SetAttribute("TDATARequested", (this->TDATARequested ? "TRUE" : "FALSE"));
+  xmldata->SetAttribute("TDATARequested", (this->GetTDATARequested() ? "TRUE" : "FALSE"));
+  xmldata->SetAttribute("SendBlocking", (this->GetSendBlocking() ? "TRUE" : "FALSE"));
 
   vtkSmartPointer<vtkXMLDataElement> messageTypes = vtkSmartPointer<vtkXMLDataElement>::New();
   messageTypes->SetName("MessageTypes");
@@ -187,7 +196,7 @@ void PlusIgtlClientInfo::GetClientInfoInXmlData(std::string& strXmlData)
   transformNames->SetName("TransformNames");
   for (unsigned int i = 0; i < TransformNames.size(); ++i)
   {
-    if (! TransformNames[i].IsValid())
+    if (!TransformNames[i].IsValid())
     {
       std::string transformName;
       TransformNames[i].GetTransformName(transformName);
@@ -257,6 +266,10 @@ void PlusIgtlClientInfo::PrintSelf(ostream& os, vtkIndent indent)
     os << "(none)";
   }
 
+  os << indent << "TDATARequested: " << this->GetTDATARequested() ? "TRUE" : "FALSE";
+  os << indent << "LastTDATASentTimeStamp: " << this->GetLastTDATASentTimeStamp();
+  os << indent << "SendBlocking: " << this->GetSendBlocking() ? "TRUE" : "FALSE";
+
   os << ". Transforms: ";
   if (!this->TransformNames.empty())
   {
@@ -323,4 +336,52 @@ int PlusIgtlClientInfo::GetClientHeaderVersion() const
 void PlusIgtlClientInfo::SetClientHeaderVersion(int version)
 {
   this->ClientHeaderVersion = version;
+}
+
+//----------------------------------------------------------------------------
+bool PlusIgtlClientInfo::GetSendBlocking() const
+{
+  return SendBlocking;
+}
+
+//----------------------------------------------------------------------------
+void PlusIgtlClientInfo::SetSendBlocking(bool val)
+{
+  SendBlocking = val;
+}
+
+//----------------------------------------------------------------------------
+int PlusIgtlClientInfo::GetResolution() const
+{
+  return Resolution;
+}
+
+//----------------------------------------------------------------------------
+void PlusIgtlClientInfo::SetResolution(int val)
+{
+  Resolution = val;
+}
+
+//----------------------------------------------------------------------------
+bool PlusIgtlClientInfo::GetTDATARequested() const
+{
+  return TDATARequested;
+}
+
+//----------------------------------------------------------------------------
+void PlusIgtlClientInfo::SetTDATARequested(bool val)
+{
+  TDATARequested = val;
+}
+
+//----------------------------------------------------------------------------
+double PlusIgtlClientInfo::GetLastTDATASentTimeStamp() const
+{
+  return LastTDATASentTimeStamp;
+}
+
+//----------------------------------------------------------------------------
+void PlusIgtlClientInfo::SetLastTDATASentTimeStamp(double val)
+{
+  LastTDATASentTimeStamp = val;
 }

--- a/src/PlusOpenIGTLink/PlusIgtlClientInfo.cxx
+++ b/src/PlusOpenIGTLink/PlusIgtlClientInfo.cxx
@@ -16,7 +16,6 @@ PlusIgtlClientInfo::PlusIgtlClientInfo()
   , TDATAResolution(0)
   , TDATARequested(false)
   , LastTDATASentTimeStamp(-1)
-  , SendBlocking(false)
 {
 
 }
@@ -64,7 +63,6 @@ PlusStatus PlusIgtlClientInfo::SetClientInfoFromXmlData(vtkXMLDataElement* xmlda
     xmldata->RemoveAttribute("Resolution");
     xmldata->SetIntAttribute("TDATAResolution", resolution);
   }
-  XML_READ_BOOL_ATTRIBUTE_OPTIONAL(SendBlocking, xmldata);
 
   // Get message types
   vtkXMLDataElement* messageTypes = xmldata->FindNestedElementWithName("MessageTypes");
@@ -185,7 +183,6 @@ void PlusIgtlClientInfo::GetClientInfoInXmlData(std::string& strXmlData)
   vtkSmartPointer<vtkXMLDataElement> xmldata = vtkSmartPointer<vtkXMLDataElement>::New();
   xmldata->SetName("ClientInfo");
   xmldata->SetAttribute("TDATARequested", (this->GetTDATARequested() ? "TRUE" : "FALSE"));
-  xmldata->SetAttribute("SendBlocking", (this->GetSendBlocking() ? "TRUE" : "FALSE"));
   xmldata->SetIntAttribute("TDATAResolution", this->GetTDATAResolution());
 
   vtkSmartPointer<vtkXMLDataElement> messageTypes = vtkSmartPointer<vtkXMLDataElement>::New();
@@ -277,7 +274,6 @@ void PlusIgtlClientInfo::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "TDATARequested: " << (this->GetTDATARequested() ? "TRUE" : "FALSE") << ". ";
   os << indent << "LastTDATASentTimeStamp: " << this->GetLastTDATASentTimeStamp() << ". ";
   os << indent << "TDATAResolution: " << this->GetTDATAResolution() << ". ";
-  os << indent << "SendBlocking: " << this->GetSendBlocking() ? "TRUE" : "FALSE";
 
   os << ". Transforms: ";
   if (!this->TransformNames.empty())
@@ -348,49 +344,37 @@ void PlusIgtlClientInfo::SetClientHeaderVersion(int version)
 }
 
 //----------------------------------------------------------------------------
-bool PlusIgtlClientInfo::GetSendBlocking() const
-{
-  return SendBlocking;
-}
-
-//----------------------------------------------------------------------------
-void PlusIgtlClientInfo::SetSendBlocking(bool val)
-{
-  SendBlocking = val;
-}
-
-//----------------------------------------------------------------------------
 int PlusIgtlClientInfo::GetTDATAResolution() const
 {
-  return TDATAResolution;
+  return this->TDATAResolution;
 }
 
 //----------------------------------------------------------------------------
 void PlusIgtlClientInfo::SetTDATAResolution(int val)
 {
-  TDATAResolution = val;
+  this->TDATAResolution = val;
 }
 
 //----------------------------------------------------------------------------
 bool PlusIgtlClientInfo::GetTDATARequested() const
 {
-  return TDATARequested;
+  return this->TDATARequested;
 }
 
 //----------------------------------------------------------------------------
 void PlusIgtlClientInfo::SetTDATARequested(bool val)
 {
-  TDATARequested = val;
+  this->TDATARequested = val;
 }
 
 //----------------------------------------------------------------------------
 double PlusIgtlClientInfo::GetLastTDATASentTimeStamp() const
 {
-  return LastTDATASentTimeStamp;
+  return this->LastTDATASentTimeStamp;
 }
 
 //----------------------------------------------------------------------------
 void PlusIgtlClientInfo::SetLastTDATASentTimeStamp(double val)
 {
-  LastTDATASentTimeStamp = val;
+  this->LastTDATASentTimeStamp = val;
 }

--- a/src/PlusOpenIGTLink/PlusIgtlClientInfo.h
+++ b/src/PlusOpenIGTLink/PlusIgtlClientInfo.h
@@ -7,11 +7,14 @@
 #ifndef __PlusIgtlClientInfo_h
 #define __PlusIgtlClientInfo_h
 
+// Local includes
 #include "PlusConfigure.h"
 #include "vtkPlusOpenIGTLinkExport.h"
 
-#include "igtlClientSocket.h"
+// IGTL includes
+#include <igtlClientSocket.h>
 
+// STL includes
 #include <string>
 #include <vector>
 
@@ -31,6 +34,10 @@ public:
   */
   struct ImageStream
   {
+    ImageStream()
+      : Name("")
+      , EmbeddedTransformToFrame("") {}
+
     /*! Name of the image stream and the IGTL image message embedded transform "From" frame */
     std::string Name;
     /*! Name of the IGTL image message embedded transform "To" frame */
@@ -50,19 +57,31 @@ public:
 
   virtual void PrintSelf(ostream& os, vtkIndent indent);
 
+  /*! IGTL header version supported by the client */
   int GetClientHeaderVersion() const;
+  /*! IGTL header version supported by the client */
   void SetClientHeaderVersion(int version);
 
+  /*! Flag for whether or not the client socket blocks when sending data (wait for all data to be sent) (default no) */
   bool GetSendBlocking() const;
+  /*! Flag for whether or not the client socket blocks when sending data (wait for all data to be sent) (default no) */
   void SetSendBlocking(bool val);
 
-  int GetResolution() const;
-  void SetResolution(int val);
+  /*! Minimum time between two TDATA frames. Use 0 for as fast as possible. If e.g. 50 ms is specified, the maximum update rate will be 20 Hz. */
+  int GetTDATAResolution() const;
+  /*! Minimum time between two TDATA frames. Use 0 for as fast as possible. If e.g. 50 ms is specified, the maximum update rate will be 20 Hz. */
+  void SetTDATAResolution(int val);
 
+  /*! Flag for start TDATA transmission request: true on STT, false on STP.
+  If the start requested flag is false then don't send TDATA to the client. */
   bool GetTDATARequested() const;
+  /*! Flag for start TDATA transmission request: true on STT, false on STP.
+  If the start requested flag is false then don't send TDATA to the client. */
   void SetTDATARequested(bool val);
 
+  /*! timestamp of the last sent TDATA message. */
   double GetLastTDATASentTimeStamp() const;
+  /*! timestamp of the last sent TDATA message. */
   void SetLastTDATASentTimeStamp(double val);
 
   /*! Message types that client expects from the server */
@@ -78,22 +97,11 @@ public:
   std::vector<ImageStream> ImageStreams;
 
 protected:
-  /*! IGTL header version supported by the client */
-  int ClientHeaderVersion;
-
-  /*! Flag for send blocking or not (default no) */
-  bool SendBlocking;
-
-  /*! flag for start TDATA transmission request: true on STT, false on STP.
-  If the start requested flag is false then don't send TDATA to the client. */
-  bool TDATARequested;
-
-  /*! timestamp of the last sent TDATA message. */
-  double LastTDATASentTimeStamp;
-
-  /*! A new TDATA is only sent if the time elapsed is at least the resolution
-  value (otherwise we don't send this tracking data to the client) */
-  int Resolution;
+  int     ClientHeaderVersion;
+  bool    SendBlocking;
+  bool    TDATARequested;
+  double  LastTDATASentTimeStamp;
+  int     TDATAResolution;
 };
 
 #endif

--- a/src/PlusOpenIGTLink/PlusIgtlClientInfo.h
+++ b/src/PlusOpenIGTLink/PlusIgtlClientInfo.h
@@ -23,8 +23,9 @@ class vtkPlusCommandProcessor;
 
   \ingroup PlusLibOpenIGTLink
 */
-struct vtkPlusOpenIGTLinkExport PlusIgtlClientInfo
+class vtkPlusOpenIGTLinkExport PlusIgtlClientInfo
 {
+public:
   /*! Helper struct for storing image stream and embedded transform frame names
   IGTL image message device name: [Name]_[EmbeddedTransformToFrame]
   */
@@ -50,11 +51,19 @@ struct vtkPlusOpenIGTLinkExport PlusIgtlClientInfo
   virtual void PrintSelf(ostream& os, vtkIndent indent);
 
   int GetClientHeaderVersion() const;
-
   void SetClientHeaderVersion(int version);
 
-  /*! IGTL header version supported by the client */
-  int ClientHeaderVersion;
+  bool GetSendBlocking() const;
+  void SetSendBlocking(bool val);
+
+  int GetResolution() const;
+  void SetResolution(int val);
+
+  bool GetTDATARequested() const;
+  void SetTDATARequested(bool val);
+
+  double GetLastTDATASentTimeStamp() const;
+  void SetLastTDATASentTimeStamp(double val);
 
   /*! Message types that client expects from the server */
   std::vector<std::string> IgtlMessageTypes;
@@ -63,21 +72,28 @@ struct vtkPlusOpenIGTLinkExport PlusIgtlClientInfo
   std::vector<PlusTransformName> TransformNames;
 
   /*! String field names to send with IGT STRING message */
-  std::vector< std::string > StringNames;
+  std::vector<std::string> StringNames;
 
   /*! Transform names to send with IGT image message */
   std::vector<ImageStream> ImageStreams;
 
-  /*! A new TDATA is only sent if the time elapsed is at least the resolution
-     value (otherwise we don't send this tracking data to the client) */
-  int Resolution;
+protected:
+  /*! IGTL header version supported by the client */
+  int ClientHeaderVersion;
+
+  /*! Flag for send blocking or not (default no) */
+  bool SendBlocking;
 
   /*! flag for start TDATA transmission request: true on STT, false on STP.
-     If the start requested flag is false then don't send TDATA to the client. */
+  If the start requested flag is false then don't send TDATA to the client. */
   bool TDATARequested;
 
   /*! timestamp of the last sent TDATA message. */
   double LastTDATASentTimeStamp;
+
+  /*! A new TDATA is only sent if the time elapsed is at least the resolution
+  value (otherwise we don't send this tracking data to the client) */
+  int Resolution;
 };
 
 #endif

--- a/src/PlusOpenIGTLink/PlusIgtlClientInfo.h
+++ b/src/PlusOpenIGTLink/PlusIgtlClientInfo.h
@@ -62,11 +62,6 @@ public:
   /*! IGTL header version supported by the client */
   void SetClientHeaderVersion(int version);
 
-  /*! Flag for whether or not the client socket blocks when sending data (wait for all data to be sent) (default no) */
-  bool GetSendBlocking() const;
-  /*! Flag for whether or not the client socket blocks when sending data (wait for all data to be sent) (default no) */
-  void SetSendBlocking(bool val);
-
   /*! Minimum time between two TDATA frames. Use 0 for as fast as possible. If e.g. 50 ms is specified, the maximum update rate will be 20 Hz. */
   int GetTDATAResolution() const;
   /*! Minimum time between two TDATA frames. Use 0 for as fast as possible. If e.g. 50 ms is specified, the maximum update rate will be 20 Hz. */
@@ -98,7 +93,6 @@ public:
 
 protected:
   int     ClientHeaderVersion;
-  bool    SendBlocking;
   bool    TDATARequested;
   double  LastTDATASentTimeStamp;
   int     TDATAResolution;

--- a/src/PlusOpenIGTLink/igtlPlusClientInfoMessage.cxx
+++ b/src/PlusOpenIGTLink/igtlPlusClientInfoMessage.cxx
@@ -2,74 +2,75 @@
 Program: Plus
 Copyright (c) Laboratory for Percutaneous Surgery. All rights reserved.
 See License.txt for details.
-=========================================================Plus=header=end*/ 
+=========================================================Plus=header=end*/
 
+// Local includes
 #include "PlusConfigure.h"
 #include "igtlPlusClientInfoMessage.h"
-#include "igtl_header.h"
-#include "igtl_util.h"
 #include "vtkPlusIgtlMessageFactory.h"
 
-namespace igtl 
-{
+// IGTL includes
+#include <igtl_header.h>
+#include <igtl_util.h>
 
-//----------------------------------------------------------------------------
-PlusClientInfoMessage::PlusClientInfoMessage() : StringMessage()
+namespace igtl
 {
-  this->m_SendMessageType = "CLIENTINFO";
-}
-
-//----------------------------------------------------------------------------
-PlusClientInfoMessage::~PlusClientInfoMessage()
-{
-}
-
-//----------------------------------------------------------------------------
-igtl::MessageBase::Pointer PlusClientInfoMessage::Clone()
-{
-  igtl::MessageBase::Pointer clone;
+  //----------------------------------------------------------------------------
+  PlusClientInfoMessage::PlusClientInfoMessage() : StringMessage()
   {
-    vtkSmartPointer<vtkPlusIgtlMessageFactory> factory = vtkSmartPointer<vtkPlusIgtlMessageFactory>::New();
-    clone = dynamic_cast<igtl::MessageBase*>(factory->CreateSendMessage(this->GetMessageType(), this->GetHeaderVersion()).GetPointer());
+    this->m_SendMessageType = "CLIENTINFO";
   }
 
-  igtl::PlusClientInfoMessage::Pointer msg = dynamic_cast<igtl::PlusClientInfoMessage*>(clone.GetPointer());
-
-  int bodySize = this->m_MessageSize - IGTL_HEADER_SIZE;
-  msg->InitBuffer();
-  msg->CopyHeader(this);
-  msg->AllocateBuffer(bodySize);
-  if (bodySize > 0)
+  //----------------------------------------------------------------------------
+  PlusClientInfoMessage::~PlusClientInfoMessage()
   {
-    msg->CopyBody(this);
   }
+
+  //----------------------------------------------------------------------------
+  igtl::MessageBase::Pointer PlusClientInfoMessage::Clone()
+  {
+    igtl::MessageBase::Pointer clone;
+    {
+      vtkSmartPointer<vtkPlusIgtlMessageFactory> factory = vtkSmartPointer<vtkPlusIgtlMessageFactory>::New();
+      clone = dynamic_cast<igtl::MessageBase*>(factory->CreateSendMessage(this->GetMessageType(), this->GetHeaderVersion()).GetPointer());
+    }
+
+    igtl::PlusClientInfoMessage::Pointer msg = dynamic_cast<igtl::PlusClientInfoMessage*>(clone.GetPointer());
+
+    int bodySize = this->m_MessageSize - IGTL_HEADER_SIZE;
+    msg->InitBuffer();
+    msg->CopyHeader(this);
+    msg->AllocateBuffer(bodySize);
+    if (bodySize > 0)
+    {
+      msg->CopyBody(this);
+    }
 
 #if OpenIGTLink_HEADER_VERSION >= 2
-  msg->m_MetaDataHeader = this->m_MetaDataHeader;
-  msg->m_MetaDataMap = this->m_MetaDataMap;
-  msg->m_IsExtendedHeaderUnpacked = this->m_IsExtendedHeaderUnpacked;
+    msg->m_MetaDataHeader = this->m_MetaDataHeader;
+    msg->m_MetaDataMap = this->m_MetaDataMap;
+    msg->m_IsExtendedHeaderUnpacked = this->m_IsExtendedHeaderUnpacked;
 #endif
 
-  return clone;
-}
-
-//----------------------------------------------------------------------------
-void PlusClientInfoMessage::SetClientInfo( const PlusIgtlClientInfo& clientInfo ) 
-{
-  this->m_ClientInfo=clientInfo;
-  std::string clientInfoXmlData; 
-  this->m_ClientInfo.GetClientInfoInXmlData(clientInfoXmlData); 
-  this->SetString(clientInfoXmlData); 
-}
-
-//----------------------------------------------------------------------------
-PlusIgtlClientInfo PlusClientInfoMessage::GetClientInfo()
-{
-  if ( this->m_ClientInfo.SetClientInfoFromXmlData(this->GetString()) != PLUS_SUCCESS )
-  {
-    LOG_ERROR("Failed to set Plus client info from received message!"); 
+    return clone;
   }
-  return this->m_ClientInfo;
-}
 
+  //----------------------------------------------------------------------------
+  void PlusClientInfoMessage::SetClientInfo(const PlusIgtlClientInfo& clientInfo)
+  {
+    this->m_ClientInfo = clientInfo;
+    std::string clientInfoXmlData;
+    this->m_ClientInfo.GetClientInfoInXmlData(clientInfoXmlData);
+    this->SetString(clientInfoXmlData);
+  }
+
+  //----------------------------------------------------------------------------
+  PlusIgtlClientInfo PlusClientInfoMessage::GetClientInfo()
+  {
+    if (this->m_ClientInfo.SetClientInfoFromXmlData(this->GetString()) != PLUS_SUCCESS)
+    {
+      LOG_ERROR("Failed to set Plus client info from received message!");
+    }
+    return this->m_ClientInfo;
+  }
 }

--- a/src/PlusOpenIGTLink/igtlPlusClientInfoMessage.h
+++ b/src/PlusOpenIGTLink/igtlPlusClientInfoMessage.h
@@ -2,54 +2,52 @@
   Program: Plus
   Copyright (c) Laboratory for Percutaneous Surgery. All rights reserved.
   See License.txt for details.
-=========================================================Plus=header=end*/ 
+=========================================================Plus=header=end*/
 
 #ifndef __igtlPlusClientInfoMessage_h
 #define __igtlPlusClientInfoMessage_h
 
+// Local includes
+#include "PlusIgtlClientInfo.h"
 #include "vtkPlusOpenIGTLinkExport.h"
 
-#include "igtlObject.h"
-#include "igtlStringMessage.h"
-#include "PlusIgtlClientInfo.h" 
+// IGTL includes
+#include <igtlStringMessage.h>
 
 namespace igtl
 {
+  /*!
+    \class PlusClientInfoMessage
+    \brief IGTL message helper class for PlusServer ClientInfo class
+    \ingroup PlusLibOpenIGTLink
+  */
+  class vtkPlusOpenIGTLinkExport PlusClientInfoMessage: public StringMessage
+  {
+  public:
+    typedef PlusClientInfoMessage          Self;
+    typedef StringMessage                  Superclass;
+    typedef SmartPointer<Self>             Pointer;
+    typedef SmartPointer<const Self>       ConstPointer;
 
-/*! 
-  \class PlusClientInfoMessage 
-  \brief IGTL message helper class for PlusServer ClientInfo class
-  \ingroup PlusLibOpenIGTLink
-*/
-class vtkPlusOpenIGTLinkExport PlusClientInfoMessage: public StringMessage
-{
-public:
-  typedef PlusClientInfoMessage                 Self;
-  typedef StringMessage                    Superclass;
-  typedef SmartPointer<Self>             Pointer;
-  typedef SmartPointer<const Self>       ConstPointer;
+    igtlTypeMacro(igtl::PlusClientInfoMessage, igtl::StringMessage);
+    igtlNewMacro(igtl::PlusClientInfoMessage);
 
-  igtlTypeMacro( igtl::PlusClientInfoMessage, igtl::StringMessage );
-  igtlNewMacro( igtl::PlusClientInfoMessage );
+  public:
+    /*! Override to use the plus igtl factory */
+    virtual igtl::MessageBase::Pointer Clone();
 
-public:
-  /*! Override to use the plus igtl factory */
-  virtual igtl::MessageBase::Pointer Clone();
+    /*! Set Plus IGTL Client Info */
+    void SetClientInfo(const PlusIgtlClientInfo& clientInfo);
 
-  /*! Set Plus IGTL Client Info */ 
-  void SetClientInfo( const PlusIgtlClientInfo& clientInfo ); 
+    /*! Get Plus IGTL Client Info */
+    PlusIgtlClientInfo GetClientInfo();
 
-  /*! Get Plus IGTL Client Info */ 
-  PlusIgtlClientInfo GetClientInfo(); 
-  
-protected:
-  PlusClientInfoMessage();
-  ~PlusClientInfoMessage();
+  protected:
+    PlusClientInfoMessage();
+    ~PlusClientInfoMessage();
 
-  PlusIgtlClientInfo m_ClientInfo; 
-};
-
-
+    PlusIgtlClientInfo m_ClientInfo;
+  };
 } // namespace igtl
 
-#endif 
+#endif

--- a/src/PlusOpenIGTLink/vtkPlusIgtlMessageFactory.cxx
+++ b/src/PlusOpenIGTLink/vtkPlusIgtlMessageFactory.cxx
@@ -143,7 +143,7 @@ PlusStatus vtkPlusIgtlMessageFactory::PackMessages(const PlusIgtlClientInfo& cli
     igtl::MessageBase::Pointer igtlMessage;
     try
     {
-      igtlMessage = this->IgtlFactory->CreateSendMessage(messageType, clientInfo.ClientHeaderVersion);
+      igtlMessage = this->IgtlFactory->CreateSendMessage(messageType, clientInfo.GetClientHeaderVersion());
     }
     catch (std::invalid_argument& e)
     {
@@ -221,7 +221,7 @@ PlusStatus vtkPlusIgtlMessageFactory::PackMessages(const PlusIgtlClientInfo& cli
     // Tracking data message
     else if (typeid(*igtlMessage) == typeid(igtl::TrackingDataMessage))
     {
-      if (clientInfo.TDATARequested && clientInfo.LastTDATASentTimeStamp + clientInfo.Resolution < trackedFrame.GetTimestamp())
+      if (clientInfo.GetTDATARequested() && clientInfo.GetLastTDATASentTimeStamp() + clientInfo.GetResolution() < trackedFrame.GetTimestamp())
       {
         std::map<std::string, vtkSmartPointer<vtkMatrix4x4> > transforms;
         for (std::vector<PlusTransformName>::const_iterator transformNameIterator = clientInfo.TransformNames.begin(); transformNameIterator != clientInfo.TransformNames.end(); ++transformNameIterator)

--- a/src/PlusOpenIGTLink/vtkPlusIgtlMessageFactory.cxx
+++ b/src/PlusOpenIGTLink/vtkPlusIgtlMessageFactory.cxx
@@ -221,7 +221,7 @@ PlusStatus vtkPlusIgtlMessageFactory::PackMessages(const PlusIgtlClientInfo& cli
     // Tracking data message
     else if (typeid(*igtlMessage) == typeid(igtl::TrackingDataMessage))
     {
-      if (clientInfo.GetTDATARequested() && clientInfo.GetLastTDATASentTimeStamp() + clientInfo.GetResolution() < trackedFrame.GetTimestamp())
+      if (clientInfo.GetTDATARequested() && clientInfo.GetLastTDATASentTimeStamp() + clientInfo.GetTDATAResolution() < trackedFrame.GetTimestamp())
       {
         std::map<std::string, vtkSmartPointer<vtkMatrix4x4> > transforms;
         for (std::vector<PlusTransformName>::const_iterator transformNameIterator = clientInfo.TransformNames.begin(); transformNameIterator != clientInfo.TransformNames.end(); ++transformNameIterator)

--- a/src/PlusServer/Commands/vtkPlusRequestIdsCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusRequestIdsCommand.cxx
@@ -183,7 +183,7 @@ PlusStatus vtkPlusRequestIdsCommand::Execute()
     {
       LOG_WARNING("Unable to locate client data for client id: " << this->GetClientId());
     }
-    if (info.ClientHeaderVersion <= IGTL_HEADER_VERSION_2)
+    if (info.GetClientHeaderVersion() <= IGTL_HEADER_VERSION_2)
     {
       oss << responseMessage;
     }
@@ -237,7 +237,7 @@ PlusStatus vtkPlusRequestIdsCommand::Execute()
     {
       LOG_WARNING("Unable to locate client data for client id: " << this->GetClientId());
     }
-    if (info.ClientHeaderVersion <= IGTL_HEADER_VERSION_2)
+    if (info.GetClientHeaderVersion() <= IGTL_HEADER_VERSION_2)
     {
       oss << responseMessage;
     }

--- a/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
+++ b/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
@@ -711,7 +711,7 @@ void* vtkPlusOpenIGTLinkServer::DataReceiverThread(vtkMultiThreader::ThreadInfo*
       int c = startTracking->Unpack(self->IgtlMessageCrcCheckEnabled);
       if (c & igtl::MessageHeader::UNPACK_BODY)
       {
-        client->ClientInfo.SetResolution(startTracking->GetResolution());
+        client->ClientInfo.SetTDATAResolution(startTracking->GetResolution());
         client->ClientInfo.SetTDATARequested(true);
       }
       else
@@ -1103,7 +1103,7 @@ PlusStatus vtkPlusOpenIGTLinkServer::ReadConfiguration(vtkXMLDataElement* server
   this->DefaultClientInfo.TransformNames.clear();
   this->DefaultClientInfo.ImageStreams.clear();
   this->DefaultClientInfo.StringNames.clear();
-  this->DefaultClientInfo.SetResolution(0);
+  this->DefaultClientInfo.SetTDATAResolution(0);
   this->DefaultClientInfo.SetTDATARequested(false);
 
   vtkXMLDataElement* defaultClientInfo = serverElement->FindNestedElementWithName("DefaultClientInfo");
@@ -1117,8 +1117,6 @@ PlusStatus vtkPlusOpenIGTLinkServer::ReadConfiguration(vtkXMLDataElement* server
 
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(float, DefaultClientSendTimeoutSec, serverElement);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(float, DefaultClientReceiveTimeoutSec, serverElement);
-
-  // TODO : how come default client info isn't mandatory? send nothing?
 
   return PLUS_SUCCESS;
 }

--- a/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
+++ b/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
@@ -246,6 +246,10 @@ void* vtkPlusOpenIGTLinkServer::ConnectionReceiverThread(vtkMultiThreader::Threa
       client->ClientSocket->SetReceiveTimeout(self->DefaultClientReceiveTimeoutSec * 1000);
       client->ClientSocket->SetSendTimeout(self->DefaultClientSendTimeoutSec * 1000);
       client->ClientInfo = self->DefaultClientInfo;
+      if (client->ClientInfo.GetSendBlocking())
+      {
+        client->ClientSocket->SetSendBlocking(1);
+      }
       client->Server = self;
 
       int port = 0;
@@ -558,7 +562,7 @@ void* vtkPlusOpenIGTLinkServer::DataReceiverThread(vtkMultiThreader::ThreadInfo*
 
     {
       PlusLockGuard<vtkPlusRecursiveCriticalSection> igtlClientsMutexGuardedLock(self->IgtlClientsMutex);
-      client->ClientInfo.ClientHeaderVersion = std::min<int>(self->GetIGTLProtocolVersion(), headerMsg->GetHeaderVersion());
+      client->ClientInfo.SetClientHeaderVersion(std::min<int>(self->GetIGTLProtocolVersion(), headerMsg->GetHeaderVersion()));
     }
 
     igtl::MessageBase::Pointer bodyMessage = self->IgtlMessageFactory->CreateReceiveMessage(headerMsg);
@@ -707,8 +711,8 @@ void* vtkPlusOpenIGTLinkServer::DataReceiverThread(vtkMultiThreader::ThreadInfo*
       int c = startTracking->Unpack(self->IgtlMessageCrcCheckEnabled);
       if (c & igtl::MessageHeader::UNPACK_BODY)
       {
-        client->ClientInfo.Resolution = startTracking->GetResolution();
-        client->ClientInfo.TDATARequested = true;
+        client->ClientInfo.SetResolution(startTracking->GetResolution());
+        client->ClientInfo.SetTDATARequested(true);
       }
       else
       {
@@ -730,7 +734,7 @@ void* vtkPlusOpenIGTLinkServer::DataReceiverThread(vtkMultiThreader::ThreadInfo*
 
       clientSocket->Receive(stopTracking->GetBufferBodyPointer(), stopTracking->GetBufferBodySize());
 
-      client->ClientInfo.TDATARequested = false;
+      client->ClientInfo.SetTDATARequested(false);
       igtl::MessageBase::Pointer msg = self->IgtlMessageFactory->CreateSendMessage("RTS_TDATA", IGTL_HEADER_VERSION_1);
       igtl::RTSTrackingDataMessage* rtsMsg = dynamic_cast<igtl::RTSTrackingDataMessage*>(msg.GetPointer());
       rtsMsg->SetStatus(0);
@@ -909,7 +913,7 @@ PlusStatus vtkPlusOpenIGTLinkServer::SendTrackedFrame(PlusTrackedFrame& trackedF
         }
 
         // Update the TDATA timestamp, even if TDATA isn't sent (cheaper than checking for existing TDATA message type)
-        clientIterator->ClientInfo.LastTDATASentTimeStamp = trackedFrame.GetTimestamp();
+        clientIterator->ClientInfo.SetLastTDATASentTimeStamp(trackedFrame.GetTimestamp());
       }
     }
   }
@@ -1099,8 +1103,8 @@ PlusStatus vtkPlusOpenIGTLinkServer::ReadConfiguration(vtkXMLDataElement* server
   this->DefaultClientInfo.TransformNames.clear();
   this->DefaultClientInfo.ImageStreams.clear();
   this->DefaultClientInfo.StringNames.clear();
-  this->DefaultClientInfo.Resolution = 0;
-  this->DefaultClientInfo.TDATARequested = false;
+  this->DefaultClientInfo.SetResolution(0);
+  this->DefaultClientInfo.SetTDATARequested(false);
 
   vtkXMLDataElement* defaultClientInfo = serverElement->FindNestedElementWithName("DefaultClientInfo");
   if (defaultClientInfo != NULL)

--- a/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
+++ b/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
@@ -246,10 +246,6 @@ void* vtkPlusOpenIGTLinkServer::ConnectionReceiverThread(vtkMultiThreader::Threa
       client->ClientSocket->SetReceiveTimeout(self->DefaultClientReceiveTimeoutSec * 1000);
       client->ClientSocket->SetSendTimeout(self->DefaultClientSendTimeoutSec * 1000);
       client->ClientInfo = self->DefaultClientInfo;
-      if (client->ClientInfo.GetSendBlocking())
-      {
-        client->ClientSocket->SetSendBlocking(1);
-      }
       client->Server = self;
 
       int port = 0;

--- a/src/PlusVolumeReconstruction/vtkPlusVolumeReconstructor.cxx
+++ b/src/PlusVolumeReconstruction/vtkPlusVolumeReconstructor.cxx
@@ -211,9 +211,9 @@ PlusStatus vtkPlusVolumeReconstructor::WriteConfiguration(vtkXMLDataElement* con
 
   // Fan parameters
   // remove deprecated attributes
-  XML_REMOVE_ATTRIBUTE(reconConfig, "FanDepth");
-  XML_REMOVE_ATTRIBUTE(reconConfig, "FanOrigin");
-  XML_REMOVE_ATTRIBUTE(reconConfig, "FanAngles");
+  XML_REMOVE_ATTRIBUTE("FanDepth", reconConfig);
+  XML_REMOVE_ATTRIBUTE("FanOrigin", reconConfig);
+  XML_REMOVE_ATTRIBUTE("FanAngles", reconConfig);
   if (this->Reconstructor->FanClippingApplied())
   {
     reconConfig->SetVectorAttribute("FanAnglesDeg", 2, this->Reconstructor->GetFanAnglesDeg());
@@ -230,11 +230,11 @@ PlusStatus vtkPlusVolumeReconstructor::WriteConfiguration(vtkXMLDataElement* con
   }
   else
   {
-    XML_REMOVE_ATTRIBUTE(reconConfig, "FanAnglesDeg");
-    XML_REMOVE_ATTRIBUTE(reconConfig, "EnableFanAnglesAutoDetect")
-    XML_REMOVE_ATTRIBUTE(reconConfig, "FanOriginPixel");
-    XML_REMOVE_ATTRIBUTE(reconConfig, "FanRadiusStartPixel");
-    XML_REMOVE_ATTRIBUTE(reconConfig, "FanRadiusStopPixel");
+    XML_REMOVE_ATTRIBUTE("FanAnglesDeg", reconConfig);
+    XML_REMOVE_ATTRIBUTE("EnableFanAnglesAutoDetect", reconConfig);
+    XML_REMOVE_ATTRIBUTE("FanOriginPixel", reconConfig);
+    XML_REMOVE_ATTRIBUTE("FanRadiusStartPixel", reconConfig);
+    XML_REMOVE_ATTRIBUTE("FanRadiusStopPixel", reconConfig);
   }
 
   // reconstruction options
@@ -248,7 +248,7 @@ PlusStatus vtkPlusVolumeReconstructor::WriteConfiguration(vtkXMLDataElement* con
   }
   else
   {
-    XML_REMOVE_ATTRIBUTE(reconConfig, "NumberOfThreads");
+    XML_REMOVE_ATTRIBUTE("NumberOfThreads", reconConfig);
   }
 
   XML_WRITE_STRING_ATTRIBUTE_REMOVE_IF_EMPTY(ImportanceMaskFilename, reconConfig);
@@ -259,7 +259,7 @@ PlusStatus vtkPlusVolumeReconstructor::WriteConfiguration(vtkXMLDataElement* con
   }
   else
   {
-    XML_REMOVE_ATTRIBUTE(reconConfig, "PixelRejectionThreshold");
+    XML_REMOVE_ATTRIBUTE("PixelRejectionThreshold", reconConfig);
   }
 
   return PLUS_SUCCESS;
@@ -418,7 +418,7 @@ PlusStatus vtkPlusVolumeReconstructor::SetOutputExtentFromFrameList(vtkPlusTrack
     std::string strImageToReferenceTransformName;
     imageToReferenceTransformName.GetTransformName(strImageToReferenceTransformName);
     errorDescription = "Automatic volume extent computation failed, there were no valid " + strImageToReferenceTransformName + " transform available in the whole sequence"
-      + " (probably wrong image or reference coordinate system was defined or all transforms were invalid)";
+                       + " (probably wrong image or reference coordinate system was defined or all transforms were invalid)";
     LOG_ERROR(errorDescription);
     return PLUS_FAIL;
   }
@@ -657,18 +657,18 @@ PlusStatus vtkPlusVolumeReconstructor::SaveReconstructedVolumeToMetafile(vtkImag
   MET_ValueEnumType scalarType = MET_NONE;
   switch (volumeToSave->GetScalarType())
   {
-    case VTK_UNSIGNED_CHAR:
-      scalarType = MET_UCHAR;
-      break;
-    case VTK_UNSIGNED_SHORT:
-      scalarType = MET_USHORT;
-      break;
-    case VTK_FLOAT:
-      scalarType = MET_FLOAT;
-      break;
-    default:
-      LOG_ERROR("Scalar type is not supported!");
-      return PLUS_FAIL;
+  case VTK_UNSIGNED_CHAR:
+    scalarType = MET_UCHAR;
+    break;
+  case VTK_UNSIGNED_SHORT:
+    scalarType = MET_USHORT;
+    break;
+  case VTK_FLOAT:
+    scalarType = MET_FLOAT;
+    break;
+  default:
+    LOG_ERROR("Scalar type is not supported!");
+    return PLUS_FAIL;
   }
 
   MetaImage metaImage(volumeToSave->GetDimensions()[0], volumeToSave->GetDimensions()[1], volumeToSave->GetDimensions()[2],


### PR DESCRIPTION
This prevents disconnects due to insufficient bandwidth on a network. Hopefully no longer necessary if image compression sending is implemented.