### PR TITLE
ENH: Add new buffer call, with WinProbe API updates for frame processing

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -753,6 +753,7 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
   if(!m_UseDeviceFrameReconstruction)
   {
     WPDXSetIsGetSpatialCompoundedTexEnabled(true);
+    WPDXSetFusedTexBufferMax(1);
   }
   WPDXSetDrawTextLayer(false);
   WPDXSetDrawScalesAndBars(false);


### PR DESCRIPTION
Set buffer max to 1, and match API updates that optimized frame processing. 