### PR TITLE
Cleaning up misnamed variable in vtkPlusUsDevice

### DIFF
--- a/src/PlusDataCollection/Interson/vtkPlusIntersonVideoSource.cxx
+++ b/src/PlusDataCollection/Interson/vtkPlusIntersonVideoSource.cxx
@@ -1256,7 +1256,7 @@ PlusStatus vtkPlusIntersonVideoSource::SetNewImagingParameters(const vtkPlusUsIm
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusIntersonVideoSource::RequestImagingParameterChange()
+PlusStatus vtkPlusIntersonVideoSource::InternalApplyImagingParameterChange()
 {
   PlusStatus status = PLUS_SUCCESS;
 

--- a/src/PlusDataCollection/Interson/vtkPlusIntersonVideoSource.h
+++ b/src/PlusDataCollection/Interson/vtkPlusIntersonVideoSource.h
@@ -65,7 +65,7 @@ public:
   /*! Set the parameters in bulk */
   virtual PlusStatus SetNewImagingParameters(const vtkPlusUsImagingParameters& newImagingParameters);
 
-  virtual PlusStatus RequestImagingParameterChange();
+  virtual PlusStatus InternalApplyImagingParameterChange();
 
   bool GetEnableProbeButtonMonitoring() const;
   void SetEnableProbeButtonMonitoring(bool _arg);

--- a/src/PlusDataCollection/SonixVideo/vtkPlusSonixPortaVideoSource.h
+++ b/src/PlusDataCollection/SonixVideo/vtkPlusSonixPortaVideoSource.h
@@ -18,7 +18,7 @@ Authors include: Elvis Chen (Queen's University)
 #include "PlusConfigure.h"
 #include "vtkPlusDataCollectionExport.h"
 
-#include "vtkPlusDevice.h"
+#include "vtkPlusUsDevice.h"
 
 class vtkPlusDataCollectionExport vtkPlusSonixPortaVideoSource;
 class porta;
@@ -77,9 +77,8 @@ private:
 
   \ingroup PlusLibDataCollection
 */
-class vtkPlusDataCollectionExport vtkPlusSonixPortaVideoSource : public vtkPlusDevice
+class vtkPlusDataCollectionExport vtkPlusSonixPortaVideoSource : public vtkPlusUsDevice
 {
-
   vtkTypeMacro(vtkPlusSonixPortaVideoSource, vtkPlusDevice);
   void PrintSelf(ostream& os, vtkIndent indent);
 
@@ -195,16 +194,6 @@ class vtkPlusDataCollectionExport vtkPlusSonixPortaVideoSource : public vtkPlusD
   vtkSetMacro(AutoClipEnabled, bool);
   vtkGetMacro(AutoClipEnabled, bool);
 
-  /*!
-    If non-NULL then ImageToTransducer transform is added as a custom field to the image data with the specified name.
-    The Transducer coordinate system origin is in the center of the transducer crystal array,
-    x axis direction is towards marked side, y axis direction is towards sound propagation direction,
-    and z direction is cross product of x and y, unit is mm. Elevational pixel spacing is set as the mean of the
-    lateral and axial pixel spacing.
-  */
-  vtkGetStringMacro(ImageToTransducerTransformName);
-  vtkSetStringMacro(ImageToTransducerTransformName);
-
   /*! Verify the device is correctly configured */
   virtual PlusStatus NotifyConfigured();
 
@@ -259,8 +248,6 @@ protected:
 
   bool AutoClipEnabled;
 
-  char* ImageToTransducerTransformName;
-
   /*! for internal use only */
   PlusStatus AddFrameToBuffer(void* param, int id, bool motorRotationCcw, int motorStepCount);
 
@@ -272,7 +259,6 @@ protected:
   virtual bool IsTracker() const { return false; }
 
 private:
-
   // data members
   static vtkPlusSonixPortaVideoSource* Instance;
 
@@ -300,7 +286,7 @@ private:
   /*! The B-mode image width */
   int PortaBModeWidth;
 
-  /*! The B-mode iamge height */
+  /*! The B-mode image height */
   int PortaBModeHeight;
 
   /*! name of the probe */

--- a/src/PlusDataCollection/SonixVideo/vtkPlusSonixVideoSource.cxx
+++ b/src/PlusDataCollection/SonixVideo/vtkPlusSonixVideoSource.cxx
@@ -15,24 +15,32 @@ Adam Rankin (Robarts Research Institute, The University of Western Ontario)
 Andras Lasso (Queen's University, Kingston, Ontario, Canada)
 =========================================================================*/
 
+// Local includes
 #include "PlusConfigure.h"
-
-#include "ImagingModes.h" // Ulterius imaging modes
-#include "ulterius_def.h"
-#include "vtkImageData.h"
-#include "vtkInformation.h"
-#include "vtkInformationVector.h"
-#include "vtkMultiThreader.h"
-#include "vtkObjectFactory.h"
 #include "vtkPlusChannel.h"
 #include "vtkPlusDataSource.h"
 #include "vtkPlusSonixVideoSource.h"
-#include "vtkStreamingDemandDrivenPipeline.h"
-#include "vtkTimerLog.h"
-#include "vtkUnsignedCharArray.h"
-#include "vtkPlusUsImagingParameters.h"
-#include "vtksys/SystemTools.hxx"
+
+// Ulterius includes
+#include <ImagingModes.h> // Ulterius imaging modes
+#include <ulterius_def.h>
+
+// VTK includes
+#include <vtkImageData.h>
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
+#include <vtkMultiThreader.h>
+#include <vtkObjectFactory.h>
+#include <vtkStreamingDemandDrivenPipeline.h>
+#include <vtkTimerLog.h>
+#include <vtkUnsignedCharArray.h>
+#include <vtkPlusUsImagingParameters.h>
+#include <vtksys/SystemTools.hxx>
+
+// OS includes
 #include <ctype.h>
+
+// STL includes
 #include <string>
 #include <vector>
 
@@ -698,7 +706,7 @@ PlusStatus vtkPlusSonixVideoSource::ReadConfiguration(vtkXMLDataElement* rootCon
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, Timeout, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(double, ConnectionSetupDelayMs, deviceConfig);
 
-  if (this->RequestImagingParameterChange() == PLUS_FAIL)
+  if (this->InternalApplyImagingParameterChange() == PLUS_FAIL)
   {
     LOG_ERROR("Failed to change imaging parameters in the device");
     return PLUS_FAIL;
@@ -1550,70 +1558,70 @@ void vtkPlusSonixVideoSource::Plus_uTGC::fromString(const std::string& input, ch
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusSonixVideoSource::RequestImagingParameterChange()
+PlusStatus vtkPlusSonixVideoSource::InternalApplyImagingParameterChange()
 {
   PlusStatus status = PLUS_SUCCESS;
 
-  if ( this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_FREQUENCY)
-    && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_FREQUENCY) )
+  if (this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_FREQUENCY)
+      && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_FREQUENCY))
   {
     if (this->SetFrequencyDevice(this->ImagingParameters->GetFrequencyMhz()) != PLUS_SUCCESS)
     {
-      LOG_ERROR("Failed to set frequency imaging parameter" );
+      LOG_ERROR("Failed to set frequency imaging parameter");
       status = PLUS_FAIL;
     }
   }
-  if ( this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_DEPTH)
-    && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_DEPTH) )
+  if (this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_DEPTH)
+      && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_DEPTH))
   {
     if (this->SetDepthDevice(this->ImagingParameters->GetDepthMm()) != PLUS_SUCCESS)
     {
-      LOG_ERROR("Failed to set depth imaging parameter" );
+      LOG_ERROR("Failed to set depth imaging parameter");
       status = PLUS_FAIL;
     }
   }
-  if ( this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_SECTOR)
-    && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_SECTOR) )
+  if (this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_SECTOR)
+      && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_SECTOR))
   {
     if (this->SetSectorDevice(this->ImagingParameters->GetSectorPercent()) != PLUS_SUCCESS)
     {
-      LOG_ERROR("Failed to set sector imaging parameter" );
+      LOG_ERROR("Failed to set sector imaging parameter");
       status = PLUS_FAIL;
     }
   }
