### PR TITLE
re #169: Add option to enable video streaming for image messages

### DIFF
--- a/src/PlusOpenIGTLink/PlusIgtlClientInfo.cxx
+++ b/src/PlusOpenIGTLink/PlusIgtlClientInfo.cxx
@@ -141,9 +141,13 @@ PlusStatus PlusIgtlClientInfo::SetClientInfoFromXmlData(vtkXMLDataElement* xmlda
         continue;
       }
 
+      std::string encodingType;
+      XML_READ_STRING_ATTRIBUTE_NONMEMBER_OPTIONAL(EncodingType, encodingType, imageElem);
+
       ImageStream stream;
       stream.EmbeddedTransformToFrame = embeddedTransformToFrame;
       stream.Name = name;
+      stream.EncodingType = encodingType;
       clientInfo.ImageStreams.push_back(stream);
     }
   }

--- a/src/PlusOpenIGTLink/PlusIgtlClientInfo.h
+++ b/src/PlusOpenIGTLink/PlusIgtlClientInfo.h
@@ -34,14 +34,15 @@ public:
   */
   struct ImageStream
   {
-    ImageStream()
-      : Name("")
-      , EmbeddedTransformToFrame("") {}
-
     /*! Name of the image stream and the IGTL image message embedded transform "From" frame */
     std::string Name;
     /*! Name of the IGTL image message embedded transform "To" frame */
     std::string EmbeddedTransformToFrame;
+    /*! Optional string indicating the image encoding using FourCC value is empty by default
+    If the string is empty, then images will be sent using igtl::ImageMessage using a raw RGB format
+    If the string is not empty, then it will be compressed and sent as an igtl::VideoMessage using the encoding specified by the FourCC value
+    */
+    std::string EncodingType;
   };
 
   PlusIgtlClientInfo();

--- a/src/PlusOpenIGTLink/vtkPlusIgtlMessageCommon.cxx
+++ b/src/PlusOpenIGTLink/vtkPlusIgtlMessageCommon.cxx
@@ -25,6 +25,9 @@ See License.txt for details.
 #include <igtlioImageConverter.h>
 #include <igtlioPolyDataConverter.h>
 #include <igtlioTransformConverter.h>
+#if defined(OpenIGTLink_ENABLE_VIDEOSTREAMING)
+#include <igtlioVideoConverter.h>
+#endif
 
 //----------------------------------------------------------------------------
 
@@ -469,6 +472,73 @@ PlusStatus vtkPlusIgtlMessageCommon::PackImageMetaMessage(igtl::ImageMetaMessage
   imageMetaMessage->Pack();
   return PLUS_SUCCESS;
 }
