### PR TITLE
BUG: remove getter and setter of cosmic correction flag from protected section

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -197,6 +197,10 @@ public:
   vtkPlusAndorVideoSource(const vtkPlusAndorVideoSource&) = delete;
   void operator=(const vtkPlusAndorVideoSource&) = delete;
 
+  /*! Flag whether to call ApplyCosmicRayCorrection of BLI acquisitions or not. */
+  PlusStatus SetUseCosmicRayCorrection(bool UseCosmicRayCorrection);
+  bool GetUseCosmicRayCorrection();
+
 protected:
   /*! Constructor */
   vtkPlusAndorVideoSource();
@@ -250,10 +254,6 @@ protected:
    */
   PlusStatus SetUseFrameCorrections(bool UseFrameCorrections);
   bool GetUseFrameCorrections();
-
-  /*! Flag whether to call ApplyCosmicRayCorrection of BLI acquisitions or not. */
-  PlusStatus SetUseCosmicRayCorrection(bool UseCosmicRayCorrection);
-  bool GetUseCosmicRayCorrection();
 
   /*! This will be triggered regularly if this->StartThreadForInternalUpdates is true.
    * Framerate is controlled by this->AcquisitionRate. This is meant for debugging.


### PR DESCRIPTION
I mistakenly made the methods `GetUseCosmicRayCorrection` and `SetUseCosmicRayCorrection` be protected.