-  if ( this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_GAIN)
-    && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_GAIN) )
+  if (this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_GAIN)
+      && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_GAIN))
   {
     if (this->SetGainDevice(this->ImagingParameters->GetGainPercent()) != PLUS_SUCCESS)
     {
-      LOG_ERROR("Failed to set gain imaging parameter" );
+      LOG_ERROR("Failed to set gain imaging parameter");
       status = PLUS_FAIL;
     }
   }
-  if ( this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_DYNRANGE)
-    && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_DYNRANGE) )
+  if (this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_DYNRANGE)
+      && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_DYNRANGE))
   {
     if (this->SetDynRangeDevice(this->ImagingParameters->GetDynRangeDb()) != PLUS_SUCCESS)
     {
-      LOG_ERROR("Failed to set dynamic range imaging parameter" );
+      LOG_ERROR("Failed to set dynamic range imaging parameter");
       status = PLUS_FAIL;
     }
   }
-  if ( this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_ZOOM)
-    && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_ZOOM) )
+  if (this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_ZOOM)
+      && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_ZOOM))
   {
     if (this->SetZoomDevice(this->ImagingParameters->GetZoomFactor()) != PLUS_SUCCESS)
     {
-      LOG_ERROR("Failed to set zoom imaging parameter" );
+      LOG_ERROR("Failed to set zoom imaging parameter");
       status = PLUS_FAIL;
     }
   }
