### PR TITLE
BUG: Fix incorrect focal point depth returned in WinProbeVideo

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -622,7 +622,7 @@ float vtkPlusWinProbeVideoSource::GetFocalPointDepth(int index)
   {
     m_FocalPointDepth[index] = ::GetFocalPointDepth(index);
   }
-  return m_TimeGainCompensation[index];
+  return m_FocalPointDepth[index];
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Time Gain Compensation was being returned instead of Focal Point Depth.