### PR TITLE
BUG: Andor processed frames not normalized from 32 to 16 bit correctly

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -9,6 +9,7 @@ See License.txt for details.
 #include "vtkPlusAndorVideoSource.h"
 #include "ATMCD32D.h"
 #include "igtlOSUtil.h" // for Sleep
+#include "opencv2/core/base.hpp"
 #include "opencv2/imgproc.hpp"
 #include "opencv2/imgcodecs.hpp"
 
@@ -751,7 +752,7 @@ void vtkPlusAndorVideoSource::ApplyFrameCorrections(int binning)
     LOG_INFO("Applied multiplicative flat correction");
   }
 
-  result.convertTo(cvIMG, CV_16UC1);
+  cv::normalize(result, cvIMG, 0, 65535, cv::NORM_MINMAX, CV_16UC1);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Processed Andor frames were not being appropriately scaled to [0, 2^16) when converting from CV_32FC1 to CV_16UC1.

cc @jrojasUNC @dzenanz for review