### PR TITLE
Adding autodetection of horizontal image flip for optical marker tracker detection

### DIFF
--- a/src/PlusDataCollection/OpticalMarkerTracking/vtkPlusOpticalMarkerTracker.h
+++ b/src/PlusDataCollection/OpticalMarkerTracking/vtkPlusOpticalMarkerTracker.h
@@ -36,19 +36,14 @@ public:
   /*! Write current main config settings to XML. */
   virtual PlusStatus WriteConfiguration(vtkXMLDataElement*);
 
-  /*! Probe to see if the tracking system is present. */
-  PlusStatus Probe();
-
   /*! Connect to the tracker hardware */
   PlusStatus InternalConnect();
 
-  /*! Disconnect from the tracker hardware */
-  PlusStatus InternalDisconnect();
-
-  /*!
-  Get an update from the tracking system and push the new transforms to the tools.
-  */
+  /*! Get an update from the tracking system and push the new transforms to the tools. */
   virtual PlusStatus InternalUpdate();
+
+  /*! Verify the device has been correctly configured */
+  virtual PlusStatus NotifyConfigured();
 
   /* This device is a virtual tracker. */
   virtual bool IsTracker() const { return true; }
@@ -58,17 +53,8 @@ protected:
   vtkPlusOpticalMarkerTracker();
   ~vtkPlusOpticalMarkerTracker();
 
-  /*! Start the tracking system. */
-  PlusStatus InternalStartRecording();
-
-  /*! Stop the tracking system and bring it back to its initial state. */
-  PlusStatus InternalStopRecording();
-
   class vtkInternal;
   vtkInternal* Internal;
-
-  unsigned int FrameNumber;
-  double LastProcessedInputDataTimestamp;
 
 private:
   vtkPlusOpticalMarkerTracker(const vtkPlusOpticalMarkerTracker&);


### PR DESCRIPTION
Adding autodetection of horizontal image flip for optical marker tracker detection, as this is a problem that is commonly experienced