### PR TITLE
BUG: Fix build errors introduced by IGSIO

### DIFF
--- a/src/PlusDataCollection/VirtualDevices/vtkPlusVirtualVolumeReconstructor.cxx
+++ b/src/PlusDataCollection/VirtualDevices/vtkPlusVirtualVolumeReconstructor.cxx
@@ -388,7 +388,9 @@ PlusStatus vtkPlusVirtualVolumeReconstructor::AddFrames(vtkIGSIOTrackedFrameList
     }
     // Insert slice for reconstruction
     bool insertedIntoVolume = false;
-    if (this->VolumeReconstructor->AddTrackedFrame(frame, this->TransformRepository, &insertedIntoVolume) != PLUS_SUCCESS)
+    bool isFirst = frameIndex == 0;
+    bool isLast = frameIndex + this->VolumeReconstructor->GetSkipInterval() >= numberOfFrames;
+    if (this->VolumeReconstructor->AddTrackedFrame(frame, this->TransformRepository, isFirst, isLast, &insertedIntoVolume) != PLUS_SUCCESS)
     {
       LOG_ERROR("Failed to add tracked frame to volume with frame #" << frameIndex);
       status = PLUS_FAIL;

--- a/src/PlusVolumeReconstruction/Tools/VolumeReconstructor.cxx
+++ b/src/PlusVolumeReconstruction/Tools/VolumeReconstructor.cxx
@@ -197,7 +197,9 @@ int main(int argc, char* argv[])
 
     // Insert slice for reconstruction
     bool insertedIntoVolume = false;
-    if (reconstructor->AddTrackedFrame(frame, transformRepository, &insertedIntoVolume) != PLUS_SUCCESS)
+    bool isFirst = frameIndex == 0;
+    bool isLast = frameIndex + reconstructor->GetSkipInterval() >= numberOfFrames;
+    if (reconstructor->AddTrackedFrame(frame, transformRepository, isFirst, isLast, &insertedIntoVolume) != PLUS_SUCCESS)
     {
       LOG_ERROR("Failed to add tracked frame to volume with frame #" << frameIndex);
       continue;


### PR DESCRIPTION
The change to the function signature of `vtkIGSIOVolumeReconstructor::AddTrackedFrame` in IGSIO/IGSIO commit [47a3e2](https://github.com/IGSIO/IGSIO/commit/47a3e2f30da3bd1a8602e2c85fad1e14ecf40129) breaks the PLUS build. This PR fixes this.
