### PR TITLE
ENH: Allow external access for adding custom headers from VirtualCapture

### DIFF
--- a/src/PlusDataCollection/VirtualDevices/vtkPlusVirtualCapture.cxx
+++ b/src/PlusDataCollection/VirtualDevices/vtkPlusVirtualCapture.cxx
@@ -596,6 +596,12 @@ PlusStatus vtkPlusVirtualCapture::TakeSnapshot()
 }
 
 //-----------------------------------------------------------------------------
+PlusStatus vtkPlusVirtualCapture::SetCustomHeaderField(const std::string& fieldName, const std::string& fieldValue)
+{
+  return this->Writer->GetTrackedFrameList()->SetCustomString(fieldName, fieldValue);
+}
+
+//-----------------------------------------------------------------------------
 PlusStatus vtkPlusVirtualCapture::WriteFrames(bool force)
 {
   if (!this->IsHeaderPrepared && this->RecordedFrames->GetNumberOfTrackedFrames() != 0)

--- a/src/PlusDataCollection/VirtualDevices/vtkPlusVirtualCapture.h
+++ b/src/PlusDataCollection/VirtualDevices/vtkPlusVirtualCapture.h
@@ -53,6 +53,8 @@ public:
 
   virtual PlusStatus TakeSnapshot();
 
+  virtual PlusStatus SetCustomHeaderField(const std::string& fieldName, const std::string& fieldValue);
+
   virtual int OutputChannelCount() const;
 
   /*! Enables capturing frames. It can be used for pausing the recording. */


### PR DESCRIPTION
I'd like to add this change so that custom header fields can be set from a virtual capture object at the time the file is being written. I wasn't sure how else to do this without making the associated tracked frame list public, so if there's an easier/better solution please let me know. Thanks!