-  if ( this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_SOUNDVELOCITY)
-    && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_SOUNDVELOCITY) )
+  if (this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_SOUNDVELOCITY)
+      && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_SOUNDVELOCITY))
   {
     if (this->SetSoundVelocityDevice(this->ImagingParameters->GetSoundVelocity()) != PLUS_SUCCESS)
     {
-      LOG_ERROR("Failed to set sound velocity imaging parameter" );
+      LOG_ERROR("Failed to set sound velocity imaging parameter");
       status = PLUS_FAIL;
     }
   }

--- a/src/PlusDataCollection/SonixVideo/vtkPlusSonixVideoSource.h
+++ b/src/PlusDataCollection/SonixVideo/vtkPlusSonixVideoSource.h
@@ -11,7 +11,7 @@ All rights reserved.
 Authors include: Danielle Pace
 (Robarts Research Institute and The University of Western Ontario)
 Siddharth Vikal (Queen's University, Kingston, Ontario, Canada)
-=========================================================================*/  
+=========================================================================*/
 
 #ifndef __vtkPlusSonixVideoSource_h
 #define __vtkPlusSonixVideoSource_h
@@ -25,22 +25,22 @@ class uDataDesc;
 enum uData;
 
 /*!
-  \class vtkPlusSonixVideoSource 
+  \class vtkPlusSonixVideoSource
   \brief VTK interface for video input from Ultrasonix machine
 
   vtkPlusSonixVideoSource is a class for providing video input interfaces between VTK and Ultrasonix machine.
   The goal is to provide the ability to be able to do acquisition
   in various imaging modes, buffer the image/volume series being acquired
-  and stream the frames to output. 
+  and stream the frames to output.
   Note that the data coming out of the SonixRP through ulterius is always RGB
-  This class talks to Ultrasonix's Ulterius SDK for executing the tasks 
+  This class talks to Ultrasonix's Ulterius SDK for executing the tasks
   Parameter setting doesn't work with Ulterius-2.x
 
   Usage:
   sonixGrabber->SetSonixIP("130.15.7.212");
   sonixGrabber->SetImagingMode(0);
   sonixGrabber->SetAcquisitionDataType(udtBPost);
-  sonixGrabber->Record();  
+  sonixGrabber->Record();
   imageviewer->SetInputData(sonixGrabber->GetOutput());
   See vtkPlusSonixVideoSourceTest1.cxx for more details
 
@@ -58,29 +58,29 @@ private:
     /// Converts a vector into stored values
     void fromVector(const std::vector<int> input);
     /// Outputs a string separated by 'separator'
-    std::string toString(char separator=' ');
+    std::string toString(char separator = ' ');
     /// Converts a string into stored values
-    void fromString(const std::string& input, char separator=' ');
+    void fromString(const std::string& input, char separator = ' ');
   };
 
 public:
   static vtkPlusSonixVideoSource* New();
-  vtkTypeMacro(vtkPlusSonixVideoSource,vtkPlusUsDevice);
+  vtkTypeMacro(vtkPlusSonixVideoSource, vtkPlusUsDevice);
   virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   /*! Hardware device SDK version. */
-  virtual std::string GetSdkVersion(); 
+  virtual std::string GetSdkVersion();
 
   /*! Read main configuration from/to xml data */
-  virtual PlusStatus ReadConfiguration(vtkXMLDataElement* config); 
+  virtual PlusStatus ReadConfiguration(vtkXMLDataElement* config);
 
   /*! Write main configuration from/to xml data */
   virtual PlusStatus WriteConfiguration(vtkXMLDataElement* config);
 
   /*! Get the IP address of the Ultrasonix host machine */
-  vtkSetStringMacro(SonixIP); 
+  vtkSetStringMacro(SonixIP);
   /*! Set the IP address of the Ultrasonix host machine */
-  vtkGetStringMacro(SonixIP); 
+  vtkGetStringMacro(SonixIP);
 
   /*! Set ultrasound transmitter frequency (MHz) */
   PlusStatus SetFrequencyDevice(double aFrequency);
@@ -133,7 +133,7 @@ public:
 
   /*! Set the Timeout (ms) value for network function calls. */
   PlusStatus SetTimeout(int aTimeout);
-  
+
   /*!
     Request a particular data type from sonix machine by means of a bitmask.
     The mask must be applied before any data can be acquired via realtime imaging or cine retrieval
@@ -146,8 +146,8 @@ public:
     udtMPre = 0x00000020,             // M Pre Scan Converted
     udtMPost = 0x00000040,            // M Post Scan Converted
     udtPWRF = 0x00000080,             // PW RF
-    udtPWSpectrum = 0x00000100,           
-    udtColorRF = 0x00000200,              
+    udtPWSpectrum = 0x00000100,
+    udtColorRF = 0x00000200,
     udtColorCombined = 0x00000400,
     udtColorVelocityVariance = 0x00000800,
     udtElastoCombined = 0x00002000,   // Elasto + B-image (32 bit)
@@ -159,11 +159,11 @@ public:
   */
   PlusStatus SetAcquisitionDataTypeDevice(int aAcquisitionDataType);
   /*! Get acquisition data type  bitmask. */
-  PlusStatus GetAcquisitionDataTypeDevice(int &acquisitionDataType);
+  PlusStatus GetAcquisitionDataTypeDevice(int& acquisitionDataType);
 
   /*!
     Request a particular mode of imaging
-    Usable values are described in ImagingModes.h (default: B-mode)  
+    Usable values are described in ImagingModes.h (default: B-mode)
     BMode = 0,
     MMode = 1,
     ColourMode = 2,
@@ -195,25 +195,25 @@ public:
   */
   PlusStatus SetImagingModeDevice(int mode);
   /*! Get current imaging mode */
-  PlusStatus GetImagingModeDevice(int & mode);
+  PlusStatus GetImagingModeDevice(int& mode);
 
-  /*! 
+  /*!
     Set the time required for setting up the connection.
     The value depends on the probe type, typical values are between 2000-3000ms. (Default: 3000)
   */
-  vtkSetMacro(ConnectionSetupDelayMs, int);  
+  vtkSetMacro(ConnectionSetupDelayMs, int);
   /*! Set the time required for setting up the connection. */
   vtkGetMacro(ConnectionSetupDelayMs, int);
 
-  /*! 
+  /*!
     Set the SharedMemoryStatus(1) to bypass TCP on local access.
   */
-  vtkSetMacro(SharedMemoryStatus, int);  
+  vtkSetMacro(SharedMemoryStatus, int);
   /*! Get the SharedMemoryStatus. */
   vtkGetMacro(SharedMemoryStatus, int);
 
   /*! Get the displayed frame rate. */
-  PlusStatus GetDisplayedFrameRateDevice(int &aFrameRate);
+  PlusStatus GetDisplayedFrameRateDevice(int& aFrameRate);
 
   /*! Set RF decimation. This requires Ulterius be connected. */
   PlusStatus SetRFDecimationDevice(int decimation);
@@ -221,7 +221,7 @@ public:
   /*! Set speckle reduction filter (filterIndex: 0=off,1,2). This requires Ulterius be connected.  */
   PlusStatus SetPPFilterDevice(int filterIndex);
 
-   /*! Set maximum frame rate limit on exam software (frLimit=403 means 40.3Hz). This requires Ulterius be connected.  */
+  /*! Set maximum frame rate limit on exam software (frLimit=403 means 40.3Hz). This requires Ulterius be connected.  */
   PlusStatus SetFrameRateLimitDevice(int frLimit);
 
   /*! Print the list of supported parameters. For diagnostic purposes only. */
@@ -249,7 +249,7 @@ protected:
 
   /*!
     Record incoming video.  The recording
-    continues indefinitely until StopRecording() is called. 
+    continues indefinitely until StopRecording() is called.
   */
   virtual PlusStatus InternalStartRecording();
 
@@ -267,25 +267,25 @@ protected:
   */
   enum RfAcquisitionModeType
   {
-    RF_UNKNOWN = -1, 
-    RF_ACQ_B_ONLY = 0, 
-    RF_ACQ_RF_ONLY = 1, 
+    RF_UNKNOWN = -1,
+    RF_ACQ_B_ONLY = 0,
+    RF_ACQ_RF_ONLY = 1,
     RF_ACQ_B_AND_RF = 2,
-    RF_ACQ_CHRF_ONLY = 3, 
-    RF_ACQ_B_AND_CHRF = 4 
-  }; 
+    RF_ACQ_CHRF_ONLY = 3,
+    RF_ACQ_B_AND_CHRF = 4
+  };
   /*! Set RF acquire mode. Determined from the video data sources. */
   PlusStatus SetRfAcquisitionModeDevice(RfAcquisitionModeType mode);
   /*! Get current RF acquire mode */
