### PR TITLE
Fixed dead BlackMagic link on configuration documentation page

### DIFF
--- a/src/Documentation/UserManual/DeviceBlackMagicDeckLink.dox
+++ b/src/Documentation/UserManual/DeviceBlackMagicDeckLink.dox
@@ -1,5 +1,5 @@
 /*!
-\page BMDeckLink BlackMagic DeckLink
+\page DeviceBlackMagicDeckLink BlackMagic DeckLink
 
 \section BMDeckLinkSupportedHwDevices Supported hardware devices
 


### PR DESCRIPTION
@adamrankin The user documentation link for configuring the BlackMagic device is dead, this commit should fix this.