### PR TITLE
Various fixes for WinProbe ARFI calls

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -151,11 +151,12 @@ PlusStatus vtkPlusWinProbeVideoSource::ReadConfiguration(vtkXMLDataElement* root
   {
     m_BMultiTxCount = focalCountFromDepthsArray(m_FocalPointDepth, m_BMultiTxCount);
   }
-  m_ARFIMultiTxCount = deviceConfig->GetVectorAttribute("ARFIFocalPointDepth", 6, m_ARFIFocalPointDepth);
-  if (m_ARFIMultiTxCount) // examine for duplicates
-  {
+  deviceConfig->GetVectorAttribute("ARFIFocalPointDepth", 6, m_ARFIFocalPointDepth);
+  // m_ARFIMultiTxCount = deviceConfig->GetVectorAttribute("ARFIFocalPointDepth", 6, m_ARFIFocalPointDepth);
+  // if (m_ARFIMultiTxCount) // examine for duplicates
+  // {
 	// m_ARFIMultiTxCount = focalCountFromDepthsArray(&m_ARFIFocalPointDepth[1], m_ARFIMultiTxCount - 1); // first value is special
-  }
+  // }
 
   return PLUS_SUCCESS;
 }
@@ -856,7 +857,7 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
     m_FocalPointDepth[i] = ::GetFocalPointDepth(i);
   }
 
-  SetARFIMultiFocalZoneCount(m_ARFIMultiTxCount);
+  // SetARFIMultiFocalZoneCount(m_ARFIMultiTxCount);
   for(int i = 0; i < 6; i++)
   {
     SetARFIFocalPointDepth(i, m_ARFIFocalPointDepth[i]);

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1007,7 +1007,6 @@ PlusStatus vtkPlusWinProbeVideoSource::SetVoltage(uint8_t voltage)
   if(Connected)
   {
     ::SetVoltage(voltage);
-    SetPendingRecreateTables(true);
     //what we requested might be only approximately satisfied
     m_Voltage = ::GetVoltage();
   }
@@ -1263,6 +1262,7 @@ PlusStatus vtkPlusWinProbeVideoSource::SetARFITxTxCycleCount(uint16_t propertyVa
   if(Connected)
   {
     ::SetARFITxTxCycleCount(propertyValue);
+    SetPendingRecreateTables(true);
   }
   return PLUS_SUCCESS;
 }
@@ -1284,6 +1284,7 @@ PlusStatus vtkPlusWinProbeVideoSource::SetARFITxTxCycleWidth(uint8_t propertyVal
   if(Connected)
   {
     ::SetARFITxTxCycleWidth(propertyValue);
+    SetPendingRecreateTables(true);
   }
   return PLUS_SUCCESS;
 }
@@ -1304,6 +1305,7 @@ PlusStatus vtkPlusWinProbeVideoSource::SetARFITxCycleCount(uint16_t propertyValu
   if(Connected)
   {
     ::SetARFITxCycleCount(propertyValue);
+    SetPendingRecreateTables(true);
   }
   return PLUS_SUCCESS;
 }
@@ -1324,6 +1326,7 @@ PlusStatus vtkPlusWinProbeVideoSource::SetARFITxCycleWidth(uint8_t propertyValue
   if(Connected)
   {
     ::SetARFITxCycleWidth(propertyValue);
+    SetPendingRecreateTables(true);
   }
   return PLUS_SUCCESS;
 }

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1273,7 +1273,7 @@ uint16_t vtkPlusWinProbeVideoSource::GetARFITxTxCycleCount()
   {
     m_ARFITxTxCycleCount = ::GetARFITxTxCycleCount();
   }
-  return m_ARFITxCycleCount;
+  return m_ARFITxTxCycleCount;
 }
 
 //----------------------------------------------------------------------------
@@ -1303,7 +1303,7 @@ PlusStatus vtkPlusWinProbeVideoSource::SetARFITxCycleCount(uint16_t propertyValu
   m_ARFITxCycleCount = propertyValue;
   if(Connected)
   {
-    ::SetARFITxTxCycleWidth(propertyValue);
+    ::SetARFITxCycleCount(propertyValue);
   }
   return PLUS_SUCCESS;
 }
@@ -1334,7 +1334,7 @@ uint8_t vtkPlusWinProbeVideoSource::GetARFITxCycleWidth()
   {
     m_ARFITxCycleWidth = ::GetARFITxCycleWidth();
   }
-  return m_ARFITxCycleCount;
+  return m_ARFITxCycleWidth;
 }
 
 //----------------------------------------------------------------------------

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -326,9 +326,9 @@ protected:
   int32_t m_BMultiTxCount = 1;
   int32_t m_ARFIMultiTxCount = 1;
   uint16_t m_ARFITxTxCycleCount = 2;
-  uint8_t m_ARFITxTxCycleWidth = 1;
+  uint8_t m_ARFITxTxCycleWidth = 10;
   uint16_t m_ARFITxCycleCount = 4096;
-  uint8_t m_ARFITxCycleWidth = 1;
+  uint8_t m_ARFITxCycleWidth = 15;
   int32_t m_ARFIPushOffset = -12;
   int32_t m_MPRF = 100;
   int32_t m_MLineIndex = 60;


### PR DESCRIPTION
This fixes some issues that were recently exposed with changes made in 70e363c72fa4e98ef35889dff6cdb3a9b35801ab. Been testing with hardware to confirm that TxCycleCount, TxCycleWidth, TxTxCycleCount and TxTxCycleWidth can be set and get correctly.