-  PlusStatus GetRfAcquisitionModeDevice(RfAcquisitionModeType & mode);
+  PlusStatus GetRfAcquisitionModeDevice(RfAcquisitionModeType& mode);
 
   /*! For internal use only */
-  PlusStatus AddFrameToBuffer(void * data, int type, int sz, bool cine, int frmnum);
+  PlusStatus AddFrameToBuffer(void* data, int type, int sz, bool cine, int frmnum);
 
-  PlusStatus SetParamValueDevice(char* paramId, int paramValue, int &validatedParamValue);
-  PlusStatus SetParamValueDevice(char* paramId, Plus_uTGC& paramValue, Plus_uTGC &validatedParamValue);
-  PlusStatus GetParamValueDevice(char* paramId, int& paramValue, int &validatedParamValue);
-  PlusStatus GetParamValueDevice(char* paramId, Plus_uTGC& paramValue, Plus_uTGC &validatedParamValue);
+  PlusStatus SetParamValueDevice(char* paramId, int paramValue, int& validatedParamValue);
+  PlusStatus SetParamValueDevice(char* paramId, Plus_uTGC& paramValue, Plus_uTGC& validatedParamValue);
+  PlusStatus GetParamValueDevice(char* paramId, int& paramValue, int& validatedParamValue);
+  PlusStatus GetParamValueDevice(char* paramId, Plus_uTGC& paramValue, Plus_uTGC& validatedParamValue);
 
   bool HasDataType( uData aValue );
   bool WantDataType( uData aValue );
