### PR TITLE
BUG: Include B-mode frames when in BRF mode.

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -306,7 +306,7 @@ void vtkPlusWinProbeVideoSource::FrameCallback(int length, char* data, char* hHe
       AdjustBufferSizes();
       AdjustSpacing();
     }
-    else if(usMode & BFRFALineImage_RFData && frameSize[0] != m_SamplesPerLine * ::GetSSDecimation())
+    else if(usMode & BFRFALineImage_RFData && frameSize[0] != m_SamplesPerLine * m_SSDecimation)
     {
       LOG_INFO("Rf frame size updated. Adjusting buffer size and spacing.");
       AdjustBufferSizes();
@@ -691,6 +691,8 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
   this->SetTransmitFrequencyMHz(m_Frequency);
   this->SetVoltage(m_Voltage);
   this->SetScanDepthMm(m_ScanDepth);
+  // Update decimation variable on start, based on scan depth
+  m_SSDecimation = ::GetSSDecimation();
   this->SetSpatialCompoundEnabled(m_SpatialCompoundEnabled); // also takes care of angle  and count
 
   //setup size for DirectX image
@@ -868,6 +870,8 @@ PlusStatus vtkPlusWinProbeVideoSource::SetScanDepthMm(float depth)
     SetPendingRecreateTables(true);
     //what we requested might be only approximately satisfied
     m_ScanDepth = ::GetSSDepth();
+    // Update decimation with scan depth
+    m_SSDecimation = ::GetSSDecimation();
     if(Recording)
     {
       WPExecute();

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -306,6 +306,12 @@ void vtkPlusWinProbeVideoSource::FrameCallback(int length, char* data, char* hHe
       AdjustBufferSizes();
       AdjustSpacing();
     }
+    else if(usMode & BFRFALineImage_RFData && frameSize[0] != m_SamplesPerLine * ::GetSSDecimation())
+    {
+      LOG_INFO("Rf frame size updated. Adjusting buffer size and spacing.");
+      AdjustBufferSizes();
+      AdjustSpacing();
+    }
     else if(this->CurrentPixelSpacingMm[1] != m_ScanDepth / (m_SamplesPerLine - 1)) // we might need approximate equality check
     {
       LOG_INFO("Scan Depth changed. Adjusting spacing.");

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -294,7 +294,7 @@ void vtkPlusWinProbeVideoSource::FrameCallback(int length, char* data, char* hHe
     frameSize[0] = cfdGeometry->LineCount;
     frameSize[1] = cfdGeometry->SamplesPerKernel;
   }
-  else if(usMode & B || usMode & BFRFALineImage_RFData)
+  else if(usMode & B || usMode & BFRFALineImage_RFData || usMode & BFRFALineImage_SampleData)
   {
     frameSize[0] = brfGeometry->LineCount;
     frameSize[1] = brfGeometry->SamplesPerLine;
@@ -358,6 +358,7 @@ void vtkPlusWinProbeVideoSource::FrameCallback(int length, char* data, char* hHe
 
   if(usMode & B && !m_PrimarySources.empty() // B-mode and primary source is defined
       || usMode & M_PostProcess && !m_ExtraSources.empty() // M-mode and extra source is defined
+      || usMode & BFRFALineImage_SampleData && !m_PrimarySources.empty()  // B-mode and primary source is defined, if in RF/BRF mode
     )
   {
     assert(length == frameSize[0] * frameSize[1] * sizeof(uint16_t) + 16); //frame + header

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1073,7 +1073,10 @@ void vtkPlusWinProbeVideoSource::SetBRFEnabled(bool value)
 {
   if(Connected)
   {
-    SetMIsEnabled(false);
+    if(m_Mode == Mode::M)
+    {
+      SetMIsEnabled(false);
+    }
     if(value)
     {
       SetHandleBRFInternally(false);

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1073,6 +1073,7 @@ void vtkPlusWinProbeVideoSource::SetBRFEnabled(bool value)
 {
   if(Connected)
   {
+    SetMIsEnabled(false);
     if(value)
     {
       SetHandleBRFInternally(false);
@@ -1119,6 +1120,10 @@ void vtkPlusWinProbeVideoSource::SetMModeEnabled(bool value)
 {
   if(Connected)
   {
+    if(m_Mode == Mode::BRF)
+    {
+      SetBRFEnabled(false);
+    }
     SetMIsEnabled(value);
     if(value)
     {

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1069,6 +1069,52 @@ int32_t vtkPlusWinProbeVideoSource::GetSpatialCompoundCount()
 
 //----------------------------------------------------------------------------
 
+void vtkPlusWinProbeVideoSource::SetBRFEnabled(bool value)
+{
+  if(Connected)
+  {
+    if(value)
+    {
+      SetHandleBRFInternally(false);
+      SetBFRFImageCaptureMode(2);
+    }
+    else
+    {
+      SetHandleBRFInternally(true);
+      SetBFRFImageCaptureMode(0);
+    }
+  }
+
+  if(value)
+  {
+    m_Mode = Mode::BRF;
+  }
+  else
+  {
+    m_Mode = Mode::B;
+  }
+}
+
+bool vtkPlusWinProbeVideoSource::GetBRFEnabled()
+{
+  bool brfEnabled = (m_Mode == Mode::BRF);
+  if(Connected)
+  {
+    brfEnabled = (GetBFRFImageCaptureMode() == 2);
+    if(brfEnabled)
+    {
+      m_Mode = Mode::BRF;
+    }
+    else
+    {
+      m_Mode = Mode::B;
+    }
+  }
+  return brfEnabled;
+}
+
+//----------------------------------------------------------------------------
+
 void vtkPlusWinProbeVideoSource::SetMModeEnabled(bool value)
 {
   if(Connected)

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -138,6 +138,9 @@ public:
   void SetSpatialCompoundCount(int32_t value);
   int32_t GetSpatialCompoundCount();
 
+  void SetBRFEnabled(bool value);
+  bool GetBRFEnabled();
+
   void SetMModeEnabled(bool value);
   bool GetMModeEnabled();
 


### PR DESCRIPTION
B-mode frames were being ignored when in BRF mode. B-mode frame header (in BRF mode) is now included within `FrameCallback()` checks.