### PR TITLE
BUG: OpenIGTLinkServer does not close data receiver threads for stopped clients

### DIFF
--- a/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
+++ b/src/PlusServer/vtkPlusOpenIGTLinkServer.cxx
@@ -999,7 +999,6 @@ void* vtkPlusOpenIGTLinkServer::DataReceiverThread(vtkMultiThreader::ThreadInfo*
   } // ConnectionActive
 
   // Close thread
-  client->DataReceiverThreadId = -1;
   client->DataReceiverActive.second = false;
   return NULL;
 }
@@ -1129,7 +1128,7 @@ void vtkPlusOpenIGTLinkServer::DisconnectClient(int clientId)
         {
           continue;
         }
-        if (clientIterator->DataReceiverThreadId > 0)
+        if (this->Threader->IsThreadActive(clientIterator->DataReceiverThreadId))
         {
           if (clientIterator->DataReceiverActive.second)
           {
@@ -1138,8 +1137,8 @@ void vtkPlusOpenIGTLinkServer::DisconnectClient(int clientId)
           }
           else
           {
-            // thread stopped
-            clientIterator->DataReceiverThreadId = -1;
+            // stop thread
+            this->Threader->TerminateThread(clientIterator->DataReceiverThreadId);
           }
           break;
         }


### PR DESCRIPTION
Was running into an issue where stopping and restarting a client many times for a running OpenIGTLinkServer was causing an error with the vtkMultiThreader where the number of opened threads exceeded the defined maximum (https://github.com/Kitware/VTK/blob/e6bd55217240af44749a02f5368cd10ccb0e087a/Common/Core/vtkMultiThreader.cxx#L466). I'm not sure if this is correct, but it seems like the spawned DataReceiverThreads that are created for new connections are not actually cleaned up when the client is disconnected. 

You can recreate the behavior with a simple PlusServer with an MmfVideo device/webcam connected to Slicer via OpenIGTLinkIF and running a script in the interpreter like
```
import time
client_node = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLIGTLConnectorNode")
for i in range(64):
  client_node.Stop()
  time.sleep(1)
  client_node.Start()
  time.sleep(1)
```
or just checking and unchecking the active property 64 times (or whatever `VTK_MAX_THREADS` is set to).

@adamrankin or @Sunderlandkyl do the changes here look appropriate?