@@ -295,17 +295,13 @@ protected:
     Determine all necessary imaging data types from the DataSource elements with Type="Video".
     Returns a combination of vtkPlusUsImagingParameters::DataType enum flags.
   */
-  virtual PlusStatus GetRequestedImagingDataTypeFromSources(int &requestedImagingDataType);
+  virtual PlusStatus GetRequestedImagingDataTypeFromSources(int& requestedImagingDataType);
 
-  /*!
-  Update changed imaging parameters from device
-  */
+  /*! Update changed imaging parameters from device */
   void UpdateImagingParametersFromDevice();
 
-  /*!
-  Set changed imaging parameter to device
-  */
-  virtual PlusStatus RequestImagingParameterChange();
+  /*! Set changed imaging parameter to device */
+  virtual PlusStatus InternalApplyImagingParameterChange();
 
 protected:
   vtkPlusSonixVideoSource();
@@ -315,7 +311,7 @@ protected:
   int AcquisitionDataType;
   int ImagingMode;
   int OutputFormat;
-  int CompressionStatus; 
+  int CompressionStatus;
   int Timeout;
   int ConnectionSetupDelayMs;
   int SharedMemoryStatus;
@@ -326,7 +322,7 @@ protected:
   bool ImagingParameterChanged;
   std::map<std::string, bool> ChangedImagingParameters;
 
