### PR TITLE
Expose setters for undistortion parameters in Andor device

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -670,7 +670,7 @@ void vtkPlusAndorVideoSource::ApplyCosmicRayCorrection(int bin, cv::Mat& floatIm
 }
 
 // ----------------------------------------------------------------------------
-void vtkPlusAndorVideoSource::ApplyFrameCorrections(int binning)
+void vtkPlusAndorVideoSource::ApplyFrameCorrections(int binning, float exposureTime)
 {
   cv::Mat cvIMG(frameSize[0], frameSize[1], CV_16UC1, &rawFrame[0]); // uses rawFrame as buffer
   CorrectBadPixels(binning, cvIMG);
@@ -696,6 +696,9 @@ void vtkPlusAndorVideoSource::ApplyFrameCorrections(int binning)
   // Divide the image by the 32-bit floating point correction image
   cv::divide(result, cvFlatCorrection, result, 1, CV_32FC1);
   LOG_INFO("Applied multiplicative flat correction");
+
+  // Convert image from count to counts/seconds
+  cv::divide(result, exposureTime, result, 1, CV_32FC1);
   result.convertTo(cvIMG, CV_16UC1);
 }
 
@@ -709,7 +712,7 @@ PlusStatus vtkPlusAndorVideoSource::AcquireBLIFrame(int binning, int vsSpeed, in
 
   if(this->UseFrameCorrections)
   {
-    ApplyFrameCorrections(binning);
+    ApplyFrameCorrections(binning, exposureTime);
     AddFrameToDataSource(BLICorrected);
   }
 
@@ -726,7 +729,7 @@ PlusStatus vtkPlusAndorVideoSource::AcquireGrayscaleFrame(int binning, int vsSpe
 
   if(this->UseFrameCorrections)
   {
-    ApplyFrameCorrections(binning);
+    ApplyFrameCorrections(binning, exposureTime);
     AddFrameToDataSource(GrayCorrected);
   }
 

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -778,7 +778,7 @@ PlusStatus vtkPlusAndorVideoSource::SetBiasDarkCorrectionImage(const std::string
 {
   try
   {
-    cvBiasDarkCorrection = cv::imread(biasDarkFilePath, cv::IMREAD_GRAYSCALE);
+    cvBiasDarkCorrection = cv::imread(biasDarkFilePath, cv::IMREAD_UNCHANGED);
     if(cvBiasDarkCorrection.empty())
     {
       throw "Bias+dark correction image empty!";
@@ -797,7 +797,7 @@ PlusStatus vtkPlusAndorVideoSource::SetFlatCorrectionImage(std::string flatFileP
 {
   try
   {
-    cvFlatCorrection = cv::imread(flatFilePath, cv::IMREAD_GRAYSCALE);
+    cvFlatCorrection = cv::imread(flatFilePath, cv::IMREAD_UNCHANGED);
     if(cvFlatCorrection.empty())
     {
       throw "Flat correction image empty!";

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -994,6 +994,36 @@ bool vtkPlusAndorVideoSource::GetUseCosmicRayCorrection()
 }
 
 // ----------------------------------------------------------------------------
+PlusStatus vtkPlusAndorVideoSource::SetCameraIntrinsics(std::array<double, 9> intrinsics)
+{
+  std::copy(std::begin(intrinsics), std::end(intrinsics), this->cameraIntrinsics);
+  return PLUS_SUCCESS;
+}
+
+// ----------------------------------------------------------------------------
+std::array<double, 9> vtkPlusAndorVideoSource::GetCameraIntrinsics()
+{
+  std::array<double, 9> returnIntrinsics;
+  std::copy(this->cameraIntrinsics, this->cameraIntrinsics + 9, std::begin(returnIntrinsics));
+  return returnIntrinsics;
+}
+
+// ----------------------------------------------------------------------------
+PlusStatus vtkPlusAndorVideoSource::SetDistanceCoefficients(std::array<double, 4> coefficients)
+{
+  std::copy(std::begin(coefficients), std::end(coefficients), this->distanceCoefficients);
+  return PLUS_SUCCESS;
+}
+
+// ----------------------------------------------------------------------------
+std::array<double, 4> vtkPlusAndorVideoSource::GetDistanceCoefficients()
+{
+  std::array<double, 4> returnCoefficients;
+  std::copy(this->distanceCoefficients, this->distanceCoefficients + 4, std::begin(returnCoefficients));
+  return returnCoefficients;
+}
+
+// ----------------------------------------------------------------------------
 PlusStatus vtkPlusAndorVideoSource::SetRequireCoolTemp(bool requireCoolTemp)
 {
   this->RequireCoolTemp = requireCoolTemp;

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -253,7 +253,7 @@ protected:
   void ApplyCosmicRayCorrection(int binning, cv::Mat& floatImage);
 
   /*! Applies bias correction for dark current, flat correction and lens distortion. */
-  void ApplyFrameCorrections(int binning);
+  void ApplyFrameCorrections(int binning, float exposureTime);
 
   /*! Flag whether to call ApplyFrameCorrections on the raw acquired frame on acquisition
       or to skip frame corrections.

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -159,6 +159,12 @@ public:
     return flatCorrection;
   }
 
+  /*! Data for setting undistortion coefficients. */
+  PlusStatus SetCameraIntrinsics(std::array<double, 9> intrinsics);
+  std::array<double, 9> GetCameraIntrinsics();
+  PlusStatus SetDistanceCoefficients(std::array<double, 4> coefficients);
+  std::array<double, 4> GetDistanceCoefficients();
+
   /*! -1 uses currently active settings. */
   PlusStatus AcquireBLIFrame(int binning, int vsSpeed, int hsSpeed, float exposureTime);
 


### PR DESCRIPTION
This PR exposes setters/getters for camera intrinsics and distance coefficients for the Andor device, since these parameters must be changed for different binning settings.

Other small changes are converting the units for processed Andor images into counts/seconds and fixing a bug where correction images are loaded as the wrong type.

cc @jrojasUNC @dzenanz for review