### PR TITLE
BUG: Set spatial compounding, TX frequency, voltage, scan depth on initial connection

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -681,10 +681,19 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
     ::SetFocalPointDepth(i, m_FocalPointDepth[i]);
     m_FocalPointDepth[i] = ::GetFocalPointDepth(i);
   }
-  this->SetTransmitFrequencyMHz(m_Frequency);
-  this->SetVoltage(m_Voltage);
-  this->SetScanDepthMm(m_ScanDepth);
-  this->SetSpatialCompoundEnabled(m_SpatialCompoundEnabled); // also takes care of angle  and count
+  ::SetTxTxFrequency(m_Frequency);
+  ::SetVoltage(m_Voltage);
+  ::SetSSDepth(m_ScanDepth);
+  SetSCIsEnabled(m_SpatialCompoundEnabled);
+  if(m_SpatialCompoundEnabled)
+  {
+    SetSCCompoundAngle(m_SpatialCompoundAngle);
+    SetSCCompoundAngleCount(m_SpatialCompoundCount);
+  }
+  else
+  {
+    SetSCCompoundAngleCount(0);
+  }
 
   //setup size for DirectX image
   LOG_DEBUG("Setting output size to " << m_LineCount << "x" << m_SamplesPerLine);

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -681,19 +681,10 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
     ::SetFocalPointDepth(i, m_FocalPointDepth[i]);
     m_FocalPointDepth[i] = ::GetFocalPointDepth(i);
   }
-  ::SetTxTxFrequency(m_Frequency);
-  ::SetVoltage(m_Voltage);
-  ::SetSSDepth(m_ScanDepth);
-  SetSCIsEnabled(m_SpatialCompoundEnabled);
-  if(m_SpatialCompoundEnabled)
-  {
-    SetSCCompoundAngle(m_SpatialCompoundAngle);
-    SetSCCompoundAngleCount(m_SpatialCompoundCount);
-  }
-  else
-  {
-    SetSCCompoundAngleCount(0);
-  }
+  this->SetTransmitFrequencyMHz(m_Frequency);
+  this->SetVoltage(m_Voltage);
+  this->SetScanDepthMm(m_ScanDepth);
+  this->SetSpatialCompoundEnabled(m_SpatialCompoundEnabled); // also takes care of angle  and count
 
   //setup size for DirectX image
   LOG_DEBUG("Setting output size to " << m_LineCount << "x" << m_SamplesPerLine);

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -681,6 +681,8 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
     ::SetFocalPointDepth(i, m_FocalPointDepth[i]);
     m_FocalPointDepth[i] = ::GetFocalPointDepth(i);
   }
+
+  this->Connected = true; // the setters and getters check this
   this->SetTransmitFrequencyMHz(m_Frequency);
   this->SetVoltage(m_Voltage);
   this->SetScanDepthMm(m_ScanDepth);


### PR DESCRIPTION
Specified settings in config file including spatial compounding, TX frequency, voltage, scan depth settings were not set up upon device connection.

@sjh26, I've tested this with the up-to-date API, and the stream starts off correctly with specified config file settings.