### PR TITLE
Allow custom header fields to be maintained after volume reconstruction or seq edits

### DIFF
--- a/src/PlusVolumeReconstruction/vtkPlusVolumeReconstructor.cxx
+++ b/src/PlusVolumeReconstruction/vtkPlusVolumeReconstructor.cxx
@@ -35,6 +35,12 @@ void vtkPlusVolumeReconstructor::PrintSelf(ostream& os, vtkIndent indent)
 //----------------------------------------------------------------------------
 igsioStatus vtkPlusVolumeReconstructor::SaveReconstructedVolumeToFile(const std::string& filename, bool accumulation/*=false*/, bool useCompression/*=true*/)
 {
+  return vtkPlusVolumeReconstructor::SaveReconstructedVolumeToFile(filename, accumulation, useCompression, nullptr, nullptr);
+}
+
+//----------------------------------------------------------------------------
+igsioStatus vtkPlusVolumeReconstructor::SaveReconstructedVolumeToFile(const std::string& filename, bool accumulation/*=false*/, bool useCompression/*=true*/, std::vector<std::string>* customFields/*=nullptr*/, std::vector<std::string>* customValues/*=nullptr*/)
+{
   vtkSmartPointer<vtkImageData> volumeToSave = vtkSmartPointer<vtkImageData>::New();
   if (accumulation)
   {
@@ -52,11 +58,11 @@ igsioStatus vtkPlusVolumeReconstructor::SaveReconstructedVolumeToFile(const std:
       return PLUS_FAIL;
     }
   }
-  return vtkPlusVolumeReconstructor::SaveReconstructedVolumeToFile(volumeToSave, filename, useCompression);
+  return vtkPlusVolumeReconstructor::SaveReconstructedVolumeToFile(volumeToSave, filename, useCompression, customFields, customValues);
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusVolumeReconstructor::SaveReconstructedVolumeToFile(vtkImageData* volumeToSave, const std::string& filename, bool useCompression/*=true*/)
+PlusStatus vtkPlusVolumeReconstructor::SaveReconstructedVolumeToFile(vtkImageData* volumeToSave, const std::string& filename, bool useCompression/*=true*/, std::vector<std::string>* customFields/*=nullptr*/, std::vector<std::string>* customValues/*=nullptr*/)
 {
   if (volumeToSave == NULL)
   {
@@ -77,6 +83,13 @@ PlusStatus vtkPlusVolumeReconstructor::SaveReconstructedVolumeToFile(vtkImageDat
   image.SetImageType(US_IMG_BRIGHTNESS);
   frame.SetImageData(image);
   list->AddTrackedFrame(&frame);
+  if (customFields != nullptr && customValues != nullptr)
+  {
+    for (unsigned i=0; i < customFields->size(); ++i)
+    {
+      list->SetCustomString(customFields->at(i), customValues->at(i));
+    }
+  }
   if (vtkPlusSequenceIO::Write(filename, list.GetPointer(), US_IMG_ORIENT_MF, useCompression) != PLUS_SUCCESS)
   {
     LOG_ERROR("Failed to save reconstructed volume in sequence metafile!");

--- a/src/PlusVolumeReconstruction/vtkPlusVolumeReconstructor.h
+++ b/src/PlusVolumeReconstruction/vtkPlusVolumeReconstructor.h
@@ -54,18 +54,23 @@ public:
     \param filename Path and filename of the output file
     \accumulation True if accumulation buffer needs to be saved, false if gray levels (default)
     \useCompression True if compression is turned on (default), false otherwise
+    \customFields List of custom header fields to insert into the output file
+    \customValues List of custom header values corresponding to customFields to insert into the output file
   */
   virtual PlusStatus SaveReconstructedVolumeToFile(const std::string& filename, bool accumulation = false, bool useCompression = true) override;
-  virtual PlusStatus SaveReconstructedVolumeToMetafile(const std::string& filename, bool accumulation = false, bool useCompression = true) { return SaveReconstructedVolumeToFile(filename, accumulation, useCompression); }
+  virtual PlusStatus SaveReconstructedVolumeToFile(const std::string& filename, bool accumulation = false, bool useCompression = true, std::vector<std::string>* customFields = nullptr, std::vector<std::string>* customValues = nullptr);
+  virtual PlusStatus SaveReconstructedVolumeToMetafile(const std::string& filename, bool accumulation = false, bool useCompression = true, std::vector<std::string>* customFields = nullptr, std::vector<std::string>* customValues = nullptr) { return SaveReconstructedVolumeToFile(filename, accumulation, useCompression, customFields, customValues); }
 
   /*!
     Save reconstructed volume to file
     \param volumeToSave Reconstructed volume to be saved
     \param filename Path and filename of the output file
     \useCompression True if compression is turned on (default), false otherwise
+    \customFields List of custom header fields to insert into the output file
+    \customValues List of custom header values corresponding to customFields to insert into the output file
   */
-  static PlusStatus SaveReconstructedVolumeToFile(vtkImageData* volumeToSave, const std::string& filename, bool useCompression = true);
-  static PlusStatus SaveReconstructedVolumeToMetafile(vtkImageData* volumeToSave, const std::string& filename, bool useCompression = true) { return vtkPlusVolumeReconstructor::SaveReconstructedVolumeToFile(volumeToSave, filename, useCompression); }
+  static PlusStatus SaveReconstructedVolumeToFile(vtkImageData* volumeToSave, const std::string& filename, bool useCompression = true, std::vector<std::string>* customFields = nullptr, std::vector<std::string>* customValues = nullptr);
+  static PlusStatus SaveReconstructedVolumeToMetafile(vtkImageData* volumeToSave, const std::string& filename, bool useCompression = true, std::vector<std::string>* customFields = nullptr, std::vector<std::string>* customValues = nullptr) { return vtkPlusVolumeReconstructor::SaveReconstructedVolumeToFile(volumeToSave, filename, useCompression, customFields, customValues); }
 
 protected:
   vtkPlusVolumeReconstructor();


### PR DESCRIPTION
I'd like for certain custom headers to be maintained after using tools like VolumeReconstructor and EditSequenceFile.

This PR adds args for each tool which take in a list of custom header fields that are read from the input volume and restored to the output volume.

The work here is a continuation of work from https://github.com/PlusToolkit/PlusLib/pull/731#issuecomment-716957361 where the usage is the same: so that custom header information doesn't need to be restored separately after acquisition and using VolumeReconstructor or EditSequenceFile.

Open to any suggestions here too.