### PR TITLE
ENH: Expose transducer internal ID getter, B harmonic mode setter/getter

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -60,6 +60,7 @@ PlusStatus vtkPlusWinProbeVideoSource::ReadConfiguration(vtkXMLDataElement* root
   XML_READ_STRING_ATTRIBUTE_REQUIRED(TransducerID, deviceConfig);
   XML_READ_BOOL_ATTRIBUTE_OPTIONAL(UseDeviceFrameReconstruction, deviceConfig);
   XML_READ_BOOL_ATTRIBUTE_OPTIONAL(SpatialCompoundEnabled, deviceConfig);
+  XML_READ_BOOL_ATTRIBUTE_OPTIONAL(BHarmonicEnabled, deviceConfig);
   XML_READ_BOOL_ATTRIBUTE_OPTIONAL(MRevolvingEnabled, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(float, TransmitFrequencyMHz, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(float, ScanDepthMm, deviceConfig);
@@ -113,6 +114,7 @@ PlusStatus vtkPlusWinProbeVideoSource::WriteConfiguration(vtkXMLDataElement* roo
   deviceConfig->SetAttribute("TransducerID", this->m_TransducerID.c_str());
   deviceConfig->SetAttribute("UseDeviceFrameReconstruction", this->m_UseDeviceFrameReconstruction ? "TRUE" : "FALSE");
   deviceConfig->SetAttribute("SpatialCompoundEnabled", this->GetSpatialCompoundEnabled() ? "TRUE" : "FALSE");
+  deviceConfig->SetAttribute("HarmonicEnabled", this->GetBHarmonicEnabled() ? "TRUE" : "FALSE");
   deviceConfig->SetAttribute("MRevolvingEnabled", this->GetMRevolvingEnabled() ? "TRUE" : "FALSE");
   deviceConfig->SetFloatAttribute("TransmitFrequencyMHz", this->GetTransmitFrequencyMHz());
   deviceConfig->SetFloatAttribute("ScanDepthMm", this->GetScanDepthMm());
@@ -1141,6 +1143,25 @@ bool vtkPlusWinProbeVideoSource::GetBRFEnabled()
   return brfEnabled;
 }
 
+void vtkPlusWinProbeVideoSource::SetBHarmonicEnabled(bool value)
+{
+  if(Connected)
+  {
+    SetBIsHarmonic(value);
+    SetPendingRecreateTables(true);
+  }
+  m_BHarmonicEnabled = GetBIsHarmonic();
+}
+
+bool vtkPlusWinProbeVideoSource::GetBHarmonicEnabled()
+{
+  if(Connected)
+  {
+    m_BHarmonicEnabled = GetBIsHarmonic();
+  }
+  return m_BHarmonicEnabled;
+}
+
 //----------------------------------------------------------------------------
 
 void vtkPlusWinProbeVideoSource::SetMModeEnabled(bool value)
@@ -1336,6 +1357,11 @@ PlusStatus vtkPlusWinProbeVideoSource::SetTransducerID(std::string guid)
   return PLUS_SUCCESS;
 }
 
+int vtkPlusWinProbeVideoSource::GetTransducerInternalID()
+{
+  int transducer_id = ::GetTransducerInternalID();
+  return transducer_id;
+}
 //----------------------------------------------------------------------------
 std::vector<double> vtkPlusWinProbeVideoSource::GetPrimarySourceSpacing()
 {

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -138,6 +138,9 @@ public:
   void SetSpatialCompoundCount(int32_t value);
   int32_t GetSpatialCompoundCount();
 
+  void SetBHarmonicEnabled(bool value);
+  bool GetBHarmonicEnabled();
+
   void SetBRFEnabled(bool value);
   bool GetBRFEnabled();
 
@@ -167,6 +170,8 @@ public:
 
   void SetBFrameRateLimit(int32_t value);
   int32_t GetBFrameRateLimit();
+
+  int GetTransducerInternalID();
 
   enum class Mode
   {
@@ -262,6 +267,7 @@ protected:
   uint8_t m_SSDecimation = 2;
   double m_FirstGainValue = 15;
   int32_t m_BFrameRateLimit = 0;
+  bool m_BHarmonicEnabled = false;
   std::vector<vtkPlusDataSource*> m_PrimarySources;
   std::vector<vtkPlusDataSource*> m_ExtraSources;
 


### PR DESCRIPTION
Exposed internal Transducer ID getter, which can be used to determine if transducer is connected to board. Can now enable Harmonic mode within B-mode.