### PR TITLE
Updating OutputFilename usage in StartStopRecording commands

### DIFF
--- a/src/Documentation/UserManual/PlusServerCommands.dox
+++ b/src/Documentation/UserManual/PlusServerCommands.dox
@@ -17,11 +17,11 @@ PlusServer.exe --config-file=..\..\PlusLib\data\ConfigFiles\Testing\PlusConfigur
 - `PlusServerRemoteControl.exe --command=GET_CHANNEL_IDS`
   - PlusServer log:  `<Command Name="RequestChannelIDs" />`
   - PlusServerRemoteControl reply data: `TrackedVideoStream`
-- `PlusServerRemoteControl.exe --command=START_ACQUISITION`
-  - PlusServer log:  `<Command Name="StartRecording"/>`
+- `PlusServerRemoteControl.exe --command=START_ACQUISITION --device="CaptureDevice" --output-file="PlusServerRecording.mha"`
+  - PlusServer log:  `<Command Name="StartRecording" CaptureDeviceId="CaptureDevice" OutputFilename="PlusServerRecording.mha" EnableCompression="False"/>`
   - PlusServerRemoteControl reply data: `VirtualStreamCapture (CaptureDevice) StartRecording completed successfully`
-- `PlusServerRemoteControl.exe --command=STOP_ACQUISITION`
-  - PlusServer log:  `<Command Name="StopRecording" OutputFilename="PlusServerRecording.mha" />`
+- `PlusServerRemoteControl.exe --command=STOP_ACQUISITION --device="CaptureDevice"`
+  - PlusServer log:  `<Command Name="StopRecording" CaptureDeviceId="CaptureDevice"/>`
   - PlusServerRemoteControl reply data:  `VirtualStreamCapture (CaptureDevice) StopRecording completed successfully`
 - `PlusServerRemoteControl.exe --command=GET_EXAM_DATA --volumeEmbeddedTransformToFrame="Reference"`
   - PlusServer log: `<Command Name="ExamData" VolumeEmbeddedTransformToFrame="Reference"`
@@ -29,7 +29,7 @@ PlusServer.exe --config-file=..\..\PlusLib\data\ConfigFiles\Testing\PlusConfigur
 
 \subsubsection PlusServerCommandsRemoteControlExampleClientVolumeReconstruction Example: volume reconstruction in batch mode (acquiring all frames then reconstruct volume at once)
 
-If `--output-file` is specified then the reconstructed volume will be written to file. If output-image-name is specified then the reconstructed volume will be sent through OpenIGTLink. 
+If `--output-file` is specified then the reconstructed volume will be written to file. If output-image-name is specified then the reconstructed volume will be sent through OpenIGTLink.
 ~~~~~~~~~~~~~~~~~~~~~
 PlusServerRemoteControl.exe --command=START_ACQUISITION
 timeout /t 10
@@ -73,9 +73,9 @@ PlusServerRemoteControl.exe --command=GET_EXAM_DATA --device=StealthLinkDevice -
 ~~~~~~~~~~~~~~~~~~~~~
 <Command Name="RequestChannelIds" />
 <Command Name="RequestDeviceIds" DeviceType="VirtualVolumeReconstructor" />
-<Command Name="StartRecording" OutputFilename="PlusServerRecording.mha" />
+<Command Name="StartRecording" OutputFilename="PlusServerRecording.nrrd" EnableCompression="True"/>
 <Command Name="StopRecording" />
-<Command Name="ReconstructVolume" InputSeqFilename="PlusServerRecording.mha" OutputVolDeviceName="recvol_Reference" />
+<Command Name="ReconstructVolume" InputSeqFilename="PlusServerRecording.nrrd" OutputVolDeviceName="recvol_Reference" />
 <Command Name="StartVolumeReconstruction" VolumeReconstructorDeviceId="VolumeReconstructorDevice" />
 <Command Name="SuspendVolumeReconstruction" VolumeReconstructorDeviceId="VolumeReconstructorDevice" />
 <Command Name="ResumeVolumeReconstruction" VolumeReconstructorDeviceId="VolumeReconstructorDevice" />
@@ -90,7 +90,7 @@ PlusServerRemoteControl.exe --command=GET_EXAM_DATA --device=StealthLinkDevice -
 \subsection PlusServerCommandsOpenIGTLinkRemoteExecCommand Command
 
 - Message type: `STRING`
