### PR TITLE
ENH: Load Default XML on WinProbe internal connection

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -378,6 +378,14 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
   LOG_DEBUG("Setting transducer ID: " << this->m_TransducerID);
   WPSetTransducerID(this->m_TransducerID.c_str());
 
+  std::string presetPath = "Default.xml";
+  LOG_DEBUG("Loading Default Presets. " << presetPath);
+  if (!LoadXmlPreset(presetPath.c_str()))
+  {
+    LOG_ERROR("Failed loading default presets!")
+    return PLUS_FAIL;
+  }
+
   m_ADCfrequency = GetADCSamplingRate();
   this->m_CustomFields["SamplingRate"] = std::to_string(m_ADCfrequency);
   m_LineCount = GetSSElementCount();


### PR DESCRIPTION
To get ultrasound stream that matches stream as seen in WinProbe GUI, loading of Default.xml is included as part of connection initialization. 

On loading Default.xml, the speckle size corresponding to transmit frequency is comparable between PLUS stream and stream as observed in WinProbe application GUI.