+
+//----------------------------------------------------------------------------
+#if defined(OpenIGTLink_ENABLE_VIDEOSTREAMING)
+PlusStatus vtkPlusIgtlMessageCommon::PackVideoMessage(igtl::VideoMessage::Pointer videoMessage,
+  PlusTrackedFrame& trackedFrame, GenericEncoder* encoder, const vtkMatrix4x4& matrix)
+{
+  if (videoMessage.IsNull())
+  {
+    LOG_ERROR("Failed to pack image message - input image message is NULL");
+    return PLUS_FAIL;
+  }
+
+  if (!trackedFrame.GetImageData()->IsImageValid())
+  {
+    LOG_WARNING("Unable to send image message - image data is NOT valid!");
+    return PLUS_FAIL;
+  }
+
+  double timestamp = trackedFrame.GetTimestamp();
+  vtkImageData* frameImage = trackedFrame.GetImageData()->GetImage();
+
+  int imageSizePixels[3] = { 0 };
+  int subSizePixels[3] = { 0 };
+  int subOffset[3] = { 0 };
+  double imageSpacingMm[3] = { 0 };
+  double imageOriginMm[3] = { 0 };
+  int scalarType = PlusVideoFrame::GetIGTLScalarPixelTypeFromVTK(trackedFrame.GetImageData()->GetVTKScalarPixelType());
+  unsigned int numScalarComponents(1);
+  if (trackedFrame.GetImageData()->GetNumberOfScalarComponents(numScalarComponents) == PLUS_FAIL)
+  {
+    LOG_ERROR("Unable to retrieve number of scalar components.");
+    return PLUS_FAIL;
+  }
+
+  frameImage->GetDimensions(imageSizePixels);
+  frameImage->GetSpacing(imageSpacingMm);
+  frameImage->GetOrigin(imageOriginMm);
+  frameImage->GetDimensions(subSizePixels);
+
+  float spacingFloat[3] = { 0 };
+  for (int i = 0; i < 3; ++i)
+  {
+    spacingFloat[i] = (float)imageSpacingMm[i];
+  }
+
+  igtlioVideoConverter::HeaderData headerData = igtlioVideoConverter::HeaderData();
+  igtlioVideoConverter::ContentData contentData = igtlioVideoConverter::ContentData();
+  contentData.videoMessage = videoMessage;
+  contentData.image = frameImage;
+  contentData.transform = vtkSmartPointer<vtkMatrix4x4>::New();
+  contentData.transform->DeepCopy(&matrix);
+  headerData.deviceName = videoMessage->GetDeviceName();
+
+  if (!igtlioVideoConverter::toIGTL(headerData, contentData, encoder))
+  {
+    LOG_ERROR("Could not create video message!");
+    return PLUS_FAIL;
+  }
+
+  igtl::TimeStamp::Pointer igtlFrameTime = igtl::TimeStamp::New();
+  igtlFrameTime->SetTime(timestamp);
+  videoMessage->SetTimeStamp(igtlFrameTime);
+  videoMessage->Pack();
+
+  return PLUS_SUCCESS;
+}
+#endif
 
 //-------------------------------------------------------------------------------
 PlusStatus vtkPlusIgtlMessageCommon::PackTransformMessage(igtl::TransformMessage::Pointer transformMessage,

--- a/src/PlusOpenIGTLink/vtkPlusIgtlMessageCommon.h
+++ b/src/PlusOpenIGTLink/vtkPlusIgtlMessageCommon.h
@@ -26,6 +26,10 @@ See License.txt for details.
 #include <igtlStringMessage.h>
 #include <igtlTrackingDataMessage.h>
 #include <igtlTransformMessage.h>
+#if defined(OpenIGTLink_ENABLE_VIDEOSTREAMING)
+#include <igtlCodecCommonClasses.h>
+#include <igtlVideoMessage.h>
+#endif
 
 class vtkXMLDataElement;
 class PlusTrackedFrame;
@@ -70,6 +74,11 @@ public:
 
   /*! Pack image meta deta message from vtkPlusServer::ImageMetaDataList  */
   static PlusStatus PackImageMetaMessage(igtl::ImageMetaMessage::Pointer imageMetaMessage, PlusCommon::ImageMetaDataList& imageMetaDataList);
+
+#if defined(OpenIGTLink_ENABLE_VIDEOSTREAMING)
+  /*! Pack video message from tracked frame */
+  static PlusStatus PackVideoMessage(igtl::VideoMessage::Pointer videoMessage, PlusTrackedFrame& trackedFrame, igtl::GenericEncoder* encoder, const vtkMatrix4x4& videoToReferenceTransform);
+#endif
 
   /*! Pack transform message from tracked frame */
   static PlusStatus PackTransformMessage(igtl::TransformMessage::Pointer transformMessage, PlusTransformName& transformName,

--- a/src/PlusOpenIGTLink/vtkPlusIgtlMessageFactory.cxx
+++ b/src/PlusOpenIGTLink/vtkPlusIgtlMessageFactory.cxx
@@ -30,6 +30,18 @@ See License.txt for details.
 #include "igtlTrackingDataMessage.h"
 #include "igtlTransformMessage.h"
 
+#if defined(OpenIGTLink_ENABLE_VIDEOSTREAMING)
+#include "igtlVideoMessage.h"
+#include "igtl_video.h"
+#include "igtlI420Encoder.h"
+#if defined(OpenIGTLink_USE_VP9)
+#include "igtlVP9Encoder.h"
+#endif
+#if defined(OpenIGTLink_USE_H264)
+#include "igtlH264Encoder.h"
+#endif
+#endif
+
 //----------------------------------------------------------------------------
 
 vtkStandardNewMacro(vtkPlusIgtlMessageFactory);
@@ -126,7 +138,7 @@ igtl::MessageBase::Pointer vtkPlusIgtlMessageFactory::CreateSendMessage(const st
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusIgtlMessageFactory::PackMessages(const PlusIgtlClientInfo& clientInfo, std::vector<igtl::MessageBase::Pointer>& igtlMessages, PlusTrackedFrame& trackedFrame,
+PlusStatus vtkPlusIgtlMessageFactory::PackMessages(int clientId, const PlusIgtlClientInfo& clientInfo, std::vector<igtl::MessageBase::Pointer>& igtlMessages, PlusTrackedFrame& trackedFrame,
     bool packValidTransformsOnly, vtkPlusTransformRepository* transformRepository/*=NULL*/)
 {
   int numberOfErrors(0);
@@ -177,37 +189,102 @@ PlusStatus vtkPlusIgtlMessageFactory::PackMessages(const PlusIgtlClientInfo& cli
           continue;
         }
 
-        igtl::ImageMessage::Pointer imageMessage = dynamic_cast<igtl::ImageMessage*>(igtlMessage->Clone().GetPointer());
         std::string deviceName = imageTransformName.From() + std::string("_") + imageTransformName.To();
-        if (trackedFrame.IsCustomFrameFieldDefined(PlusTrackedFrame::FIELD_FRIENDLY_DEVICE_NAME))
-        {
-          // Allow overriding of device name with something human readable
-          // The transform name is passed in the metadata
-          deviceName = trackedFrame.GetCustomFrameField(PlusTrackedFrame::FIELD_FRIENDLY_DEVICE_NAME);
-        }
-        imageMessage->SetDeviceName(deviceName.c_str());
 
-        // Send PlusTrackedFrame::CustomFrameFields as meta data in the image message.
-        std::vector<std::string> frameFields;
-        trackedFrame.GetCustomFrameFieldNameList(frameFields);
-        for (std::vector<std::string>::const_iterator stringNameIterator = frameFields.begin(); stringNameIterator != frameFields.end(); ++stringNameIterator)
+        if (imageStream.EncodingType.empty())
         {
-          if (trackedFrame.GetCustomFrameField(*stringNameIterator) == NULL)
+          igtl::ImageMessage::Pointer imageMessage = dynamic_cast<igtl::ImageMessage*>(igtlMessage->Clone().GetPointer());
+          if (trackedFrame.IsCustomFrameFieldDefined(PlusTrackedFrame::FIELD_FRIENDLY_DEVICE_NAME))
           {
-            // No value is available, do not send anything
-            LOG_WARNING("No metadata value for: " << *stringNameIterator)
+            // Allow overriding of device name with something human readable
+            // The transform name is passed in the metadata
+            deviceName = trackedFrame.GetCustomFrameField(PlusTrackedFrame::FIELD_FRIENDLY_DEVICE_NAME);
+          }
+          imageMessage->SetDeviceName(deviceName.c_str());
+
+          // Send PlusTrackedFrame::CustomFrameFields as meta data in the image message.
+          std::vector<std::string> frameFields;
+          trackedFrame.GetCustomFrameFieldNameList(frameFields);
+          for (std::vector<std::string>::const_iterator stringNameIterator = frameFields.begin(); stringNameIterator != frameFields.end(); ++stringNameIterator)
+          {
+            if (trackedFrame.GetCustomFrameField(*stringNameIterator) == NULL)
+            {
+              // No value is available, do not send anything
+              LOG_WARNING("No metadata value for: " << *stringNameIterator)
+                continue;
+            }
+            imageMessage->SetMetaDataElement(*stringNameIterator, IANA_TYPE_US_ASCII, trackedFrame.GetCustomFrameField(*stringNameIterator));
+          }
+
+          if (vtkPlusIgtlMessageCommon::PackImageMessage(imageMessage, trackedFrame, *matrix) != PLUS_SUCCESS)
+          {
+            LOG_ERROR("Failed to create " << messageType << " message - unable to pack image message");
+            numberOfErrors++;
             continue;
           }
-          imageMessage->SetMetaDataElement(*stringNameIterator, IANA_TYPE_US_ASCII, trackedFrame.GetCustomFrameField(*stringNameIterator));
+          igtlMessages.push_back(imageMessage.GetPointer());
         }
-
-        if (vtkPlusIgtlMessageCommon::PackImageMessage(imageMessage, trackedFrame, *matrix) != PLUS_SUCCESS)
+        else
         {
-          LOG_ERROR("Failed to create " << messageType << " message - unable to pack image message");
-          numberOfErrors++;
-          continue;
+
+#if defined(OpenIGTLink_ENABLE_VIDEOSTREAMING)
+          igtl::SmartPointer<igtl::GenericEncoder> encoder = NULL;
+          ClientEncoderKeyType clientEncoderKey;
+          clientEncoderKey.ClientId = clientId;
+          clientEncoderKey.ImageName = imageStream.Name;
+
+          VideoEncoderMapType::iterator encoderIt = this->IgtlVideoEncoders.find(clientEncoderKey);
+          if (encoderIt != this->IgtlVideoEncoders.end())
+          {
+            encoder = encoderIt->second;
+          }
+          else if (imageStream.EncodingType == IGTL_VIDEO_CODEC_NAME_I420)
+          {
+            encoder = new igtl::I420Encoder();
+            this->IgtlVideoEncoders.insert(std::make_pair(clientEncoderKey, encoder));
+          }
+#if defined(OpenIGTLink_USE_VP9)
+          else if (imageStream.EncodingType == IGTL_VIDEO_CODEC_NAME_VP9)
+          {
+            encoder = new igtl::VP9Encoder();
+            this->IgtlVideoEncoders.insert(std::make_pair(clientEncoderKey, encoder));
+          }
+#endif
+#if defined(OpenIGTLink_USE_H264)
+          else if (imageStream.EncodingType == IGTL_VIDEO_CODEC_NAME_H264)
+          {
+            encoder = new igtl::H264Encoder();
+            this->IgtlVideoEncoders.insert(std::make_pair(clientEncoderKey, encoder));
+          }
+#endif
+          else
+          {
+            LOG_ERROR("Could not create encoder for image stream " << imageStream.Name << " of type " << imageStream.EncodingType);
+            continue;
+          }
+
+          if (!encoder->GetInitializationStatus())
+          {
+            FrameSizeType frameSize = trackedFrame.GetFrameSize();
+            encoder->SetPicWidthAndHeight(frameSize[0], frameSize[1]);
+            encoder->SetLosslessLink(false);
+            encoder->InitializeEncoder();
+          }
+
+          igtl::VideoMessage::Pointer videoMessage = igtl::VideoMessage::New();
+          videoMessage->SetDeviceName(deviceName.c_str());
+          if (vtkPlusIgtlMessageCommon::PackVideoMessage(videoMessage, trackedFrame, encoder, *matrix) != PLUS_SUCCESS)
+          {
+            LOG_ERROR("Failed to create " << "VIDEO" << " message - unable to pack image message");
+            numberOfErrors++;
+            continue;
+          }
+          videoMessage->SetDeviceName(deviceName.c_str());
+          igtlMessages.push_back(videoMessage.GetPointer());
+#else
+          LOG_ERROR("Plus is not currently compiled with video streaming support!");
+#endif
         }
-        igtlMessages.push_back(imageMessage.GetPointer());
       }
     }
     // Transform message
@@ -366,3 +443,16 @@ PlusStatus vtkPlusIgtlMessageFactory::PackMessages(const PlusIgtlClientInfo& cli
   return (numberOfErrors == 0 ? PLUS_SUCCESS : PLUS_FAIL);
 }
 
+//----------------------------------------------------------------------------
+void vtkPlusIgtlMessageFactory::RemoveClientEncoders(int clientId)
+{
+  VideoEncoderMapType currentIgtlVideoEncoders = this->IgtlVideoEncoders;
+  for (VideoEncoderMapType::iterator encoderIt = currentIgtlVideoEncoders.begin(); encoderIt != currentIgtlVideoEncoders.end(); ++encoderIt)
+  {
+    if (encoderIt->first.ClientId != clientId)
+    {
+      continue;
+    }
+    this->IgtlVideoEncoders.erase(encoderIt->first);
+  }
+}

--- a/src/PlusOpenIGTLink/vtkPlusIgtlMessageFactory.h
+++ b/src/PlusOpenIGTLink/vtkPlusIgtlMessageFactory.h
@@ -2,7 +2,7 @@
   Program: Plus
   Copyright (c) Laboratory for Percutaneous Surgery. All rights reserved.
   See License.txt for details.
-=========================================================Plus=header=end*/ 
+=========================================================Plus=header=end*/
 
 #ifndef __vtkPlusIgtlMessageFactory_h
 #define __vtkPlusIgtlMessageFactory_h
@@ -10,23 +10,32 @@
 #include "PlusConfigure.h"
 #include "vtkPlusOpenIGTLinkExport.h"
 
-#include "vtkObject.h" 
+// VTK includes
+#include "vtkObject.h"
+
+// OpenIGTLink includes
 #include "igtlMessageBase.h"
 #include "igtlMessageFactory.h"
-#include "PlusIgtlClientInfo.h" 
 
-class vtkXMLDataElement; 
-class PlusTrackedFrame; 
+#if defined(OpenIGTLink_ENABLE_VIDEOSTREAMING)
+#include "igtlCodecCommonClasses.h"
+#endif
+
+// PlusLib includes
+#include "PlusIgtlClientInfo.h"
+
+class vtkXMLDataElement;
+class PlusTrackedFrame;
 class vtkPlusTransformRepository;
 
 /*!
-  \class vtkPlusIgtlMessageFactory 
+  \class vtkPlusIgtlMessageFactory
   \brief Factory class of supported OpenIGTLink message types
 
   This class is a factory class of supported OpenIGTLink message types to localize the message creation code.
 
   \ingroup PlusLibOpenIGTLink
-*/ 
+*/
 class vtkPlusOpenIGTLinkExport vtkPlusIgtlMessageFactory: public vtkObject
 {
 public:
@@ -34,14 +43,14 @@ public:
   vtkTypeMacro(vtkPlusIgtlMessageFactory,vtkObject);
   virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  /*! Function pointer for storing New() static methods of igtl::MessageBase classes */ 
-  typedef igtl::MessageBase::Pointer (*PointerToMessageBaseNew)(); 
+  /*! Function pointer for storing New() static methods of igtl::MessageBase classes */
+  typedef igtl::MessageBase::Pointer (*PointerToMessageBaseNew)();
 
-  /*! 
-  Get pointer to message type new function, or NULL if the message type not registered 
-  Usage: igtl::MessageBase::Pointer message = GetMessageTypeNewPointer("IMAGE")(); 
-  */ 
-  virtual vtkPlusIgtlMessageFactory::PointerToMessageBaseNew GetMessageTypeNewPointer(const std::string& messageTypeName); 
+  /*!
+  Get pointer to message type new function, or NULL if the message type not registered
+  Usage: igtl::MessageBase::Pointer message = GetMessageTypeNewPointer("IMAGE")();
+  */
+  virtual vtkPlusIgtlMessageFactory::PointerToMessageBaseNew GetMessageTypeNewPointer(const std::string& messageTypeName);
 
   /*! Print all supported OpenIGTLink message types */
   virtual void PrintAvailableMessageTypes(ostream& os, vtkIndent indent);
@@ -63,16 +72,25 @@ public:
   /// Creates message, sets header onto message and calls AllocateBuffer() on the message.
   igtl::MessageBase::Pointer CreateSendMessage(const std::string& messageType, int headerVersion) const;
 
-  /*! 
+  /*!
   Generate and pack IGTL messages from tracked frame
+  \param clientId Id of the client that messages will be sent to
   \param packValidTransformsOnly Control whether or not to pack transform messages if they contain invalid transforms
   \param clientInfo Specifies list of message types and names to generate for a client.
   \param igtMessages Output list for the generated IGTL messages
-  \param trackedFrame Input tracked frame data used for IGTL message generation 
-  \param transformRepository Transform repository used for computing the selected transforms 
-  */ 
-  PlusStatus PackMessages(const PlusIgtlClientInfo& clientInfo, std::vector<igtl::MessageBase::Pointer>& igtMessages, PlusTrackedFrame& trackedFrame, 
-    bool packValidTransformsOnly, vtkPlusTransformRepository* transformRepository=NULL); 
+  \param trackedFrame Input tracked frame data used for IGTL message generation
+  \param transformRepository Transform repository used for computing the selected transforms
+  */
+  PlusStatus PackMessages(int clientId, const PlusIgtlClientInfo& clientInfo, std::vector<igtl::MessageBase::Pointer>& igtMessages, PlusTrackedFrame& trackedFrame,
+    bool packValidTransformsOnly, vtkPlusTransformRepository* transformRepository=NULL);
+
+#if defined(OpenIGTLink_ENABLE_VIDEOSTREAMING)
+  /*!
+  Remove all encoders with matching clientId from this->IgtlVideoEncoders
+  \param clientId Id of the client for which the video encoders will be removed
+  */
+  void RemoveClientEncoders(int clientId);
+#endif
 
 protected:
   vtkPlusIgtlMessageFactory();
@@ -80,10 +98,25 @@ protected:
 
   igtl::MessageFactory::Pointer IgtlFactory;
 
+#if defined(OpenIGTLink_ENABLE_VIDEOSTREAMING)
+  struct ClientEncoderKeyType
+  {
+    int                 ClientId;
+    std::string         ImageName;
+    friend bool operator<(const ClientEncoderKeyType & left, const ClientEncoderKeyType & right)
+    {
+      return left.ClientId < right.ClientId || left.ImageName < right.ImageName;
+    }
+  };
+
+  typedef std::map<ClientEncoderKeyType, igtl::SmartPointer<igtl::GenericEncoder> > VideoEncoderMapType;
+  VideoEncoderMapType IgtlVideoEncoders;
+#endif
+
 private:
   vtkPlusIgtlMessageFactory(const vtkPlusIgtlMessageFactory&);
   void operator=(const vtkPlusIgtlMessageFactory&);
 
-}; 
+};
 
-#endif 
+#endif

--- a/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
+++ b/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
@@ -888,7 +888,7 @@ PlusStatus vtkPlusOpenIGTLinkServer::SendTrackedFrame(PlusTrackedFrame& trackedF
       std::vector<igtl::MessageBase::Pointer> igtlMessages;
       std::vector<igtl::MessageBase::Pointer>::iterator igtlMessageIterator;
 
-      if (this->IgtlMessageFactory->PackMessages(clientIterator->ClientInfo, igtlMessages, trackedFrame, this->SendValidTransformsOnly, this->TransformRepository) != PLUS_SUCCESS)
+      if (this->IgtlMessageFactory->PackMessages(clientIterator->ClientId, clientIterator->ClientInfo, igtlMessages, trackedFrame, this->SendValidTransformsOnly, this->TransformRepository) != PLUS_SUCCESS)
       {
         LOG_WARNING("Failed to pack all IGT messages");
       }
@@ -1010,6 +1010,11 @@ void vtkPlusOpenIGTLinkServer::DisconnectClient(int clientId)
       break;
     }
   }
+
+#if defined(OpenIGTLink_ENABLE_VIDEOSTREAMING)
+  this->IgtlMessageFactory->RemoveClientEncoders(clientId);
+#endif
+
   LOG_INFO("Client disconnected (" <<  address << ":" << port << "). Number of connected clients: " << GetNumberOfConnectedClients());
 }
 
