### PR TITLE
BUG: Do not update m_mode when getting M-Mode/Rf mode disabled status

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1133,10 +1133,6 @@ bool vtkPlusWinProbeVideoSource::GetBRFEnabled()
     {
       m_Mode = Mode::BRF;
     }
-    else
-    {
-      m_Mode = Mode::B;
-    }
   }
   return brfEnabled;
 }
@@ -1182,10 +1178,6 @@ bool vtkPlusWinProbeVideoSource::GetMModeEnabled()
     if(mmodeEnabled)
     {
       m_Mode = Mode::M;
-    }
-    else
-    {
-      m_Mode = Mode::B;
     }
   }
   return mmodeEnabled;


### PR DESCRIPTION
m_Mode was getting to set to B-mode, even if M-mode had been enabled. Update m_Mode now only when mode is found to be enabled in getter functions.