### PR TITLE
BUG: Fix missed IGSIO name changes in WinProbeVideo

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -273,7 +273,7 @@ void vtkPlusWinProbeVideoSource::AdjustBufferSize()
              << "Frame size: " << frameSize[0] << "x" << frameSize[1]
              << ", pixel type: " << vtkImageScalarTypeNameMacro(m_BSources[i]->GetPixelType())
              << ", buffer image orientation: "
-             << PlusVideoFrame::GetStringFromUsImageOrientation(m_BSources[i]->GetInputImageOrientation()));
+             << igsioVideoFrame::GetStringFromUsImageOrientation(m_BSources[i]->GetInputImageOrientation()));
   }
 
   for(unsigned i = 0; i < m_RFSources.size(); i++)
@@ -289,7 +289,7 @@ void vtkPlusWinProbeVideoSource::AdjustBufferSize()
              << "Frame size: " << frameSize[0] << "x" << frameSize[1]
              << ", pixel type: " << vtkImageScalarTypeNameMacro(m_RFSources[i]->GetPixelType())
              << ", buffer image orientation: "
-             << PlusVideoFrame::GetStringFromUsImageOrientation(m_RFSources[i]->GetInputImageOrientation()));
+             << igsioVideoFrame::GetStringFromUsImageOrientation(m_RFSources[i]->GetInputImageOrientation()));
   }
 
   m_BModeBuffer.resize(m_SamplesPerLine * m_LineCount);
@@ -455,7 +455,7 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalStartRecording()
   }
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-  m_TimestampOffset = vtkPlusAccurateTimer::GetSystemTime();
+  m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime();
   LOG_DEBUG("GetPendingRecreateTables: " << GetPendingRecreateTables());
   LOG_DEBUG("GetPendingRestartSequencer: " << GetPendingRestartSequencer());
   LOG_DEBUG("GetPendingRun30Frames: " << GetPendingRun30Frames());

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -166,7 +166,7 @@ protected:
   unsigned m_SamplesPerLine = 512;
   std::vector<uint8_t> m_BModeBuffer; //avoid reallocating buffer every frame
   bool m_UseDeviceFrameReconstruction = true;
-  PlusTrackedFrame::FieldMapType m_CustomFields;
+  igsioTrackedFrame::FieldMapType m_CustomFields;
   double m_TimeGainCompensation[8];
   float m_FocalPointDepth[4];
   uint16_t m_MinValue = 16; //noise floor


### PR DESCRIPTION
A few IGSIO name changes were missed for the WinProbeVideo class probably because 2 pull requests were issued around the same time. This was causing build errors for this device. It build successfully now with these updates.