### PR TITLE
ENH: Fail WinProbe connection if API identifies no transducer connected

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -775,6 +775,11 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
     LOG_ERROR("Failed loading defaults!");
     return PLUS_FAIL;
   }
+  if(this->GetTransducerInternalID() == 15) // 15 corresponds to the "No transducer" entry in the Transducers.xml
+  {
+    LOG_ERROR("Transducer not connected!");
+    return PLUS_FAIL;
+  }
   LOG_DEBUG("Setting transducer ID: " << this->m_TransducerID);
   WPSetTransducerID(this->m_TransducerID.c_str());
 
@@ -1768,11 +1773,13 @@ PlusStatus vtkPlusWinProbeVideoSource::SetTransducerID(std::string guid)
   return PLUS_SUCCESS;
 }
 
+//----------------------------------------------------------------------------
 int vtkPlusWinProbeVideoSource::GetTransducerInternalID()
 {
   int transducer_id = ::GetTransducerInternalID();
   return transducer_id;
 }
+
 //----------------------------------------------------------------------------
 std::vector<double> vtkPlusWinProbeVideoSource::GetPrimarySourceSpacing()
 {


### PR DESCRIPTION
Previously there would be no failure if connecting to the WinProbe engine with no transducer connected. Now when starting to connect it will fail if there is no transducer plugged in.

Tested with WinProbe hardware
```
Attempting to load: C:\Program Files\MyPlus\bin\Transducers.xml
|ERROR|001.935000| Transducer not connected!| in C:\SP\SPR15_x64\PlusLib\src\PlusDataCollection\WinProbe\vtkPlusWinProbeVideoSource.cxx(780)
|ERROR|001.937000| VideoDeviceLinearArray: Cannot connect to device, ConnectInternal failed| in C:\SP\SPR15_x64\PlusLib\src\PlusDataCollection\vtkPlusDevice.cxx(1239)
|ERROR|001.937000| Unable to connect device: VideoDeviceLinearArray.| in C:\SP\SPR15_x64\PlusLib\src\PlusDataCollection\vtkPlusDataCollector.cxx(369)
```

cc: @dzenanz