### PR TITLE
ENH: Expose WinProbe ARFIPushOffset

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1683,7 +1683,25 @@ int32_t vtkPlusWinProbeVideoSource::GetARFIStopSample()
   return stopSample;
 }
 
+//----------------------------------------------------------------------------
+void vtkPlusWinProbeVideoSource::SetARFIPushOffset(int32_t value)
+{
+  if(Connected)
+  {
+    ::SetARFIPushOffset(value);
+    SetPendingRecreateTables(true);
+  }
+}
 
+//----------------------------------------------------------------------------
+int32_t vtkPlusWinProbeVideoSource::GetARFIPushOffset()
+{
+  if(Connected)
+  {
+    m_ARFIPushOffset = ::GetARFIPushOffset();
+  }
+  return m_ARFIPushOffset;
+}
 
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusWinProbeVideoSource::SetTransducerID(std::string guid)

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -222,8 +222,12 @@ public:
   PlusStatus ARFIPush();
   void SetARFIStartSample(int32_t value);
   int32_t GetARFIStartSample();
+
   void SetARFIStopSample(int32_t value);
   int32_t GetARFIStopSample();
+
+  void SetARFIPushOffset(int32_t value);
+  int32_t GetARFIPushOffset();
 
   int GetTransducerInternalID();
 
@@ -325,6 +329,7 @@ protected:
   uint8_t m_ARFITxTxCycleWidth = 1;
   uint16_t m_ARFITxCycleCount = 4096;
   uint8_t m_ARFITxCycleWidth = 1;
+  int32_t m_ARFIPushOffset = -12;
   int32_t m_MPRF = 100;
   int32_t m_MLineIndex = 60;
   int32_t m_MWidth = 256;


### PR DESCRIPTION
This exposes ARFIPushOffset for the WinProbe device so that PLUS can set it to different values other than the default.

This was tested with hardware to confirm the change.