### PR TITLE
BUG: Update Capistrano pulse frequency

### DIFF
--- a/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
+++ b/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
@@ -1368,6 +1368,7 @@ PlusStatus vtkPlusCapistranoVideoSource::SetSampleFrequency(float sf)
 PlusStatus vtkPlusCapistranoVideoSource::SetPulseFrequency(float pf)
 {
   this->PulseFrequency = pf;
+  this->Internal->SetUSProbePulserParamsFromDB(this->PulseFrequency);
   return PLUS_SUCCESS;
 }
 


### PR DESCRIPTION
Set Capistrano probe pulse frequency on `setPulseFrequency()` call