### PR TITLE
BUG: Define correct Capistrano pulser frequency params for newer SDKs

### DIFF
--- a/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
+++ b/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
@@ -487,6 +487,7 @@ public:
     USProbePulserParamsDB.clear();
     PULSER pulser;
 
+    #if defined(CAPISTRANO_SDK2013)
     // Frequency = 10.0f ----------------------------------------------------
     pulser.MINDelay              = 93;
     pulser.MIDDelay              = 94;
@@ -556,6 +557,77 @@ public:
     pulser.MAXDelay              = 29;
 
     USProbePulserParamsDB[50.0f] = pulser;
+    #else
+    // Frequency = 10.0f ----------------------------------------------------
+    pulser.MINDelay              = 10;
+    pulser.MIDDelay              = 10;
+    pulser.MAXDelay              = 11;
+
+    USProbePulserParamsDB[10.0f] = pulser;
+
+    // Frequency = 12.0f ----------------------------------------------------
+    pulser.MINDelay              = 8;
+    pulser.MIDDelay              = 9;
+    pulser.MAXDelay              = 10;
+
+    USProbePulserParamsDB[12.0f] = pulser;
+
+    // Frequency = 16.0f ----------------------------------------------------
+    pulser.MINDelay              = 6;
+    pulser.MIDDelay              = 7;
+    pulser.MAXDelay              = 8;
+
+    USProbePulserParamsDB[16.0f] = pulser;
+
+    // Frequency = 18.0f ----------------------------------------------------
+    pulser.MINDelay              = 5;
+    pulser.MIDDelay              = 6;
+    pulser.MAXDelay              = 7;
+
+    USProbePulserParamsDB[18.0f] = pulser;
+
+    // Frequency = 20.0f ----------------------------------------------------
+    pulser.MINDelay              = 4;
+    pulser.MIDDelay              = 5;
+    pulser.MAXDelay              = 6;
+
+    USProbePulserParamsDB[20.0f] = pulser;
+
+    // Frequency = 25.0f ----------------------------------------------------
+    pulser.MINDelay              = 3;
+    pulser.MIDDelay              = 4;
+    pulser.MAXDelay              = 5;
+
+    USProbePulserParamsDB[25.0f] = pulser;
+
+    // Frequency = 30.0f ----------------------------------------------------
+    pulser.MINDelay              = 2;
+    pulser.MIDDelay              = 3;
+    pulser.MAXDelay              = 4;
+
+    USProbePulserParamsDB[30.0f] = pulser;
+
+    // Frequency = 35.0f ----------------------------------------------------
+    pulser.MINDelay              = 2;
+    pulser.MIDDelay              = 3;
+    pulser.MAXDelay              = 4;
+
+    USProbePulserParamsDB[35.0f] = pulser;
+
+    // Frequency = 45.0f ----------------------------------------------------
+    pulser.MINDelay              = 1;
+    pulser.MIDDelay              = 2;
+    pulser.MAXDelay              = 3;
+
+    USProbePulserParamsDB[45.0f] = pulser;
+
+    // Frequency = 50.0f ----------------------------------------------------
+    pulser.MINDelay              = 1;
+    pulser.MIDDelay              = 2;
+    pulser.MAXDelay              = 3;
+
+    USProbePulserParamsDB[50.0f] = pulser;
+    #endif
   }
 
   /*! Retrieve US pulser parameters from predefined values */


### PR DESCRIPTION
I confirmed with official Capistrano SDK installers that these new pulser values were included starting with everything after the cSDK2013 installer (ie cSDK2016/2018/2019). The results of using the current delay values with the newer cSDK versions was invalid frequency output.

**First a table of the current delay values with cSDK versions after cSDK2013:**

|10 MHz | 16 MHz | 20 MHz | 35 MHz |
|---------|----------|----------|----------|
|![10MHz-current](https://user-images.githubusercontent.com/15837524/98130592-6d1dff00-1e88-11eb-868a-a2ba45e7b32f.png)|![16MHz-current](https://user-images.githubusercontent.com/15837524/98130601-7018ef80-1e88-11eb-9675-5873bb65cd28.png)|![20MHz-current](https://user-images.githubusercontent.com/15837524/98130615-74450d00-1e88-11eb-9a1c-c7d5ad9bca3f.png)|![35MHz-current](https://user-images.githubusercontent.com/15837524/98130632-773ffd80-1e88-11eb-9976-b255294ef1a8.png)|

**Now a table of results when using the correct delay values:**

|10 MHz | 16 MHz | 20 MHz | 35 MHz |
|---------|----------|----------|----------|
|![10MHz-new](https://user-images.githubusercontent.com/15837524/98130851-b3735e00-1e88-11eb-9c6c-030d952145df.png)|![16MHz-new](https://user-images.githubusercontent.com/15837524/98130869-b79f7b80-1e88-11eb-8cfc-f041db9f12a6.png)|![20MHz-new](https://user-images.githubusercontent.com/15837524/98130884-bb330280-1e88-11eb-9147-9c1d1462b169.png)|![35MHz-new](https://user-images.githubusercontent.com/15837524/98130891-bec68980-1e88-11eb-976e-0207a5735ac7.png)|

Here the imaging depth and brightness changes as expected when going from higher frequency to lower frequency. You can see deeper and the image is brighter for the lower frequency.

cc: @adamrankin or @Sunderlandkyl for approval and merging