### PR TITLE
Prevent compression of metaimage when using recording command

### DIFF
--- a/src/PlusDataCollection/VirtualDevices/vtkPlusVirtualCapture.cxx
+++ b/src/PlusDataCollection/VirtualDevices/vtkPlusVirtualCapture.cxx
@@ -182,7 +182,7 @@ PlusStatus vtkPlusVirtualCapture::OpenFile(const char* aFilename)
     else if (vtkPlusMetaImageSequenceIO::CanWriteFile(this->BaseFilename) && this->GetEnableFileCompression())
     {
       // they've requested mhd/mha with compression, no can do, yet
-      LOG_WARNING("Compressed saving of metaimage file requested. This is not supported. Reverting to uncompressed mha.");
+      LOG_WARNING("Compressed saving of metaimage file requested. This is not supported. Reverting to uncompressed metaimage file.");
       this->SetEnableFileCompression(false);
     }
     this->CurrentFilename = filenameRoot + "_" + vtksys::SystemTools::GetCurrentDateTime("%Y%m%d_%H%M%S") + ext;
@@ -193,7 +193,7 @@ PlusStatus vtkPlusVirtualCapture::OpenFile(const char* aFilename)
     if (vtkPlusMetaImageSequenceIO::CanWriteFile(aFilename) && this->GetEnableFileCompression())
     {
       // they've requested mhd/mha with compression, no can do, yet
-      LOG_WARNING("Compressed saving of metaimage file requested. This is not supported. Reverting to uncompressed mha.");
+      LOG_WARNING("Compressed saving of metaimage file requested. This is not supported. Reverting to uncompressed metaimage file.");
       this->SetEnableFileCompression(false);
     }
     this->CurrentFilename = aFilename;

--- a/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.cxx
@@ -300,12 +300,12 @@ PlusStatus vtkPlusStartStopRecordingCommand::Execute()
     {
       outputFilename = this->OutputFilename;
     }
+    captureDevice->SetEnableFileCompression(GetEnableCompression());
     if (captureDevice->OpenFile(outputFilename.c_str()) != PLUS_SUCCESS)
     {
       this->QueueCommandResponse(PLUS_FAIL, "Command failed. See error message.", responseMessageBase + std::string("Failed to open file ") + (!this->OutputFilename.empty() ? this->OutputFilename : "(undefined)") + std::string("."));
       return PLUS_FAIL;
     }
-    captureDevice->SetEnableFileCompression(GetEnableCompression());
     captureDevice->SetEnableCapturing(true);
     this->QueueCommandResponse(PLUS_SUCCESS, responseMessageBase + "successful.");
     return PLUS_SUCCESS;


### PR DESCRIPTION
This closes #402.

In StartStopRecordingCommand, moving `SetEnableFileCompression` before `OpenFile` prevents the loophole of allowing compressed metaimage files(that are then unable to be uncompressed) when using the StartStopRecordingCommand.

I've also updated the log warning message in `OpenFile` to use the general "metaimage" term since the user could be requesting to record as mha _or_ mhd.