### PR TITLE
Andor cooling no longer has to be set on startup

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -37,6 +37,7 @@ void vtkPlusAndorVideoSource::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "ReadMode: " << m_ReadMode << std::endl;
   os << indent << "TriggerMode: " << m_TriggerMode << std::endl;
   os << indent << "UseCooling: " << UseCooling << std::endl;
+  os << indent << "CoolerMode: " << CoolerMode << std::endl;
   os << indent << "CoolTemperature: " << CoolTemperature << std::endl;
   os << indent << "SafeTemperature: " << SafeTemperature << std::endl;
   os << indent << "CurrentTemperature: " << CurrentTemperature << std::endl;
@@ -113,6 +114,7 @@ PlusStatus vtkPlusAndorVideoSource::ReadConfiguration(vtkXMLDataElement* rootCon
 
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(float, ExposureTime, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, PreAmpGain, deviceConfig);
+  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, CoolerMode, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, CoolTemperature, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, SafeTemperature, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, VSSpeed, deviceConfig);
@@ -148,6 +150,7 @@ PlusStatus vtkPlusAndorVideoSource::WriteConfiguration(vtkXMLDataElement* rootCo
   deviceConfig->SetIntAttribute("AcquisitionMode", this->m_AcquisitionMode);
   deviceConfig->SetIntAttribute("ReadMode", this->m_ReadMode);
   deviceConfig->SetIntAttribute("TriggerMode", this->m_TriggerMode);
+  deviceConfig->SetIntAttribute("CoolerMode", this->CoolerMode);
   deviceConfig->SetIntAttribute("CoolTemperature", this->CoolTemperature);
   deviceConfig->SetIntAttribute("SafeTemperature", this->SafeTemperature);
   deviceConfig->SetIntAttribute("VSSpeed", this->VSSpeed);
@@ -888,7 +891,7 @@ PlusStatus vtkPlusAndorVideoSource::SetCoolerMode(int mode)
     this->CoolerMode = mode;
     if(mode == 1)
     {
-      LOG_INFO("Cooler mode set to 1. Temperature will be maintained on ShutDown.");
+      LOG_INFO("Cooler mode set to 1. If the cooler is ON, temperature will be maintained on Shutdown, otherwise Camera will return to ambient temperature.");
     }
     else
     {
@@ -898,6 +901,12 @@ PlusStatus vtkPlusAndorVideoSource::SetCoolerMode(int mode)
   }
   LOG_ERROR("SetCoolerMode command failed to execute.");
   return PLUS_FAIL;
+}
+
+// ----------------------------------------------------------------------------
+int vtkPlusAndorVideoSource::GetCoolerMode()
+{
+  return this->CoolerMode;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -169,6 +169,10 @@ public:
   PlusStatus SetCoolerMode(int mode);
   int GetCoolerMode();
 
+  /*! Turn the cooler on/off. */
+  PlusStatus SetCoolerState(bool coolerState);
+  bool IsCoolerOn();
+
   /*! Wait for the camera to reach operating temperature (e.g. -70°C). */
   void WaitForCooldown();
 
@@ -240,13 +244,19 @@ protected:
     return PLUS_SUCCESS;
   }
 
-  /*! Dev flag whether to use the cooler during acquisition.
-      It is better for the camera to undergo fewer temperature changes, so use sparingly.
-   */
-  PlusStatus SetUseCooling(bool useCooling);
-  bool GetUseCooling();
+  /*! Setting to true means cooler turns on at startup.
+      Setting to false means cooler state doesn't change on start.
+      Therefore use false if your previous session was set to maintain temperature on ShutDown.
+  */
+  PlusStatus SetInitializeCoolerState(bool InitializeCoolerState);
+  bool InitializeCoolerState = true;
 
-  int IsCoolerOn();
+  /*! Dev flag whether to require the Camera to be at the Cool Temperature to acquire frames.
+      It can be set to false to acquire frames even though not at the cool temperature.
+  */
+  PlusStatus SetRequireCoolTemp(bool RequireCoolTemp);
+  bool RequireCoolTemp = true;
+
   PlusStatus TurnCoolerON();
   PlusStatus TurnCoolerOFF();
 
@@ -271,7 +281,6 @@ protected:
   TriggerMode m_TriggerMode = TriggerMode::Internal;
 
   /*! Temperatures are in °C (degrees Celsius) */
-  bool UseCooling = true;  // dev param to bypass cooling procedures
   int CoolerMode = 0;  // whether to return to ambient temperature on ShutDown
   int CoolTemperature = -50;
   int SafeTemperature = 5;

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -162,11 +162,12 @@ public:
   PlusStatus AcquireCorrectionFrame(std::string correctionFilePath, ShutterMode shutter, int binning, int vsSpeed, int hsSpeed, float exposureTime);
 
   /*! Cooler Mode control. When CoolerMode is set on, the cooler
-      will be kept online when the camera is shutdown. This is helpful to
-      reduce the cooling cycles the camera undergoes. Turning the Cooler ON
-      and OFF should be done sparingly for the same reason.
+      will be kept on when the camera is shutdown. This is helpful to
+      reduce the number of cooling cycles the camera undergoes. Power loss to the camera
+      will result in the camera returning to ambient temperature.
   */
   PlusStatus SetCoolerMode(int mode);
+  int GetCoolerMode();
 
   /*! Wait for the camera to reach operating temperature (e.g. -70°C). */
   void WaitForCooldown();


### PR DESCRIPTION
This PR includes some changes to the Andor cooling functionality.

The primary change is the addition of `InitializeCoolerState` and `RequireCoolTemp` to replace the single usage of `UseCooling`. The outgoing attribute would turn the cooler on/off on startup and also enforce whether `WaitForCooldown` was required for acquiring images. Now the current cooler state can be maintained on startup instead of turned on/off while a separate attribute controls the requirement to be at the cooled state to acquire images.

Here in PLUS you can do the following situations:
- InitializeCoolerState="false" RequireCoolTemp="false" which won't change the current state of the cooler on startup (a power loss state typically means the cooler starts in an off state) and images can be acquired without being at the cooled state.
- InitializeCoolerState="false" RequireCoolTemp="true" which won't change the current state of the cooler on startup (a power loss state typically means the cooler starts in an off state) and once you call to acquire an image it will turn the cooler on and wait to get to the cool temperature before acquiring.
- InitializeCoolerState="true" RequireCoolTemp="false" which will immediately turn the cooler on at startup, but images can be acquired as it continues cooling since the desired Cool Temp is not being required.
- InitializeCoolerState="true" RequireCoolTemp="true" which will immediately turn the cooler on at startup, and images will be acquired once it is at the cool temperature if it isn't already.

Additionally with the new CoolerMode specification in the config file you can alter cooling behavior on close:
- InitializeCoolerState="false" RequireCoolTemp="true" CoolerMode="0" allows for you to start without changing the current state of the cooler (could be on or off), and then upon acquiring an image the cooler will turn on and wait to get to the cool temperature before acquiring and then on ShutDown the device cooler will turn off and go back to ambient safely.

cc: @adamaji or @dzenanz for review