### PR TITLE
Andor camera startup and close improvements

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -233,6 +233,20 @@ PlusStatus vtkPlusAndorVideoSource::InitializeAndorCamera()
     return PLUS_FAIL;
   }
 
+  char headModel[_MAX_PATH];
+  unsigned headModelResult = checkStatus(GetHeadModel(headModel), "GetHeadModel");
+  if(headModelResult == DRV_SUCCESS)
+  {
+    LOG_INFO("Andor Camera Model: " << headModel);
+  }
+
+  int serialNumber;
+  unsigned cameraSNResult = checkStatus(GetCameraSerialNumber(&serialNumber), "GetCameraSerialNumber");
+  if(cameraSNResult == DRV_SUCCESS)
+  {
+    LOG_INFO("Andor Camera Serial Number: " << serialNumber);
+  }
+
   // Check the safe temperature, and the maximum allowable temperature on the camera.
   // Use the min of the two as the safe temp.
   int MinTemp, MaxTemp;

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -53,6 +53,17 @@ PlusStatus vtkPlusAndorVideoSource::ReadConfiguration(vtkXMLDataElement* rootCon
   LOG_TRACE("vtkPlusAndorVideoSource::ReadConfiguration");
   XML_FIND_DEVICE_ELEMENT_REQUIRED_FOR_READING(deviceConfig, rootConfigElement);
 
+  long totalCameras = 0;
+  // It is possible to call GetAvailableCameras before any of the cameras are initialized.
+  unsigned availableCamerasResult = checkStatus(GetAvailableCameras(&totalCameras), "GetAvailableCameras");
+  if(availableCamerasResult == DRV_SUCCESS)
+  {
+    if(totalCameras == 0)
+    {
+      LOG_ERROR("Unable to find any Andor cameras devices installed.");
+    }
+  }
+
   // Must initialize the system before setting parameters
   unsigned initializeResult = checkStatus(Initialize(""), "Initialize");
   if(initializeResult != DRV_SUCCESS)
@@ -204,6 +215,18 @@ vtkPlusAndorVideoSource::~vtkPlusAndorVideoSource()
 // ----------------------------------------------------------------------------
 PlusStatus vtkPlusAndorVideoSource::InitializeAndorCamera()
 {
+  long totalCameras = 0;
+  // It is possible to call GetAvailableCameras before any of the cameras are initialized.
+  unsigned availableCamerasResult = checkStatus(GetAvailableCameras(&totalCameras), "GetAvailableCameras");
+  if(availableCamerasResult == DRV_SUCCESS)
+  {
+    if(totalCameras == 0)
+    {
+      LOG_ERROR("Unable to find any Andor cameras devices installed.");
+      return PLUS_FAIL;
+    }
+  }
+
   unsigned initializeResult = checkStatus(Initialize(""), "Initialize");
   if(initializeResult != DRV_SUCCESS)
   {

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -341,14 +341,18 @@ PlusStatus vtkPlusAndorVideoSource::InternalDisconnect()
     this->InternalStopRecording();
   }
 
-  int status;
-  checkStatus(::IsCoolerOn(&status), "IsCoolerOn");
+  // // From Andor Employee:
+  // // Only Classic, ICCD and cameras with a fibre attached must have their cooling and warming up controlled at a particular rate.
+  // // For everything else you can just call ShutDown and the camera will safely return to room temperature.
+  // // Classic systems are cameras that use our original PCI controller cards eg CCI-010 or CCI-001.
+  // int status;
+  // checkStatus(::IsCoolerOn(&status), "IsCoolerOn");
 
-  if(status && this->CoolerMode == 0)
-  {
-    LOG_INFO("CoolerMode 0 and Cooler is still ON. Turning off the cooler and waiting for warmup. Do not unplug the camera from power.");
-    WaitForWarmup();
-  }
+  // if(status && this->CoolerMode == 0)
+  // {
+  //   LOG_INFO("CoolerMode 0 and Cooler is still ON. Turning off the cooler and waiting for warmup. Do not unplug the camera from power.");
+  //   WaitForWarmup();
+  // }
 
   checkStatus(FreeInternalMemory(), "FreeInternalMemory");
 

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -54,7 +54,11 @@ PlusStatus vtkPlusAndorVideoSource::ReadConfiguration(vtkXMLDataElement* rootCon
   XML_FIND_DEVICE_ELEMENT_REQUIRED_FOR_READING(deviceConfig, rootConfigElement);
 
   // Must initialize the system before setting parameters
-  checkStatus(Initialize(""), "Initialize");
+  unsigned initializeResult = checkStatus(Initialize(""), "Initialize");
+  if(initializeResult != DRV_SUCCESS)
+  {
+    return PLUS_FAIL;
+  }
 
   const char * shutterString = deviceConfig->GetAttribute("Shutter");
   if(shutterString)
@@ -200,7 +204,11 @@ vtkPlusAndorVideoSource::~vtkPlusAndorVideoSource()
 // ----------------------------------------------------------------------------
 PlusStatus vtkPlusAndorVideoSource::InitializeAndorCamera()
 {
-  checkStatus(Initialize(""), "Initialize");
+  unsigned initializeResult = checkStatus(Initialize(""), "Initialize");
+  if(initializeResult != DRV_SUCCESS)
+  {
+    return PLUS_FAIL;
+  }
 
   // Check the safe temperature, and the maximum allowable temperature on the camera.
   // Use the min of the two as the safe temp.

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -170,7 +170,13 @@ public:
 
   /*! Wait for the camera to reach operating temperature (e.g. -70°C). */
   void WaitForCooldown();
-  /*! Wait for the camera to reach safe temperature for poweroff (e.g. 10°C). */
+
+  /*! Wait for the camera to reach safe temperature for poweroff (e.g. -20°C).
+      From Andor Employee:
+      Only Classic, ICCD and cameras with a fibre attached must have their cooling and warming up controlled at a particular rate.
+      For everything else you can just call ShutDown and the camera will safely return to room temperature.
+      Classic systems are cameras that use our original PCI controller cards eg CCI-010 or CCI-001.
+  */
   void WaitForWarmup();
 
   /*! Check the return status of Andor SDK functions. */


### PR DESCRIPTION
This PR is a series of commits to improve understanding of the Andor camera startup and close connection. `Initialize` is now only called if there are available cameras.  This provides a better understanding of what goes wrong when `Initialize` fails. If fails to initializes it will return early instead of failing to do the various SDK commands. Additional logging of the Camera model and Serial Number on startup also provides better understanding of what was connected.

Previously if the Camera cooler was set to return ambient, it would wait to warm up to the Safe Temperature before calling `ShutDown`. This is unnecessary for most of their most common cameras and appears to be mostly for their older cameras. I have removed this requirement for now. If someone has an old camera and use this class they can implement the necessary change.  I clarified this fact with an Andor employee prior to proceeding with this change. Their response is quoted below and I've included this in the changed files as well.

> Only Classic, ICCD and cameras with a fibre attached must have their cooling and warming up controlled at a particular rate.
> For everything else you can just call ShutDown and the camera will safely return to room temperature.
> Classic systems are cameras that use our original PCI controller cards eg CCI-010 or CCI-001.

All of these changes was tested with an Andor CCD camera.