### PR TITLE
Fix std::future_error: No associated state

### DIFF
--- a/src/PlusDataCollection/NDICAPITracking/vtkPlusNDITracker.cxx
+++ b/src/PlusDataCollection/NDICAPITracking/vtkPlusNDITracker.cxx
@@ -1408,9 +1408,9 @@ PlusStatus vtkPlusNDITracker::ProbeSerialInternal()
   for (int i = 0; i < MAX_SERIAL_PORT_NUMBER; i++)
   {
     const char* dev = ndiSerialDeviceName(i);
-    LOG_DEBUG("Testing serial port: " << dev);
     if (dev != nullptr)
     {
+      LOG_DEBUG("Testing serial port: " << dev);
       std::string devName = std::string(dev);
       std::future<void> result = std::async([this, i, &deviceExists, devName]()
       {
@@ -1424,7 +1424,7 @@ PlusStatus vtkPlusNDITracker::ProbeSerialInternal()
       tasks.push_back(std::move(result));
     }
   }
-  for (int i = 0; i < MAX_SERIAL_PORT_NUMBER; i++)
+  for (int i = 0; i < tasks.size(); i++)
   {
     tasks[i].wait();
   }


### PR DESCRIPTION
Two minor changes:

1. Moved LOG_DEBUG output to prevent flooding log with nullptr device names.

2. Fixed std::future_error (no ticket number). Reason: If some devices are not found (dev == nullptr), then tasks.size() < MAX_SERIAL_PORT_NUMBER and we'll wait for a std::future that has not been initialized.
