### PR TITLE
BUG: Fix WinProbe API crash due to setting focal zone count to 0

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -43,6 +43,10 @@ int32_t focalCountFromDepthsArray(float* depths, unsigned arraySize)
       ++i;
     }
   }
+  if (nonZeroes.size() == 0)
+  {
+    nonZeroes.push_back(depths[0]);  // Need to specify at least one focal depth even if all depths are 0 mm
+  }
   int32_t count = nonZeroes.size();
 
   // copy sorted non-zero array back into original array


### PR DESCRIPTION
The following WinProbe API unhandled exception happens when attempting to set focal zone count to 0.  It was being set to 0 when FocalDepth in the config file was being specified to "0 0 0 0".  
```
Unhandled Exception: System.InvalidOperationException: Sequence contains no elements
  at UltraVision.Core.SystemInterface.RecreateTables()
  at UltraVision.Core.SystemInterface._Execute()
  at UltraVision.Core.SystemInterface.Execute()
  at UltraVision.Wrapper.SlimSystem.Execute()
  at mainCRTStartup()
```
This bug was introduced in changes made in 19481203cc5b6b47f71e61c06e026f701a37dd94.  There we made changes so that a string of "0 0 7 0" was set to one focal zone count by ignoring the other "0" values. However when all are "0" we can't set focal zone count to 0. It must be at least one.

I've tested with hardware to confirm this fix works.

cc: @dzenanz 