### PR TITLE
Fix SendText command in vtkPlusGenericSerialDevice

### DIFF
--- a/src/PlusDataCollection/vtkPlusGenericSerialDevice.cxx
+++ b/src/PlusDataCollection/vtkPlusGenericSerialDevice.cxx
@@ -251,8 +251,7 @@ PlusStatus vtkPlusGenericSerialDevice::GetCTS(bool & onOff)
 }
 
 //-------------------------------------------------------------------------
-PlusStatus vtkPlusGenericSerialDevice::SendText(const std::string& textToSend, std::string* textReceived/*=NULL*/,
-  ReplyTermination acceptReply/*=REQUIRE_LINE_ENDING*/)
+PlusStatus vtkPlusGenericSerialDevice::SendText(const std::string& textToSend, std::string* textReceived, ReplyTermination acceptReply)
 {
   LOG_DEBUG("Send to Serial device: " << textToSend);
 

--- a/src/PlusDataCollection/vtkPlusGenericSerialDevice.h
+++ b/src/PlusDataCollection/vtkPlusGenericSerialDevice.h
@@ -77,8 +77,8 @@ public:
     Some devices (e.g. Velmex VXM) has both kinds of commands, e.g. `V` command is not CR terminated:
     http://www.velmex.com/Downloads/Spec_Sheets/VXM%20-%20%20Command%20Summary%20Rev%20B%20814.pdf
   */
-  virtual PlusStatus SendText(const std::string& textToSend, std::string* textReceived = NULL,
-    ReplyTermination acceptReply = REQUIRE_LINE_ENDING);
+  virtual PlusStatus SendText(const std::string& textToSend, std::string* textReceived = NULL) VTK_OVERRIDE { return this->SendText(textToSend, textReceived, REQUIRE_LINE_ENDING); };
+  virtual PlusStatus SendText(const std::string& textToSend, std::string* textReceived, ReplyTermination acceptReply);
 
   /*!
     Receive a response from the serial device.


### PR DESCRIPTION
Due to a change in the signature of SendText() in vtkPlusGenericSerialDevice, the method was no longer overridden.
This commit restores the original function signature by creating a new function with the original signature that calls the modified function.