-  char *SonixIP;
+  char* SonixIP;
   /*!
     Indicates if connection to the device has been established. It's not the same as the Connected parameter,
     because Connected indicates that the connection is successfully completed; while UlteriusConnected
@@ -336,10 +332,10 @@ protected:
   bool UlteriusConnected;
   bool AutoClipEnabled;
   bool ImageGeometryOutputEnabled;
-    
+
 private:
-  static bool vtkPlusSonixVideoSourceNewFrameCallback(void * data, int type, int sz, bool cine, int frmnum);
-  static bool vtkPlusSonixVideoSourceParamCallback(void * paramId, int ptX, int ptY);
+  static bool vtkPlusSonixVideoSourceNewFrameCallback(void* data, int type, int sz, bool cine, int frmnum);
+  static bool vtkPlusSonixVideoSourceParamCallback(void* paramId, int ptX, int ptY);
   static vtkPlusSonixVideoSource* ActiveSonixDevice;
   vtkPlusSonixVideoSource(const vtkPlusSonixVideoSource&);  // Not implemented.
   void operator=(const vtkPlusSonixVideoSource&);  // Not implemented.

--- a/src/PlusDataCollection/UsSimulatorVideo/vtkPlusUsSimulatorVideoSource.cxx
+++ b/src/PlusDataCollection/UsSimulatorVideo/vtkPlusUsSimulatorVideoSource.cxx
@@ -236,10 +236,10 @@ PlusStatus vtkPlusUsSimulatorVideoSource::NotifyConfigured()
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusUsSimulatorVideoSource::RequestImagingParameterChange()
+PlusStatus vtkPlusUsSimulatorVideoSource::InternalApplyImagingParameterChange()
 {
   if ( this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_DEPTH)
-    && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_DEPTH) )
+       && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_DEPTH) )
   {
     vtkPlusUsScanConvert* scanConverter = this->UsSimulator->GetRfProcessor()->GetScanConverter();
     vtkPlusUsScanConvertLinear* linearScanConverter = vtkPlusUsScanConvertLinear::SafeDownCast(scanConverter);
@@ -256,19 +256,19 @@ PlusStatus vtkPlusUsSimulatorVideoSource::RequestImagingParameterChange()
     this->ImagingParameters->SetPending(vtkPlusUsImagingParameters::KEY_DEPTH, false);
   }
   if ( this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_FREQUENCY)
-    && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_FREQUENCY) )
+       && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_FREQUENCY) )
   {
     this->UsSimulator->SetFrequencyMhz(this->ImagingParameters->GetFrequencyMhz());
     this->ImagingParameters->SetPending(vtkPlusUsImagingParameters::KEY_FREQUENCY, false);
   }
   if ( this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_INTENSITY)
-    && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_INTENSITY) )
+       && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_INTENSITY) )
   {
     this->UsSimulator->SetIncomingIntensityMwPerCm2(this->ImagingParameters->GetIntensity());
     this->ImagingParameters->SetPending(vtkPlusUsImagingParameters::KEY_INTENSITY, false);
   }
   if ( this->ImagingParameters->IsSet(vtkPlusUsImagingParameters::KEY_CONTRAST)
-    && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_CONTRAST) )
+       && this->ImagingParameters->IsPending(vtkPlusUsImagingParameters::KEY_CONTRAST) )
   {
     this->UsSimulator->SetBrightnessConversionGamma(this->ImagingParameters->GetContrast());
     this->ImagingParameters->SetPending(vtkPlusUsImagingParameters::KEY_CONTRAST, false);

--- a/src/PlusDataCollection/UsSimulatorVideo/vtkPlusUsSimulatorVideoSource.h
+++ b/src/PlusDataCollection/UsSimulatorVideo/vtkPlusUsSimulatorVideoSource.h
@@ -12,12 +12,12 @@
 #include "vtkPlusUsDevice.h"
 #include "vtkPlusUsSimulatorAlgo.h"
 
-class vtkPlusDataBuffer; 
+class vtkPlusDataBuffer;
 
 class vtkPlusDataCollectionExport vtkPlusUsSimulatorVideoSource;
 
 /*!
-  \class vtkPlusUsSimulatorVideoSource 
+  \class vtkPlusUsSimulatorVideoSource
   \brief Class for providing VTK video input interface from simulated ultrasound
   \ingroup PlusLibDataCollection
 */
