### PR TITLE
ENH: Add initial ARFI support for WinProbe

### DIFF
--- a/src/PlusDataCollection/Testing/vtkWinProbeVideoSourceTest.cxx
+++ b/src/PlusDataCollection/Testing/vtkWinProbeVideoSourceTest.cxx
@@ -123,19 +123,21 @@ int main(int argc, char* argv[])
 
   if(renderingOff)
   {
-    Sleep(2500); //allow some time to buffer frames
+    Sleep(1500);
+    WinProbeDevice->ARFIPush(); // in case we are in ARFI mode, invoke it
+    Sleep(8000); //allow some time to buffer frames
 
     vtkPlusChannel* bChannel(nullptr);
     if(WinProbeDevice->GetOutputChannelByName(bChannel, "VideoStream") != PLUS_SUCCESS)
     {
       LOG_ERROR("Unable to locate the channel with Id=\"VideoStream\". Check config file.");
-      exit(EXIT_FAILURE);
+      return EXIT_FAILURE;
     }
 
     vtkPlusChannel* rfChannel(nullptr);
-    if(WinProbeDevice->GetOutputChannelByName(rfChannel, "RfStream") != PLUS_SUCCESS)
+    if(WinProbeDevice->GetOutputChannelByName(rfChannel, "AdditionalStream") != PLUS_SUCCESS)
     {
-      LOG_WARNING("Unable to locate the channel with Id=\"RFStream\". RF mode will not be used.");
+      LOG_WARNING("Unable to locate the channel with Id=\"AdditionalStream\". Additional mode will not be used.");
     }
 
     WinProbeDevice->FreezeDevice(true);

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -694,8 +694,8 @@ vtkPlusWinProbeVideoSource::~vtkPlusWinProbeVideoSource()
   {
     this->Disconnect();
   }
-  WPDispose();
   WPDXDispose();
+  WPDispose();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -81,17 +81,56 @@ public:
   /* Set the TGC First Gain Value near transducer face */
   PlusStatus SetFirstGainValue(double value);
 
-  /* Get the focal depth, index 0 to 4 */
+  /* Get the B-Mode focal depth at a specific index, index 0 to 3 */
   float GetFocalPointDepth(int index);
 
-  /* Set the focal depth, index 0 to 4 */
+  /* Set the B-Mode focal depth at a specific index, index 0 to 3 */
   PlusStatus SetFocalPointDepth(int index, float depth);
 
-  /* Get the number of active focal zones, count 1 to 4 */
+  /* Get the ARFI focal depth at a specific index, index 0 to 5 */
+  float GetARFIFocalPointDepth(int index);
+
+  /* Set the ARFI focal depth at a specific index, index 0 to 5 */
+  PlusStatus SetARFIFocalPointDepth(int index, float depth);
+
+  /* Get the number of active focal zones for B-Mode, count 1 to 4 */
   int32_t GetBMultiFocalZoneCount();
 
-  /* Set the number of active focal zones, count 1 to 4 */
+  /* Set the number of active focal zones for B-Mode, count 1 to 4 */
   PlusStatus SetBMultiFocalZoneCount(int32_t count);
+
+  /* Get the number of active focal zones for ARFI, count 1 to 6 */
+  int32_t GetARFIMultiFocalZoneCount();
+
+  /* Set the number of active focal zones for ARFI, count 1 to 6 */
+  PlusStatus SetARFIMultiFocalZoneCount(int32_t count);
+
+  /* Get if the connected engine has an x8 beamformer. */
+  bool GetARFIIsX8BFEnabled();
+
+  /* Set the number of states in the transmit pulse. 1-16 */
+  PlusStatus vtkPlusWinProbeVideoSource::SetARFITxTxCycleCount(uint16_t propertyValue);
+
+  /* Get the number of states in the transmit pulse. 1-16 */
+  uint16_t vtkPlusWinProbeVideoSource::GetARFITxTxCycleCount();
+
+  /* Set the width of the tx cycle. Determines the transmit frequency for non apodized transmits. 1-255 */
+  PlusStatus vtkPlusWinProbeVideoSource::SetARFITxTxCycleWidth(uint8_t propertyValue);
+
+  /* Get the width of the tx cycle. Determines the transmit frequency for non apodized transmits. 1-255 */
+  uint8_t vtkPlusWinProbeVideoSource::GetARFITxTxCycleWidth();
+
+  /* Set the number of cycles in the ARFI push pulse. */
+  PlusStatus vtkPlusWinProbeVideoSource::SetARFITxCycleCount(uint16_t propertyValue);
+
+  /* Get the number of cycles in the ARFI push pulse. */
+  uint16_t vtkPlusWinProbeVideoSource::GetARFITxCycleCount();
+
+  /* Set the frequency of the push pulse. */
+  PlusStatus vtkPlusWinProbeVideoSource::SetARFITxCycleWidth(uint8_t propertyValue);
+
+  /* Get the frequency of the push pulse. */
+  uint8_t vtkPlusWinProbeVideoSource::GetARFITxCycleWidth();
 
   /* Whether or not to use device's built-in frame reconstruction */
   void SetUseDeviceFrameReconstruction(bool value) { m_UseDeviceFrameReconstruction = value; }
@@ -181,6 +220,10 @@ public:
   bool GetARFIEnabled();
   /*! If running in ARFI mode, does an ARFI push. Otherwise does nothing and returns failure status. */
   PlusStatus ARFIPush();
+  void SetARFIStartSample(int32_t value);
+  int32_t GetARFIStartSample();
+  void SetARFIStopSample(int32_t value);
+  int32_t GetARFIStopSample();
 
   int GetTransducerInternalID();
 
@@ -265,6 +308,7 @@ protected:
   igsioFieldMapType m_CustomFields;
   double m_TimeGainCompensation[8];
   float m_FocalPointDepth[4];
+  float m_ARFIFocalPointDepth[6];
   uint16_t m_MinValue = 16; //noise floor
   uint16_t m_MaxValue = 16384; //maximum typical value
   uint16_t m_Knee = 4096; // threshold value for switching from log to linear
@@ -274,6 +318,11 @@ protected:
   int32_t m_SpatialCompoundCount = 0;
   bool m_MRevolvingEnabled = false;
   int32_t m_BMultiTxCount = 1;
+  int32_t m_ARFIMultiTxCount = 1;
+  uint16_t m_ARFITxTxCycleCount = 2;
+  uint8_t m_ARFITxTxCycleWidth = 1;
+  uint16_t m_ARFITxCycleCount = 4096;
+  uint8_t m_ARFITxCycleWidth = 1;
   int32_t m_MPRF = 100;
   int32_t m_MLineIndex = 60;
   int32_t m_MWidth = 256;

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -195,6 +195,8 @@ public:
     CFD // Color-Flow Doppler
   };
 
