### PR TITLE
ENH: Simplify setting Capistrano debug file path

### DIFF
--- a/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
+++ b/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
@@ -823,17 +823,10 @@ PlusStatus vtkPlusCapistranoVideoSource::InitializeCapistranoProbe()
   // These include: usbInitializeProbes, usbProbeHandle, usbSelectProbe.
   usbErrorString errorStatus = {0};
   #ifdef CAPISTRANO_SDK2019_3
-    const char* string = (std::getenv("APPDATA") + std::string("\\CLI")).c_str();
-    size_t len = strlen(string);
-    WCHAR* unistring=new WCHAR[len + 1];
-    int result = MultiByteToWideChar(CP_OEMCP, 0, string, -1, unistring, len + 1);
-    const char* filename = "debug.txt";
-    size_t len_fn = strlen(filename);
-    WCHAR* filename_uni=new WCHAR[len_fn + 1];
-    int result_fn = MultiByteToWideChar(CP_OEMCP, 0, filename, -1, filename_uni, len_fn + 1);
-    usbUseFileNamePath((LPTSTR)filename_uni, (LPTSTR)unistring);
-    delete unistring;
-    delete filename_uni;
+    wchar_t* appData = _wgetenv(L"APPDATA");
+    std::wstring path = appData + std::wstring(L"\\CLI");
+    wchar_t* filename_uni = L"debug.txt";
+    usbUseFileNamePath((LPTSTR)filename_uni, (LPTSTR)path.c_str());
   #endif
   ULONG status = usbFindProbes(errorStatus);
   LOG_DEBUG("Find USB probes: status=" << status << ", details: " << errorStatus);


### PR DESCRIPTION
This is a follow-up to #687, to simplify the method for setting the Capistrano debug output file path.

@Sunderlandkyl, this PR has also been tested with hardware and can be merged as well. Thanks! 