### PR TITLE
Binning and spacing changes for Andor Video Source

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -204,6 +204,8 @@ protected:
   /*! Initialize all data sources of the provided port */
   void InitializePort(DataSourceArray& port);
 
+  void AdjustBuffers(int horizontalBins, int verticalBins);
+
   /*! Acquire a single frame using current parameters. Data is put in the frameBuffer ivar. */
   PlusStatus AcquireFrame(float exposure, ShutterMode shutterMode, int binning, int vsSpeed, int hsSpeed);
 

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -127,6 +127,8 @@ public:
   PlusStatus SetTriggerMode(TriggerMode triggerMode);
   TriggerMode GetTriggerMode();
 
+  std::vector<double> GetSpacing(int horizontalBins, int verticalBins);
+
   /*! Normal operating temperature (degrees celsius). */
   PlusStatus SetCoolTemperature(int coolTemp);
   int GetCoolTemperature();
@@ -205,6 +207,7 @@ protected:
   void InitializePort(DataSourceArray& port);
 
   void AdjustBuffers(int horizontalBins, int verticalBins);
+  void AdjustSpacing(int horizontalBins, int verticalBins);
 
   /*! Acquire a single frame using current parameters. Data is put in the frameBuffer ivar. */
   PlusStatus AcquireFrame(float exposure, ShutterMode shutterMode, int binning, int vsSpeed, int hsSpeed);
@@ -283,6 +286,10 @@ protected:
   DataSourceArray BLICorrected;
   DataSourceArray GrayRaw;
   DataSourceArray GrayCorrected;
+
+  double OutputSpacing[3] = { 0 };
+
+  igsioFieldMapType CustomFields;
 };
 
 #endif


### PR DESCRIPTION
Previously, the buffer size used in the Andor camera video source class for acquiring image data was not accounting for changes to binning. This PR addresses that and also adds ElementSpacing as a custom field for output frames.

cc: @dzenanz for review