### PR TITLE
ENH: Expose IsScanning method for WinProbe device

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -985,6 +985,12 @@ bool vtkPlusWinProbeVideoSource::IsFrozen()
 }
 
 // ----------------------------------------------------------------------------
+bool vtkPlusWinProbeVideoSource::IsScanning()
+{
+  return WPGetIsScanningProperty();
+}
+
+// ----------------------------------------------------------------------------
 PlusStatus vtkPlusWinProbeVideoSource::SetTransmitFrequencyMHz(float frequency)
 {
   m_Frequency = frequency;

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -144,6 +144,9 @@ public:
   /*! Checks whether the device is frozen or live. */
   bool IsFrozen();
 
+  /*! Checks whether the device is scanning or not. It could be in the process of resetting the sequencer. */
+  bool IsScanning();
+
   /*! Sets GUID of the probe type to be used. */
   PlusStatus SetTransducerID(std::string guid);
 


### PR DESCRIPTION
This exposes the IsScanning property for the WinProbe ultrasound device.

Tested this with hardware to confirm that it returns the expected results.

cc: @adamrankin or @Sunderlandkyl for merging