+  PlusStatus SetExtraSourceMode(Mode mode);
+
   /*! Sets the ultrasound imaging mode. */
   void SetMode(Mode mode)
   {

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -177,6 +177,11 @@ public:
   void SetBFrameRateLimit(int32_t value);
   int32_t GetBFrameRateLimit();
 
+  void SetARFIEnabled(bool value);
+  bool GetARFIEnabled();
+  /*! If running in ARFI mode, does an ARFI push. Otherwise does nothing and returns failure status. */
+  PlusStatus ARFIPush();
+
   int GetTransducerInternalID();
 
   enum class Mode
@@ -186,6 +191,7 @@ public:
     RF, // RF mode only
     M, // M mode
     PW, // Pulsed Wave Doppler
+    ARFI, // Acoustic Radiation Force Impulse
     CFD // Color-Flow Doppler
   };
 
@@ -250,7 +256,7 @@ protected:
   double first_timestamp = 0;
   double m_LastTimestamp = 1000; //used to determine timer restarts and to update timestamp offset
   FrameSizeType m_PrimaryFrameSize = { 128, 256, 1 };
-  FrameSizeType m_ExtraFrameSize = { 128, 256, 1 };
+  FrameSizeType m_ExtraFrameSize = { 256, 128, 1 };
   std::vector<uint8_t> m_PrimaryBuffer;
   std::vector<uint8_t> m_ExtraBuffer;
   bool m_UseDeviceFrameReconstruction = true;

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -249,8 +249,8 @@ protected:
   double m_TimestampOffset = 0; //difference between program start time and latest internal timer restart
   double first_timestamp = 0;
   double m_LastTimestamp = 1000; //used to determine timer restarts and to update timestamp offset
-  unsigned m_LineCount = 128;
-  unsigned m_SamplesPerLine = 0;
+  FrameSizeType m_PrimaryFrameSize = { 128, 256, 1 };
+  FrameSizeType m_ExtraFrameSize = { 128, 256, 1 };
   std::vector<uint8_t> m_PrimaryBuffer;
   std::vector<uint8_t> m_ExtraBuffer;
   bool m_UseDeviceFrameReconstruction = true;


### PR DESCRIPTION
This PR exposes some of the WinProbe ARFI API, and is largely work by @dzenanz . I've squashed ARFI related commits from https://github.com/dzenanz/PlusLib/commit/2d8f07e5be364e6ae1032ebbf645b7457d054995 to https://github.com/dzenanz/PlusLib/commit/a4e084ba6e17f74c53edab88ae4d531947ed0849 into the one ENH commit, and pulled out the commits from https://github.com/dzenanz/PlusLib/commit/f866d7ca3140c5d2c8cff940d61b83d0aff5b4ff until ARFI for the REFACTOR.

This is currently WIP as @tomekcz and I are confirming the returned data with a phantom. The implementation as it stands adds the ARFI data as one long 2d frame to the extra source which can be manipulated post acquisition, and can be changed later when the API is updated to allow changes to the number of 6x5 repetitions.

@dzenanz @jamesobutler , could you take a look?