### PR TITLE
BUG: Fix WinProbe not disconnecting all the way

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -628,6 +628,8 @@ vtkPlusWinProbeVideoSource::~vtkPlusWinProbeVideoSource()
   {
     this->Disconnect();
   }
+  WPDispose();
+  WPDXDispose();
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
The WinProbe device was not closing completely when disconnect was called. This uses 2 new calls as directed by the API developer. Tested with hardware and PlusServer will correctly close all the way now. 
 This requires UltraVisionAPI as of November 22nd 2019.