### PR TITLE
BUG: Offset WinProbe frame timestamp based on frame 0 timestamp

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -371,9 +371,13 @@ void vtkPlusWinProbeVideoSource::FrameCallback(int length, char* data, char* hHe
     LOG_INFO("Unsupported frame type: " << std::hex << usMode);
     return;
   }
-
+  if(header->TotalFrameCounter == 0)
+  {
+    first_timestamp = header->TimeStamp / 1000.0;
+    LOG_DEBUG("First frame timestamp: "<< first_timestamp);
+  }
   //timestamp counters are in milliseconds since last sequencer restart
-  double timestamp = header->TimeStamp / 1000.0;
+  double timestamp = (header->TimeStamp / 1000.0) - first_timestamp;
   if(timestamp == 0.0) // some change is being applied, so this frame is not valid
   {
     return; // ignore this frame

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -236,6 +236,7 @@ protected:
   std::string m_TransducerID; //GUID
   double m_ADCfrequency = 60.0e6; //MHz
   double m_TimestampOffset = 0; //difference between program start time and latest internal timer restart
+  double first_timestamp = 0;
   double m_LastTimestamp = 1000; //used to determine timer restarts and to update timestamp offset
   unsigned m_LineCount = 128;
   unsigned m_SamplesPerLine = 0;


### PR DESCRIPTION
Laggy livestream issue is resolved. Reconstructed volume no longer has the smear. First frame timestamp delay is now included as an offset. 

@dzenanz, @sjh26, Could you please review this?