### PR TITLE
Andor index value updates

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -33,7 +33,7 @@ void vtkPlusAndorVideoSource::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "ExposureTime: " << ExposureTime << std::endl;
   os << indent << "Binning: " << HorizontalBins << " " << VerticalBins << std::endl;
   os << indent << "HSSpeed: " << HSSpeed[0] << HSSpeed[1] << std::endl;
-  os << indent << "VSSpeed: " << VSSpeed << std::endl;
+  os << indent << "VSSpeedIndex: " << VSSpeedIndex << std::endl;
   os << indent << "OutputSpacing: " << OutputSpacing[0] << " " << OutputSpacing[1] << std::endl;
   os << indent << "PreAmpGainIndex: " << PreAmpGainIndex << std::endl;
   os << indent << "AcquisitionMode: " << m_AcquisitionMode << std::endl;
@@ -122,7 +122,7 @@ PlusStatus vtkPlusAndorVideoSource::ReadConfiguration(vtkXMLDataElement* rootCon
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, CoolerMode, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, CoolTemperature, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, SafeTemperature, deviceConfig);
-  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, VSSpeed, deviceConfig);
+  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, VSSpeedIndex, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, HorizontalBins, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, VerticalBins, deviceConfig);
 
@@ -162,7 +162,7 @@ PlusStatus vtkPlusAndorVideoSource::WriteConfiguration(vtkXMLDataElement* rootCo
   deviceConfig->SetIntAttribute("CoolerMode", this->CoolerMode);
   deviceConfig->SetIntAttribute("CoolTemperature", this->CoolTemperature);
   deviceConfig->SetIntAttribute("SafeTemperature", this->SafeTemperature);
-  deviceConfig->SetIntAttribute("VSSpeed", this->VSSpeed);
+  deviceConfig->SetIntAttribute("VSSpeedIndex", this->VSSpeedIndex);
   deviceConfig->SetIntAttribute("HorizontalBins", this->HorizontalBins);
   deviceConfig->SetIntAttribute("VerticalBins", this->VerticalBins);
 
@@ -700,7 +700,7 @@ void vtkPlusAndorVideoSource::ApplyFrameCorrections(int binning, float exposureT
 }
 
 // ----------------------------------------------------------------------------
-PlusStatus vtkPlusAndorVideoSource::StartBLIFrameAcquisition(int binning, int vsSpeed, int hsSpeed, float exposureTime)
+PlusStatus vtkPlusAndorVideoSource::StartBLIFrameAcquisition(int binning, int vsSpeedIndex, int hsSpeed, float exposureTime)
 {
   if (this->threadID > -1)
   {
@@ -710,7 +710,7 @@ PlusStatus vtkPlusAndorVideoSource::StartBLIFrameAcquisition(int binning, int vs
 
   this->effectiveHBins = binning > 0 ? binning : this->HorizontalBins;
   this->effectiveVBins = binning > 0 ? binning : this->VerticalBins;
-  this->effectiveVSInd = vsSpeed > -1 ? vsSpeed : this->VSSpeed;
+  this->effectiveVSInd = vsSpeedIndex > -1 ? vsSpeedIndex : this->VSSpeedIndex;
   this->effectiveHSInd = hsSpeed > -1 ? hsSpeed : this->HSSpeed[1];
   this->effectiveExpTime = exposureTime > -1 ? exposureTime : this->ExposureTime;
   this->effectiveShutter = ShutterMode::FullyAuto;
@@ -744,7 +744,7 @@ void* vtkPlusAndorVideoSource::AcquireBLIFrameThread(vtkMultiThreader::ThreadInf
 }
 
 // ----------------------------------------------------------------------------
-PlusStatus vtkPlusAndorVideoSource::StartGrayscaleFrameAcquisition(int binning, int vsSpeed, int hsSpeed, float exposureTime)
+PlusStatus vtkPlusAndorVideoSource::StartGrayscaleFrameAcquisition(int binning, int vsSpeedIndex, int hsSpeed, float exposureTime)
 {
   if (this->threadID > -1)
   {
@@ -754,7 +754,7 @@ PlusStatus vtkPlusAndorVideoSource::StartGrayscaleFrameAcquisition(int binning, 
 
   this->effectiveHBins = binning > 0 ? binning : this->HorizontalBins;
   this->effectiveVBins = binning > 0 ? binning : this->VerticalBins;
-  this->effectiveVSInd = vsSpeed > -1 ? vsSpeed : this->VSSpeed;
+  this->effectiveVSInd = vsSpeedIndex > -1 ? vsSpeedIndex : this->VSSpeedIndex;
   this->effectiveHSInd = hsSpeed > -1 ? hsSpeed : this->HSSpeed[1];
   this->effectiveExpTime = exposureTime > -1 ? exposureTime : this->ExposureTime;
   this->effectiveShutter = ShutterMode::FullyAuto;
@@ -789,7 +789,7 @@ void* vtkPlusAndorVideoSource::AcquireGrayscaleFrameThread(vtkMultiThreader::Thr
 }
 
 // ----------------------------------------------------------------------------
-PlusStatus vtkPlusAndorVideoSource::StartCorrectionFrameAcquisition(const std::string correctionFilePath, ShutterMode shutter, int binning, int vsSpeed, int hsSpeed, float exposureTime)
+PlusStatus vtkPlusAndorVideoSource::StartCorrectionFrameAcquisition(const std::string correctionFilePath, ShutterMode shutter, int binning, int vsSpeedIndex, int hsSpeed, float exposureTime)
 {
   if (this->threadID > -1)
   {
@@ -799,7 +799,7 @@ PlusStatus vtkPlusAndorVideoSource::StartCorrectionFrameAcquisition(const std::s
 
   this->effectiveHBins = binning > 0 ? binning : this->HorizontalBins;
   this->effectiveVBins = binning > 0 ? binning : this->VerticalBins;
-  this->effectiveVSInd = vsSpeed > -1 ? vsSpeed : this->VSSpeed;
+  this->effectiveVSInd = vsSpeedIndex > -1 ? vsSpeedIndex : this->VSSpeedIndex;
   this->effectiveHSInd = hsSpeed > -1 ? hsSpeed : this->HSSpeed[1];
   this->effectiveExpTime = exposureTime > -1 ? exposureTime : this->ExposureTime;
   this->effectiveShutter = shutter;
@@ -987,7 +987,7 @@ PlusStatus vtkPlusAndorVideoSource::SetHSSpeed(int type, int index)
 }
 
 // ----------------------------------------------------------------------------
-PlusStatus vtkPlusAndorVideoSource::SetVSSpeed(int index)
+PlusStatus vtkPlusAndorVideoSource::SetVSSpeedIndex(int index)
 {
   unsigned status = checkStatus(::SetVSSpeed(index), "SetVSSpeed");
   if(status != DRV_SUCCESS)
@@ -995,7 +995,7 @@ PlusStatus vtkPlusAndorVideoSource::SetVSSpeed(int index)
     LOG_ERROR("SetVSSpeed command failed.");
     return PLUS_FAIL;
   }
-  this->VSSpeed = index;
+  this->VSSpeedIndex = index;
   return PLUS_SUCCESS;
 }
 

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -1006,11 +1006,8 @@ PlusStatus vtkPlusAndorVideoSource::SetPreAmpGain(int preAmpGain)
   unsigned status = checkStatus(::SetPreAmpGain(this->PreAmpGain), "SetPreAmpGain");
   if(status == DRV_P1INVALID)
   {
-    LOG_ERROR("Minimum threshold outside valid range (1-65535).");
-  }
-  else if(status == DRV_P2INVALID)
-  {
-    LOG_ERROR("Maximum threshold outside valid range.");
+    LOG_ERROR("Index out of range.");
+    return PLUS_FAIL;
   }
   return PLUS_SUCCESS;
 }

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -1012,6 +1012,12 @@ PlusStatus vtkPlusAndorVideoSource::SetVSSpeedIndex(int index)
 }
 
 // ----------------------------------------------------------------------------
+int vtkPlusAndorVideoSource::GetVSSpeedIndex()
+{
+  return this->VSSpeedIndex;
+}
+
+// ----------------------------------------------------------------------------
 float vtkPlusAndorVideoSource::GetVSSpeed()
 {
   float speed;

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -1019,6 +1019,18 @@ int vtkPlusAndorVideoSource::GetPreAmpGainIndex()
 }
 
 // ----------------------------------------------------------------------------
+float vtkPlusAndorVideoSource::GetPreAmpGain()
+{
+  float gain;
+  unsigned status = checkStatus(::GetPreAmpGain(this->PreAmpGainIndex, &gain), "GetPreAmpGain");
+  if(status != DRV_SUCCESS)
+  {
+    LOG_ERROR("GetPreAmpGain command failed.");
+  }
+  return gain;
+}
+
+// ----------------------------------------------------------------------------
 PlusStatus vtkPlusAndorVideoSource::SetAcquisitionMode(AcquisitionMode acquisitionMode)
 {
   this->m_AcquisitionMode = acquisitionMode;

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -1000,6 +1000,18 @@ PlusStatus vtkPlusAndorVideoSource::SetVSSpeedIndex(int index)
 }
 
 // ----------------------------------------------------------------------------
+float vtkPlusAndorVideoSource::GetVSSpeed()
+{
+  float speed;
+  unsigned status = checkStatus(::GetVSSpeed(this->VSSpeedIndex, &speed), "GetVSSpeed");
+  if(status != DRV_SUCCESS)
+  {
+    LOG_ERROR("GetVSSpeed command failed.");
+  }
+  return speed;
+}
+
+// ----------------------------------------------------------------------------
 PlusStatus vtkPlusAndorVideoSource::SetPreAmpGainIndex(int PreAmpGainIndex)
 {
   this->PreAmpGainIndex = PreAmpGainIndex;

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -35,7 +35,7 @@ void vtkPlusAndorVideoSource::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "HSSpeed: " << HSSpeed[0] << HSSpeed[1] << std::endl;
   os << indent << "VSSpeed: " << VSSpeed << std::endl;
   os << indent << "OutputSpacing: " << OutputSpacing[0] << " " << OutputSpacing[1] << std::endl;
-  os << indent << "PreAmpGain: " << PreAmpGain << std::endl;
+  os << indent << "PreAmpGainIndex: " << PreAmpGainIndex << std::endl;
   os << indent << "AcquisitionMode: " << m_AcquisitionMode << std::endl;
   os << indent << "ReadMode: " << m_ReadMode << std::endl;
   os << indent << "TriggerMode: " << m_TriggerMode << std::endl;
@@ -118,7 +118,7 @@ PlusStatus vtkPlusAndorVideoSource::ReadConfiguration(vtkXMLDataElement* rootCon
   }
 
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(float, ExposureTime, deviceConfig);
-  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, PreAmpGain, deviceConfig);
+  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, PreAmpGainIndex, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, CoolerMode, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, CoolTemperature, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, SafeTemperature, deviceConfig);
@@ -155,7 +155,7 @@ PlusStatus vtkPlusAndorVideoSource::WriteConfiguration(vtkXMLDataElement* rootCo
 
   deviceConfig->SetIntAttribute("Shutter", this->Shutter);
   deviceConfig->SetFloatAttribute("ExposureTime", this->ExposureTime);
-  deviceConfig->SetIntAttribute("PreAmpGain", this->PreAmpGain);
+  deviceConfig->SetIntAttribute("PreAmpGainIndex", this->PreAmpGainIndex);
   deviceConfig->SetIntAttribute("AcquisitionMode", this->m_AcquisitionMode);
   deviceConfig->SetIntAttribute("ReadMode", this->m_ReadMode);
   deviceConfig->SetIntAttribute("TriggerMode", this->m_TriggerMode);
@@ -1000,10 +1000,10 @@ PlusStatus vtkPlusAndorVideoSource::SetVSSpeed(int index)
 }
 
 // ----------------------------------------------------------------------------
-PlusStatus vtkPlusAndorVideoSource::SetPreAmpGain(int preAmpGain)
+PlusStatus vtkPlusAndorVideoSource::SetPreAmpGainIndex(int PreAmpGainIndex)
 {
-  this->PreAmpGain = preAmpGain;
-  unsigned status = checkStatus(::SetPreAmpGain(this->PreAmpGain), "SetPreAmpGain");
+  this->PreAmpGainIndex = PreAmpGainIndex;
+  unsigned status = checkStatus(::SetPreAmpGain(this->PreAmpGainIndex), "SetPreAmpGain");
   if(status == DRV_P1INVALID)
   {
     LOG_ERROR("Index out of range.");
@@ -1013,9 +1013,9 @@ PlusStatus vtkPlusAndorVideoSource::SetPreAmpGain(int preAmpGain)
 }
 
 // ----------------------------------------------------------------------------
-int vtkPlusAndorVideoSource::GetPreAmpGain()
+int vtkPlusAndorVideoSource::GetPreAmpGainIndex()
 {
-  return this->PreAmpGain;
+  return this->PreAmpGainIndex;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -987,6 +987,18 @@ PlusStatus vtkPlusAndorVideoSource::SetHSSpeed(int type, int index)
 }
 
 // ----------------------------------------------------------------------------
+float vtkPlusAndorVideoSource::GetHSSpeed()
+{
+  float speed;
+  unsigned status = checkStatus(::GetHSSpeed(0, HSSpeed[0], HSSpeed[1], &speed), "GetHSSpeed");
+  if(status != DRV_SUCCESS)
+  {
+    LOG_ERROR("GetHSSpeed command failed.");
+  }
+  return speed;
+}
+
+// ----------------------------------------------------------------------------
 PlusStatus vtkPlusAndorVideoSource::SetVSSpeedIndex(int index)
 {
   unsigned status = checkStatus(::SetVSSpeed(index), "SetVSSpeed");

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -78,6 +78,7 @@ public:
 
   /*! Set index to use in the vertical shift speed table. */
   PlusStatus SetVSSpeedIndex(int index);
+  int GetVSSpeedIndex();
 
   /*! Get the actual VS Speed in microseconds per pixel shift for the current VSSpeed index. */
   float GetVSSpeed();

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -78,6 +78,9 @@ public:
   PlusStatus SetPreAmpGainIndex(int preAmpGainIndex);
   int GetPreAmpGainIndex();
 
+  /*! Get the actual gain factor for the current pre amp gain index. */
+  float GetPreAmpGain();
+
   /*! Acquisition mode. Valid values:
    * 1 Single Scan
    * 2 Accumulate

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -73,6 +73,9 @@ public:
   /*! Set horizontal shift speed. */
   PlusStatus SetHSSpeed(int type, int index);
 
+  /*! Get the actual HS Speed in MHz for the current HSSpeed index. */
+  float GetHSSpeed();
+
   /*! Set index to use in the vertical shift speed table. */
   PlusStatus SetVSSpeedIndex(int index);
 

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -75,8 +75,8 @@ public:
   PlusStatus SetVSSpeed(int index);
 
   /*! Index of the pre-amp gain, not the actual value. */
-  PlusStatus SetPreAmpGain(int preAmptGain);
-  int GetPreAmpGain();
+  PlusStatus SetPreAmpGainIndex(int preAmpGainIndex);
+  int GetPreAmpGainIndex();
 
   /*! Acquisition mode. Valid values:
    * 1 Single Scan
@@ -307,7 +307,7 @@ protected:
   int VerticalBins = 1;
   int HSSpeed[2] = { 0, 1 };  // type, index
   int VSSpeed = 0;  // index
-  int PreAmpGain = 0;
+  int PreAmpGainIndex = 0;
   bool UseFrameCorrections = true;
   bool UseCosmicRayCorrection = true;
 

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -76,6 +76,9 @@ public:
   /*! Set index to use in the vertical shift speed table. */
   PlusStatus SetVSSpeedIndex(int index);
 
+  /*! Get the actual VS Speed in microseconds per pixel shift for the current VSSpeed index. */
+  float GetVSSpeed();
+
   /*! Index of the pre-amp gain, not the actual value. */
   PlusStatus SetPreAmpGainIndex(int preAmpGainIndex);
   int GetPreAmpGainIndex();

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -70,9 +70,11 @@ public:
   PlusStatus SetHorizontalBins(int bins);
   PlusStatus SetVerticalBins(int bins);
 
-  /*! Horizontal and vertical shift speed. */
+  /*! Set horizontal shift speed. */
   PlusStatus SetHSSpeed(int type, int index);
-  PlusStatus SetVSSpeed(int index);
+
+  /*! Set index to use in the vertical shift speed table. */
+  PlusStatus SetVSSpeedIndex(int index);
 
   /*! Index of the pre-amp gain, not the actual value. */
   PlusStatus SetPreAmpGainIndex(int preAmpGainIndex);
@@ -309,7 +311,7 @@ protected:
   int HorizontalBins = 1;
   int VerticalBins = 1;
   int HSSpeed[2] = { 0, 1 };  // type, index
-  int VSSpeed = 0;  // index
+  int VSSpeedIndex = 0;
   int PreAmpGainIndex = 0;
   bool UseFrameCorrections = true;
   bool UseCosmicRayCorrection = true;


### PR DESCRIPTION
This exposes a few more methods from the Andor SDK to get the actual HSSpeed and VSSpeed values.  There has been some getters in this Andor PlusLib class, but they were returning the index values. Andor's SDK uses index values to "Set" the value, but then the corresponding Andor SDK Getter returns the actual value.  These changes should make it clearer about if the index or the actual value is being used.

To Maintainers: It would be great if you can "Rebase and Merge" this PR to include the multiple commits here. This will help me manage corresponding updates in a private repo.

cc: @adamaji, @dzenanz 