@@ -1313,7 +1318,7 @@ igtl::MessageBase::Pointer vtkPlusOpenIGTLinkServer::CreateIgtlMessageFromComman
       std::ostringstream replyStr;
       if (commandResponse->GetUseDefaultFormat())
       {
-        
+
         replyStr << "<CommandReply";
         replyStr << " Name=\"" << commandResponse->GetCommandName() << "\"";
         replyStr << " Status=\"" << (commandResponse->GetStatus() ? "SUCCESS" : "FAIL") << "\"";
@@ -1335,7 +1340,7 @@ igtl::MessageBase::Pointer vtkPlusOpenIGTLinkServer::CreateIgtlMessageFromComman
         igtlMessage->SetMetaDataElement(it->first, it->second.first, it->second.second);
       }
 
-      igtlMessage->SetMetaDataElement("Status", IANA_TYPE_US_ASCII, (commandResponse->GetStatus() ? "SUCCESS" : "FAIL"));    
+      igtlMessage->SetMetaDataElement("Status", IANA_TYPE_US_ASCII, (commandResponse->GetStatus() ? "SUCCESS" : "FAIL"));
       if (commandResponse->GetStatus() == PLUS_FAIL)
       {
         igtlMessage->SetMetaDataElement("Error", IANA_TYPE_US_ASCII, commandResponse->GetErrorString());


### PR DESCRIPTION
When OpenIGTLink is compiled with OpenIGTLink_ENABLE_VIDEOSTREAMING and one of the potential video codecs enabled (Currently just VP9 and H264).

Users can specify the encoding type in the config file to send the image as a compressed VideoMessage.
Transforms are not applied to VideoMessage.

Ex.
```
  <PlusOpenIGTLinkServer 
    MaxNumberOfIgtlMessagesToSend="1" 
    MaxTimeSpentWithProcessingMs="50" 
    ListeningPort="18944" 
    SendValidTransformsOnly="true" 
    OutputChannelId="VideoStream" > 
    <DefaultClientInfo> 
      <MessageTypes> 
        <Message Type="IMAGE" />
      </MessageTypes>
      <ImageNames>
        <Image Name="Image" EmbeddedTransformToFrame="Reference" EncodingType="VP90"/>
      </ImageNames>
    </DefaultClientInfo>
  </PlusOpenIGTLinkServer>
```

See list at re #169 for other TODO.
