### PR TITLE
Add MSVC80 OpenMP dll to OptiTrack 32-bit builds

### DIFF
--- a/src/PlusDataCollection/CMakeLists.txt
+++ b/src/PlusDataCollection/CMakeLists.txt
@@ -226,7 +226,14 @@ IF(PLUS_USE_OPTITRACK)
     ${OPTITRACK_NATNET_BINARY_DIR}/NatNetLib${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${OPTITRACK_OPENMP_DIR}/libiomp5md${CMAKE_SHARED_LIBRARY_SUFFIX}
     )
-    
+
+  IF (OPTITRACK_MSVC80_OPENMP_DIR)
+    LIST(APPEND External_Libraries_Install
+      ${OPTITRACK_MSVC80_OPENMP_DIR}/Microsoft.VC80.OpenMP.manifest
+      ${OPTITRACK_MSVC80_OPENMP_DIR}/vcomp.dll
+      )
+  ENDIF()
+
 ENDIF()
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
This is the PlusLib part of a fix to allow 32-bit versions of Plus (with OptiTrack enabled) to run successfully without having to install the MSVC redistributable.

https://github.com/PerkLab/PLTools/pull/3
https://github.com/PlusToolkit/PlusLib/pull/320
https://github.com/PlusToolkit/PlusBuild/pull/28