### PR TITLE
Add a device name to KeepAlive status messages

### DIFF
--- a/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
+++ b/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
@@ -1027,6 +1027,7 @@ void vtkPlusOpenIGTLinkServer::KeepAlive()
     for (std::list<ClientData>::iterator clientIterator = this->IgtlClients.begin(); clientIterator != this->IgtlClients.end(); ++clientIterator)
     {
       igtl::StatusMessage::Pointer replyMsg = igtl::StatusMessage::New();
+      replyMsg->SetDeviceName("KeepAlive");
       replyMsg->SetCode(igtl::StatusMessage::STATUS_OK);
       replyMsg->Pack();
 


### PR DESCRIPTION
@lassoan 

I found that the reason so many status nodes were being created was that the keep alive message had no device name.

In SlicerOpenIGTLink/OpenIGTLinkIF, device name was used for the status node name, so GetFirstNode would not find the existing nodes.

As far as I can see, there are two solutions to this:
1. Add device name "KeepAlive" to KeepAlive status messages
1. Implement some sort of check in OpenIGTLinkIF to avoid creating multiple nodes for messages with no device name. (I imagine this would apply to all types of messges, not just status messages).

Which one (or both) of the solutions should be the preferred approach?