-- Device name: `CMD_`commandUid 
+- Device name: `CMD_`commandUid
 - Contents: an XML element with the name `Command` and the following attributes:
   - `Name`: command name, defined by the user
   - Custom parameters: attributes and/or child elements
@@ -119,6 +119,7 @@ PlusServerRemoteControl.exe --command=GET_EXAM_DATA --device=StealthLinkDevice -
 - StartRecording: starts recording to file
   - \xmlAtt CaptureDeviceId \RequiredAtt
   - \xmlAtt OutputFilename
+  - \xmlAtt EnableCompression: Set capture device to record compressed data. Only supported with .nrrd capture.
 - StopRecording: stops recording to file
   - \xmlAtt CaptureDeviceId \RequiredAtt
   - \xmlAtt OutputFilename: overrides the value that was defined in StartRecording
@@ -216,5 +217,5 @@ remoteExecLogic->GetCommandReplyNode(commandId);
 A new pair of command and reply node is created for each call.
 
 If the caller does not need the command and reply node anymore than the caller has to delete them.
-    
+
 */

--- a/src/PlusDataCollection/VirtualDevices/vtkPlusVirtualCapture.cxx
+++ b/src/PlusDataCollection/VirtualDevices/vtkPlusVirtualCapture.cxx
@@ -170,7 +170,6 @@ PlusStatus vtkPlusVirtualCapture::OpenFile(const char* aFilename)
 {
   PlusLockGuard<vtkPlusRecursiveCriticalSection> writerLock(this->WriterAccessMutex);
 
-  // Because this virtual device continually appends data to the file, we cannot do live compression
   if (aFilename == NULL || strlen(aFilename) == 0)
   {
     std::string filenameRoot = vtksys::SystemTools::GetFilenameWithoutExtension(this->BaseFilename);

--- a/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.cxx
@@ -61,7 +61,7 @@ std::string vtkPlusStartStopRecordingCommand::GetDescription(const std::string& 
   if (commandName.empty() || PlusCommon::IsEqualInsensitive(commandName, START_CMD))
   {
     desc += START_CMD;
-    desc += ": Start collecting data into file with a VirtualCapture device. CaptureDeviceId: ID of the capture device, if not specified then the first VirtualCapture device will be started (optional)";
+    desc += ": Start collecting data into file with a VirtualCapture device. Attributes: OutputFilename: name of the output file (optional if base file name is specified in config file). CaptureDeviceId: ID of the capture device, if not specified then the first VirtualCapture device will be started (optional)";
   }
   if (commandName.empty() || PlusCommon::IsEqualInsensitive(commandName, SUSPEND_CMD))
   {
@@ -111,10 +111,10 @@ PlusStatus vtkPlusStartStopRecordingCommand::ReadConfiguration(vtkXMLDataElement
     return PLUS_FAIL;
   }
 
-  // Stop parameters
+  // Start/Stop Common parameters
   XML_READ_CSTRING_ATTRIBUTE_OPTIONAL(OutputFilename, aConfig);
 
-  // Start parameters
+  // Start-only parameters
   if (this->GetName() == START_CMD)
   {
     XML_READ_BOOL_ATTRIBUTE_OPTIONAL(EnableCompression, aConfig);

--- a/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.cxx
@@ -295,7 +295,12 @@ PlusStatus vtkPlusStartStopRecordingCommand::Execute()
       this->QueueCommandResponse(PLUS_FAIL, "Command failed. See error message.", responseMessageBase + std::string("Recording to file is already in progress."));
       return PLUS_FAIL;
     }
-    if (captureDevice->OpenFile(this->OutputFilename.c_str()) != PLUS_SUCCESS)
+    std::string outputFilename = captureDevice->GetBaseFilename();
+    if (!this->OutputFilename.empty())
+    {
+      outputFilename = this->OutputFilename;
+    }
+    if (captureDevice->OpenFile(outputFilename.c_str()) != PLUS_SUCCESS)
     {
       this->QueueCommandResponse(PLUS_FAIL, "Command failed. See error message.", responseMessageBase + std::string("Failed to open file ") + (!this->OutputFilename.empty() ? this->OutputFilename : "(undefined)") + std::string("."));
       return PLUS_FAIL;

--- a/src/PlusServer/Tools/PlusServerRemoteControl.cxx
+++ b/src/PlusServer/Tools/PlusServerRemoteControl.cxx
@@ -134,10 +134,6 @@ PlusStatus ExecuteStopAcquisition(vtkPlusOpenIGTLinkClient* client, const std::s
   vtkSmartPointer<vtkPlusStartStopRecordingCommand> cmd = vtkSmartPointer<vtkPlusStartStopRecordingCommand>::New();
   cmd->SetNameToStop();
   cmd->SetId(commandId);
-  if (outputFilename.empty())
-  {
-    outputFilename = "PlusServerRecording.nrrd";
-  }
   cmd->SetOutputFilename(outputFilename.c_str());
   if (!deviceId.empty())
   {

--- a/src/PlusServer/Tools/PlusServerRemoteControl.cxx
+++ b/src/PlusServer/Tools/PlusServerRemoteControl.cxx
@@ -113,11 +113,12 @@ void PrintCommand(vtkPlusCommand* command)
 }
 
 //----------------------------------------------------------------------------
-PlusStatus ExecuteStartAcquisition(vtkPlusOpenIGTLinkClient* client, const std::string& deviceId, bool enableCompression, int commandId)
+PlusStatus ExecuteStartAcquisition(vtkPlusOpenIGTLinkClient* client, const std::string& deviceId, std::string outputFilename, bool enableCompression, int commandId)
 {
   vtkSmartPointer<vtkPlusStartStopRecordingCommand> cmd = vtkSmartPointer<vtkPlusStartStopRecordingCommand>::New();
   cmd->SetNameToStart();
   cmd->SetId(commandId);
+  cmd->SetOutputFilename(outputFilename.c_str());
   cmd->SetEnableCompression(enableCompression);
   if (!deviceId.empty())
   {
@@ -638,7 +639,7 @@ PlusStatus RunTests(vtkPlusOpenIGTLinkClient* client)
   parameters.clear();
 
   // Capturing
-  ExecuteStartAcquisition(client, captureDeviceId, false, commandId++);
+  ExecuteStartAcquisition(client, captureDeviceId, capturingOutputFileName, false, commandId++);
   RETURN_IF_FAIL(ReceiveAndPrintReply(client, didTimeout, replyMessage, errorMessage, parameters));
   parameters.clear();
   vtkPlusAccurateTimer::DelayWithEventProcessing(2.0);
@@ -818,7 +819,7 @@ int main(int argc, char** argv)
     // Execute command
     if (STRCASECMP(command.c_str(), "START_ACQUISITION") == 0)
     {
-      commandExecutionStatus = ExecuteStartAcquisition(client, deviceId, enableCompression, commandId);
+      commandExecutionStatus = ExecuteStartAcquisition(client, deviceId, outputFilename, enableCompression, commandId);
     }
     else if (STRCASECMP(command.c_str(), "STOP_ACQUISITION") == 0)
     {


### PR DESCRIPTION
https://github.com/PlusToolkit/PlusLib/commit/41fec394f908a32b4d69940dc9136f66d0f3161c adds OutputFilename support to START_ACQUISITION remote command and closes #403.

In order for OutputFilename to actually be used in the START_ACQUISITION remote command without getting overwritten by the STOP_ACQUISITION remote command I changed where the default OutputFilename originates (https://github.com/PlusToolkit/PlusLib/commit/56009bd7a86397d436ea6efa9ea3cacc3149a5fa).  "PlusServerRecording.nrrd" was being used as a default when OutputFilename wasn't specified in the STOP_ACQUISITION command of PlusServerRemoteControl. 

OutputFilename will now use the default as specified in VirtualCapture:
https://github.com/PlusToolkit/PlusLib/blob/05e31501a11c0d7a9241bfc4a7c4420ee8e91463/src/PlusDataCollection/VirtualDevices/vtkPlusVirtualCapture.cxx#L43

OutputFilename will be overwritten in the following order
- if BaseFilename is specified in VirtualCapture section in config xml
- if OutputFilename is specified in START_ACQUISITION PlusServerRemoteControl command
- if OutputFilename is specified in STOP_ACQUISITION PlusServerRemoteControl command


@adamrankin I've also included a commit that removes what I believe is an old comment that VirtualCapture couldn't do live compression.  You clarified in https://github.com/PlusToolkit/PlusLib/issues/402#issuecomment-417894968 that there was live compression support for the nrrd extension type.