### PR TITLE
Allow Andor device to process acquisition on separate thread

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -368,8 +368,7 @@ PlusStatus vtkPlusAndorVideoSource::InternalDisconnect()
   // }
 
   // in case we quit before an acquisition is complete, close the acquisition thread
-  checkStatus(::CancelWait(), "CancelWait");
-  checkStatus(::AbortAcquisition(), "AbortAcquisition");
+  AbortAcquisition();
 
   checkStatus(FreeInternalMemory(), "FreeInternalMemory");
 
@@ -832,6 +831,19 @@ void* vtkPlusAndorVideoSource::AcquireCorrectionFrameThread(vtkMultiThreader::Th
   cv::imwrite(device->saveCorrectionPath, cvIMG);
   device->threadID = -1;
   return NULL;
+}
+
+//-----------------------------------------------------------------------------
+PlusStatus vtkPlusAndorVideoSource::AbortAcquisition()
+{
+  checkStatus(::CancelWait(), "CancelWait");
+  unsigned result = checkStatus(::AbortAcquisition(), "AbortAcquisition");
+  if ((result != DRV_SUCCESS) && (result != DRV_IDLE))
+  {
+    LOG_ERROR("Unable to abort acquisition.");
+    return PLUS_FAIL;
+  }
+  return PLUS_SUCCESS;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -1247,6 +1247,22 @@ int vtkPlusAndorVideoSource::GetSafeTemperature()
 }
 
 // ----------------------------------------------------------------------------
+unsigned int vtkPlusAndorVideoSource::GetCCDStatus()
+{
+	int status;
+	GetStatus(&status);
+
+	return status;
+}
+
+// ----------------------------------------------------------------------------
+bool vtkPlusAndorVideoSource::IsCCDAcquiring()
+{
+	int status = GetCCDStatus();
+	return status == DRV_ACQUIRING;
+}
+
+// ----------------------------------------------------------------------------
 unsigned int vtkPlusAndorVideoSource::checkStatus(unsigned int returnStatus, std::string functionName)
 {
   if(returnStatus == DRV_SUCCESS)

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -163,8 +163,8 @@ public:
   /*! Data for setting undistortion coefficients. */
   PlusStatus SetCameraIntrinsics(std::array<double, 9> intrinsics);
   std::array<double, 9> GetCameraIntrinsics();
-  PlusStatus SetDistanceCoefficients(std::array<double, 4> coefficients);
-  std::array<double, 4> GetDistanceCoefficients();
+  PlusStatus SetDistortionCoefficients(std::array<double, 4> coefficients);
+  std::array<double, 4> GetDistortionCoefficients();
 
   /*! -1 uses currently active settings. */
   PlusStatus StartBLIFrameAcquisition(int binning, int vsSpeed, int hsSpeed, float exposureTime);
@@ -344,7 +344,7 @@ protected:
   // {0}{f_y}{c_y}
   // {0}{0}{1}
   double cameraIntrinsics[9] = { 0 };
-  double distanceCoefficients[4] = { 0 }; // k_1, k_2, p_1, p_2
+  double distortionCoefficients[4] = { 0 }; // k_1, k_2, p_1, p_2
   std::string badPixelCorrection; //filepath to bad pixel image
   std::string flatCorrection; // filepath to master flat image
   std::string biasDarkCorrection; // filepath to master bias+dark image

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -175,6 +175,9 @@ public:
   /*! Convenience function to save a bias frame for a certain binning/speed configuration. */
   PlusStatus StartCorrectionFrameAcquisition(std::string correctionFilePath, ShutterMode shutter, int binning, int vsSpeed, int hsSpeed, float exposureTime);
 
+  /*! Abort the running acquisition process and thread. */
+  PlusStatus AbortAcquisition();
+
   /*! Cooler Mode control. When CoolerMode is set on, the cooler
       will be kept on when the camera is shutdown. This is helpful to
       reduce the number of cooling cycles the camera undergoes. Power loss to the camera

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -211,6 +211,12 @@ public:
   PlusStatus SetUseCosmicRayCorrection(bool UseCosmicRayCorrection);
   bool GetUseCosmicRayCorrection();
 
+  /*! Check the status of the SDK. */
+  unsigned int GetCCDStatus();
+
+  /*! Check if the Andor CCD is acquiring. */
+  bool IsCCDAcquiring();
+
 protected:
   /*! Constructor */
   vtkPlusAndorVideoSource();


### PR DESCRIPTION
This PR puts the acquisition for the Andor device on a separate thread so that the process can be aborted properly through the `AbortAcquisition` SDK call.

cc @dzenanz @jrojasUNC for review