### PR TITLE
Fix VTK deprecated code

### DIFF
--- a/src/PlusCommon/vtkPlusAccurateTimer.cxx
+++ b/src/PlusCommon/vtkPlusAccurateTimer.cxx
@@ -22,9 +22,6 @@ double vtkPlusAccurateTimer::SystemStartTime = 0;
 double vtkPlusAccurateTimer::UniversalStartTime = 0;
 
 //----------------------------------------------------------------------------
-vtkInstantiatorNewMacro(vtkPlusAccurateTimer);
-
-//----------------------------------------------------------------------------
 // The singleton, and the singleton cleanup
 
 vtkPlusAccurateTimer* vtkPlusAccurateTimer::Instance = NULL;

--- a/src/PlusDataCollection/vtkPlusTimestampedCircularBuffer.h
+++ b/src/PlusDataCollection/vtkPlusTimestampedCircularBuffer.h
@@ -10,7 +10,6 @@
 #include "PlusConfigure.h"
 #include "PlusStreamBufferItem.h"
 #include "vtkObject.h"
-#include "vtkTypeTemplate.h"
 #include <deque>
 
 #include "vnl/vnl_matrix.h"


### PR DESCRIPTION
PlusLib failed to compile on Ubuntu due to use of deprecated VTK macros / header files