### PR TITLE
Expose BMultiTxCount from UltraVision API as BMultiFocalZoneCount

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -729,6 +729,7 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
   }
   SetTGCFirstGainValue(m_FirstGainValue);
   //SetPendingTGCUpdate(true);
+  SetBMultiFocalZoneCount(m_BMultiTxCount);
   for(int i = 0; i < 4; i++)
   {
     ::SetFocalPointDepth(i, m_FocalPointDepth[i]);
@@ -1028,6 +1029,29 @@ PlusStatus vtkPlusWinProbeVideoSource::SetFocalPointDepth(int index, float depth
     SetPendingRecreateTables(true);
     //what we requested might be only approximately satisfied
     m_FocalPointDepth[index] = ::GetFocalPointDepth(index);
+  }
+  return PLUS_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int32_t vtkPlusWinProbeVideoSource::GetBMultiFocalZoneCount()
+{
+  if(Connected)
+  {
+    m_BMultiTxCount = GetBMultiTxCount();
+  }
+  return m_BMultiTxCount;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusWinProbeVideoSource::SetBMultiFocalZoneCount(int32_t count)
+{
+  assert(count >= 1 && count < 4);
+  m_BMultiTxCount = count;
+  if(Connected)
+  {
+    SetBMultiTxCount(count);
+    SetPendingRecreateTables(true);
   }
   return PLUS_SUCCESS;
 }

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -87,6 +87,12 @@ public:
   /* Set the focal depth, index 0 to 4 */
   PlusStatus SetFocalPointDepth(int index, float depth);
 
+  /* Get the number of active focal zones, count 1 to 4 */
+  int32_t GetBMultiFocalZoneCount();
+
+  /* Set the number of active focal zones, count 1 to 4 */
+  PlusStatus SetBMultiFocalZoneCount(int32_t count);
+
   /* Whether or not to use device's built-in frame reconstruction */
   void SetUseDeviceFrameReconstruction(bool value) { m_UseDeviceFrameReconstruction = value; }
 
@@ -259,6 +265,7 @@ protected:
   float m_SpatialCompoundAngle = 10.0f;
   int32_t m_SpatialCompoundCount = 0;
   bool m_MRevolvingEnabled = false;
+  int32_t m_BMultiTxCount = 1;
   int32_t m_MPRF = 100;
   int32_t m_MLineIndex = 60;
   int32_t m_MWidth = 256;


### PR DESCRIPTION
Exposed `GetBMultiTxCount` and `SetBMultiTxCount` from UltraVision API as `GetBMultiFocalZoneCount` and `SetBMultiFocalZoneCount`. 

Setting the focal zone count to a number higher than 1 allows changes to the focal depth at an index other than 0 to be seen in the winprobe stream.
https://github.com/PlusToolkit/PlusLib/blob/6be00876645c62838ff637dcbc1a3fb2a030fdae/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h#L86-L89
