### PR TITLE
Fix acquisition rate bkprofocusoem

### DIFF
--- a/src/PlusDataCollection/BkProFocus/vtkPlusBkProFocusOemVideoSource.cxx
+++ b/src/PlusDataCollection/BkProFocus/vtkPlusBkProFocusOemVideoSource.cxx
@@ -205,6 +205,19 @@ PlusStatus vtkPlusBkProFocusOemVideoSource::InternalConnect()
 PlusStatus vtkPlusBkProFocusOemVideoSource::StartContinuousDataStreaming()
 {
   std::string query;
+
+  /* Build the query string including the acquisition rate
+  as defined in the config file.
+  Example - Colour Enabled "QUERY:GRAB_FRAME \"ON\",20,\"OVERLAY\";";
+  Example - Colour Disabled "QUERY:GRAB_FRAME \"ON\",20;";
+  */
+  
+  query = "QUERY:GRAB_FRAME \"ON\",";
+
+  std::stringstream ss;
+  ss << this->AcquisitionRate;
+  query += ss.str().c_str();
+  
   if (this->ColorEnabled)
   {
     //Switch to power doppler
@@ -212,12 +225,10 @@ PlusStatus vtkPlusBkProFocusOemVideoSource::StartContinuousDataStreaming()
     {
       return PLUS_FAIL;
     }*/
-    query = "QUERY:GRAB_FRAME \"ON\",20,\"OVERLAY\";";
+    query += ",\"OVERLAY\"";
   }
-  else
-  {
-    query = "QUERY:GRAB_FRAME \"ON\",20;";
-  }
+
+  query += ";";
 
   LOG_DEBUG("Start data streaming. Query: " << query);
   if (!SendQuery(query))

--- a/src/PlusDataCollection/BkProFocus/vtkPlusBkProFocusOemVideoSource.cxx
+++ b/src/PlusDataCollection/BkProFocus/vtkPlusBkProFocusOemVideoSource.cxx
@@ -161,7 +161,8 @@ PlusStatus vtkPlusBkProFocusOemVideoSource::InternalConnect()
 
   LOG_DEBUG("BK scanner address: " << this->ScannerAddress);
   LOG_DEBUG("BK scanner OEM port: " << this->OemPort);
-
+  LOG_DEBUG("BK scanner Acquisition rate: " << this->AcquisitionRate);
+    
   if (this->OfflineTesting)
   {
     LOG_INFO("Offline testing on");

--- a/src/PlusDataCollection/BkProFocus/vtkPlusBkProFocusOemVideoSource.cxx
+++ b/src/PlusDataCollection/BkProFocus/vtkPlusBkProFocusOemVideoSource.cxx
@@ -1019,6 +1019,7 @@ PlusStatus vtkPlusBkProFocusOemVideoSource::ReadConfiguration(vtkXMLDataElement*
   XML_READ_SCALAR_ATTRIBUTE_REQUIRED(int, OemPort, deviceConfig);
   XML_READ_BOOL_ATTRIBUTE_OPTIONAL(ContinuousStreamingEnabled, deviceConfig);
   XML_READ_BOOL_ATTRIBUTE_OPTIONAL(ColorEnabled, deviceConfig);
+  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(double, AcquisitionRate, deviceConfig);
   XML_READ_BOOL_ATTRIBUTE_OPTIONAL(OfflineTesting, deviceConfig);
   XML_READ_CSTRING_ATTRIBUTE_REQUIRED(OfflineTestingFilePath, deviceConfig);
   return PLUS_SUCCESS;

--- a/src/PlusDataCollection/BkProFocus/vtkPlusBkProFocusOemVideoSource.cxx
+++ b/src/PlusDataCollection/BkProFocus/vtkPlusBkProFocusOemVideoSource.cxx
@@ -1031,7 +1031,6 @@ PlusStatus vtkPlusBkProFocusOemVideoSource::ReadConfiguration(vtkXMLDataElement*
   XML_READ_SCALAR_ATTRIBUTE_REQUIRED(int, OemPort, deviceConfig);
   XML_READ_BOOL_ATTRIBUTE_OPTIONAL(ContinuousStreamingEnabled, deviceConfig);
   XML_READ_BOOL_ATTRIBUTE_OPTIONAL(ColorEnabled, deviceConfig);
-  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(double, AcquisitionRate, deviceConfig);
   XML_READ_BOOL_ATTRIBUTE_OPTIONAL(OfflineTesting, deviceConfig);
   XML_READ_CSTRING_ATTRIBUTE_REQUIRED(OfflineTestingFilePath, deviceConfig);
   return PLUS_SUCCESS;

--- a/src/PlusDataCollection/BkProFocus/vtkPlusBkProFocusOemVideoSource.h
+++ b/src/PlusDataCollection/BkProFocus/vtkPlusBkProFocusOemVideoSource.h
@@ -47,6 +47,12 @@ public:
   /*! BK scanner OEM port */
   vtkSetMacro(OemPort, unsigned short);
 
+  /*! BK scanner Acquisition Rate */
+  vtkSetMacro(AcquisitionRate, double);
+
+  /*! BK scanner Acquisition Rate */
+  vtkGetMacro(AcquisitionRate, double);
+
   /*!
     Enable/disable continuous streaming. Continuous streaming (GRAB_FRAME command) requires extra license
     from BK but it allows faster image acquisition.

--- a/src/PlusDataCollection/BkProFocus/vtkPlusBkProFocusOemVideoSource.h
+++ b/src/PlusDataCollection/BkProFocus/vtkPlusBkProFocusOemVideoSource.h
@@ -47,12 +47,6 @@ public:
   /*! BK scanner OEM port */
   vtkSetMacro(OemPort, unsigned short);
 
-  /*! BK scanner Acquisition Rate */
-  vtkSetMacro(AcquisitionRate, double);
-
-  /*! BK scanner Acquisition Rate */
-  vtkGetMacro(AcquisitionRate, double);
-
   /*!
     Enable/disable continuous streaming. Continuous streaming (GRAB_FRAME command) requires extra license
     from BK but it allows faster image acquisition.


### PR DESCRIPTION
RE: https://github.com/PlusToolkit/PlusLib/issues/486#issuecomment-456881448

I have addressed the bug where the acquisition rate for the BK5000 was hardcoded, rather than using the rate specified in the config file, and tested successfully on our BK5000.