### PR TITLE
ENH: Allow Andor device to set frame fields with acquisition parameters

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -435,6 +435,13 @@ void vtkPlusAndorVideoSource::AdjustSpacing(int horizontalBins, int verticalBins
 }
 
 // ----------------------------------------------------------------------------
+PlusStatus vtkPlusAndorVideoSource::SetFrameFieldImageToReferenceTransform(std::array<float, 16> transform)
+{
+  this->imageToReferenceTransform = transform;
+  return PLUS_SUCCESS;
+}
+
+// ----------------------------------------------------------------------------
 std::vector<double> vtkPlusAndorVideoSource::GetSpacing(int horizontalBins, int verticalBins)
 {
   std::vector<double> spacing = { 0.0, 0.0, 1.0 };

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -248,6 +248,9 @@ protected:
   void AdjustBuffers(int horizontalBins, int verticalBins);
   void AdjustSpacing(int horizontalBins, int verticalBins);
 
+  /*! Set some acquisition parameters as per-frame header fields */
+  void SetCustomFrameFields();
+
   /*! Acquire a single frame using current parameters. Data is put in the frameBuffer ivar. */
   PlusStatus AcquireFrame();
 

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -130,6 +130,7 @@ public:
   PlusStatus SetTriggerMode(TriggerMode triggerMode);
   TriggerMode GetTriggerMode();
 
+  PlusStatus SetFrameFieldImageToReferenceTransform(std::array<float, 16> transform);
   std::vector<double> GetSpacing(int horizontalBins, int verticalBins);
 
   /*! Normal operating temperature (degrees celsius). */
@@ -356,6 +357,10 @@ protected:
   DataSourceArray GrayCorrected;
 
   double OutputSpacing[3] = { 0 };
+
+  /*! Frame field for image transform. Since applications of this device are 
+      mainly stationary, don't use a tracker and just set the transform manually. */
+  std::array<float, 16> imageToReferenceTransform = { 0 };
 
   igsioFieldMapType CustomFields;
 


### PR DESCRIPTION
This PR makes the Andor device set some frame fields with acquisition parameters (exposure time, binning) on each frame acquisition. Also exposes an `ImageToReference` transform setter so that a tracker doesn't have to be used for setting the frame field transform.