@@ -29,10 +29,10 @@ public:
   virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   /*! Read configuration from xml data */
-  virtual PlusStatus ReadConfiguration(vtkXMLDataElement* config); 
+  virtual PlusStatus ReadConfiguration(vtkXMLDataElement* config);
 
   /*! Get ultrasound simulator */
-  vtkGetObjectMacro(UsSimulator, vtkPlusUsSimulatorAlgo); 
+  vtkGetObjectMacro(UsSimulator, vtkPlusUsSimulatorAlgo);
 
   /*! Verify the device is correctly configured */
   virtual PlusStatus NotifyConfigured();
@@ -41,12 +41,10 @@ public:
 
 protected:
   /*! Set ultrasound simulator */
-  vtkSetObjectMacro(UsSimulator, vtkPlusUsSimulatorAlgo); 
+  vtkSetObjectMacro(UsSimulator, vtkPlusUsSimulatorAlgo);
 
-  /*!
-  Set changed imaging parameter to device
-  */
-  virtual PlusStatus RequestImagingParameterChange();
+  /*! Set changed imaging parameter to device */
+  virtual PlusStatus InternalApplyImagingParameterChange();
 
 protected:
   /*! Constructor */


### PR DESCRIPTION
Resolving redundant behaviour in some US device classes and the base class

Minor code formatting cleanup