### PR TITLE
BUG: Update WP RF stream pixel spacing

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -216,7 +216,7 @@ protected:
   virtual PlusStatus InternalStopRecording() VTK_OVERRIDE;
 
   /*! Updates internal spacing based on current depth */
-  void AdjustSpacing();
+  void AdjustSpacing(bool value);
 
   /*! Updates buffer size based on current depth */
   void AdjustBufferSizes();


### PR DESCRIPTION
Pixel spacing has been updated for Rf stream, to account for orientation updates. Decimation factor is also accounted, to get the correct pixel spacing in y (which is in the case for Rf, ElementSpacing[0])