### PR TITLE
BUG: Fix Capistrano last set voltage not being used when unfrozen

### DIFF
--- a/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
+++ b/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
@@ -1547,6 +1547,7 @@ unsigned char vtkPlusCapistranoVideoSource::GetDerivativeCompensation()
 PlusStatus vtkPlusCapistranoVideoSource::SetPulseVoltage(float pv)
 {
   usbSetPulseVoltage(pv);
+  this->Internal->ImagingParameters->SetProbeVoltage(pv);
   return PLUS_SUCCESS;
 }
 


### PR DESCRIPTION
Capistrano device uses internal probe voltage value from its database to set voltage when unfreezing the probe. Discovered this after setting a voltage, freezing, unfreezing and then the voltage getting set to about 30V, at least while in MIS mode. Other settings update the internal setting like the change proposed here. 

I confirmed with hardware that voltage upon unfreezing the probe is the voltage that was last set.
@dzenanz I know you make some updates to this class if you would like to review.