### PR TITLE
ENH: Add bad pixel correction

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -9,6 +9,8 @@
 
 #include "vtkPlusDataCollectionExport.h"
 #include "vtkPlusDevice.h"
+#include "opencv2/imgproc.hpp"
+#include "opencv2/imgcodecs.hpp"
 
 /*!
  \class vtkPlusAndorVideoSource
@@ -141,6 +143,11 @@ public:
   float GetCurrentTemperature();
 
   /*! Paths to additive and multiplicative bias+dark charge correction images. */
+  PlusStatus SetBadPixelCorrectionImage(const std::string badPixelFilePath);
+  std::string GetBadPixelCorrectionImage()
+  {
+    return badPixelCorrection;
+  }
   PlusStatus SetBiasDarkCorrectionImage(const std::string biasDarkFilePath);
   std::string GetBiasDarkCorrectionImage()
   {
@@ -226,8 +233,11 @@ protected:
   /*! Data from the frameBuffer ivar is added to the provided data source. */
   void AddFrameToDataSource(DataSourceArray& ds);
 
+  /*! Applies correction for bad pixels.  */
+  void CorrectBadPixels(int binning, cv::Mat& cvIMG);
+
   /*! Applies bias correction for dark current, flat correction and lens distortion. */
-  void ApplyFrameCorrections();
+  void ApplyFrameCorrections(int binning);
 
   /*! Flag whether to call ApplyFrameCorrections on the raw acquired frame on acquisition
       or to skip frame corrections.
@@ -295,6 +305,7 @@ protected:
   // {0}{0}{1}
   double cameraIntrinsics[9] = { 0 };
   double distanceCoefficients[4] = { 0 }; // k_1, k_2, p_1, p_2
+  std::string badPixelCorrection; //filepath to bad pixel image
   std::string flatCorrection; // filepath to master flat image
   std::string biasDarkCorrection; // filepath to master bias+dark image
 


### PR DESCRIPTION
CCD cameras usually have "bad pixels" these are either dead pixels, pixels with significantly lower intensities than neighbors, or pixels whose intensity does not scale with exposure time. Resolution cells (for example 4x4 pixels if bin=4) with more than 20% bad pixels are replaced by the median of surrounding cells. 

I have included the DeviceConfig.xml that I used and all of the supporting files here [](url)
[Bad Pixel Correction supporting files.zip](https://github.com/PlusToolkit/PlusLib/files/5692714/Bad.Pixel.Correction.supporting.files.zip)


I randomly made up an bad pixel image for testing and it has bad pixels here:
![image](https://user-images.githubusercontent.com/20046115/102154555-a3677a80-3e47-11eb-8b2c-693fcf23a11e.png)

If the algorithm works the image may look basically the same as without the algorithm because the camera being used may not have many dead pixels so I suggest first changing line 642 of vtkPlusAndorVideoSource to `cvIMG.at<ushort>(resolutionCellIndexY, resolutionCellIndexX) = 0;`. This will write an image where the resolution cells that have bad pixels will be set to zero:
![image](https://user-images.githubusercontent.com/20046115/102154441-67341a00-3e47-11eb-9c4e-0003e6595e09.png)

These images show that the algorithm is correctly identifying the location of the bad pixels from the bad pixel image. It also shows that the algorithm will not correct (in this case make 0) resolution cells where less than 25% of the pixels are bad (bin 4 and bin 8 images).

Reverting the change to make the cells with bad pixels 0 (original state) will produce images that look like ones above but without any black pixels and the regions where there are bad pixels look the same are their surroundings.