### PR TITLE
BUG: do not call initialization logic during parameter update

### DIFF
--- a/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
+++ b/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
@@ -2064,5 +2064,5 @@ PlusStatus vtkPlusCapistranoVideoSource::InternalApplyImagingParameterChange()
     }
   }
 
-  return this->InitializeCapistranoVideoSource(true);
+  return PLUS_SUCCESS;
 }


### PR DESCRIPTION
The last bug which prevented successful use of PlusRemoteControl with Capistrano probe.