### PR TITLE
ENH re #172: Implemented saving intermediate images 

### DIFF
--- a/src/PlusImageProcessing/vtkPlusBoneEnhancer.h
+++ b/src/PlusImageProcessing/vtkPlusBoneEnhancer.h
@@ -51,7 +51,8 @@ public:
   /*! If optional output files for intermediate images should saved */
   vtkSetMacro(IntermediateImageFileName, std::string);
   vtkSetMacro(SaveIntermediateResults, bool);
-
+  vtkGetMacro(SaveIntermediateResults, bool);
+  
   /*! Get and Set methods for variables related to the scanner used */
   vtkSetMacro(NumberOfScanLines, int);
   vtkGetMacro(NumberOfScanLines, int);

--- a/src/PlusImageProcessing/vtkPlusTransverseProcessEnhancer.h
+++ b/src/PlusImageProcessing/vtkPlusTransverseProcessEnhancer.h
@@ -29,6 +29,8 @@ public:
   vtkTypeMacro(vtkPlusTransverseProcessEnhancer, vtkPlusBoneEnhancer);
   virtual void PrintSelf(ostream& os, vtkIndent indent);
 
+  virtual const char* GetProcessorTypeName() { return "vtkPlusTransverseProcessEnhancer"; };
+
   /*! Process input frame to localize transverse process bone surfaces */
   PlusStatus ProcessFrame(PlusTrackedFrame* inputFrame, PlusTrackedFrame* outputFrame);
 


### PR DESCRIPTION
@lassoan @cpinter @ungi 
I think this commit with intermediate image saving for vtkPlusBoneEnhancer is ready to merge. Although I encountered a separate problem trying to implement this for vtkPlusTransverseProcessEnhancer:

I tried testing the vtkPlusTransverseProcessEnhancer device with the same image saving changes by setting the Processor config elements Type attribute to Type="vtkPlusTransverseProcessEnhancer" but running it as a Plus device returned the error:
|ERROR|271.682000|SERVER> Unknown processor type: vtkPlusTransverseProcessEnhancer| in :\D\plusGit\PB-B\PlusLib\src\PlusDataCollection\ImageProcessor\vtkPlusImageProcessorVideoSource.cxx(128)

Is anything obviously wrong with vtkPlusTransverseProcessEnhancer's type name to any of you?

I understand that vtkPlusTransverseProcessEnhancer inherits functionality from vtkPlusBoneEnhancer since they were seperated in [https://github.com/PlusToolkit/PlusLib/commit/fe12a12ccd86ad7d9336b1dce584c6dc88b53580](url) and [https://github.com/adamrankin/PlusLib/commit/c1965919c8bdc732c4ff74c7cb6d3cff42eb56ba](url). I do not understand the full extent of the inheritance if it relates to the type name.

I will begin investigating unless someone knows the solution right off hand.



