### PR TITLE
Spinnaker video set an orientation for image

### DIFF
--- a/src/PlusDataCollection/PointGrey/vtkPlusSpinnakerVideoSource.cxx
+++ b/src/PlusDataCollection/PointGrey/vtkPlusSpinnakerVideoSource.cxx
@@ -748,19 +748,25 @@ PlusStatus vtkPlusSpinnakerVideoSource::InternalUpdate()
     if (this->PixelEncoding == RGB24)
     {
       retVal = videoSource->AddItem(
-        convertedImage->GetData(),
+        convertedImage->GetData(), 
+        US_IMG_ORIENT_MN,
         this->FrameSize,
-        convertedImage->GetImageSize(),
+        VTK_UNSIGNED_CHAR,
+        3,
         US_IMG_RGB_COLOR,
+        0,
         this->FrameNumber);
     }
     else if (this->PixelEncoding == MONO8)
     {
       retVal = videoSource->AddItem(
         convertedImage->GetData(),
+        US_IMG_ORIENT_MN,
         this->FrameSize,
-        convertedImage->GetImageSize(),
+        VTK_UNSIGNED_CHAR,
+        1,
         US_IMG_BRIGHTNESS,
+        0,
         this->FrameNumber);
     }
 
@@ -772,7 +778,6 @@ PlusStatus vtkPlusSpinnakerVideoSource::InternalUpdate()
     LOG_ERROR("SpinnakerVideoSource: Failed in InternalUpdate(). Exception text: " << e.what());
     return PLUS_FAIL;
   }
-  LOG_INFO(this->FrameNumber);
   this->FrameNumber++; 
   return retVal;
 }


### PR DESCRIPTION
Spinnaker video source wasn't setting an orientation for the image and as a result, the image couldn't be flipped using the config file. Now it is setting MN as default orientation and users can get the image to flip by specifying a different orientation in the config file (ex. MF).