### PR TITLE
Set single flat image but resize for different binnings for Andor acquisitions

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -9,7 +9,6 @@ See License.txt for details.
 #include "vtkPlusAndorVideoSource.h"
 #include "ATMCD32D.h"
 #include "igtlOSUtil.h" // for Sleep
-#include "opencv2/core/base.hpp"
 #include "opencv2/imgproc.hpp"
 #include "opencv2/imgcodecs.hpp"
 
@@ -752,7 +751,7 @@ void vtkPlusAndorVideoSource::ApplyFrameCorrections(int binning)
     LOG_INFO("Applied multiplicative flat correction");
   }
 
-  cv::normalize(result, cvIMG, 0, 65535, cv::NORM_MINMAX, CV_16UC1);
+  result.convertTo(cvIMG, CV_16UC1);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -684,11 +684,7 @@ void vtkPlusAndorVideoSource::ApplyCosmicRayCorrection(int bin, cv::Mat& floatIm
     kernelSize = 5;
   }
 
-  // find and subtract background
-  cv::Mat meanCols, medianImage, diffImage, medianPixels;
-  cv::reduce(floatImage, meanCols, 0, cv::REDUCE_AVG, CV_32FC1);
-  ushort background = (ushort)meanCols.at<float>(0, 0);
-  cv::subtract(floatImage, background, floatImage);
+  cv::Mat medianImage, diffImage, medianPixels;
 
   // idenfify cosmice ray indices
   cv::medianBlur(floatImage, medianImage, kernelSize);

--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.h
@@ -309,6 +309,9 @@ protected:
   PlusStatus SetUseFrameCorrections(bool UseFrameCorrections);
   bool GetUseFrameCorrections();
 
+  /*! Resizes flat correction image depeding on the binning */
+  void ResizeFlatCorrectionImage(int binning);
+
   /*! This will be triggered regularly if this->StartThreadForInternalUpdates is true.
    * Framerate is controlled by this->AcquisitionRate. This is meant for debugging.
    */
@@ -390,7 +393,7 @@ protected:
 
   double OutputSpacing[3] = { 0 };
 
-  /*! Frame field for image transform. Since applications of this device are 
+  /*! Frame field for image transform. Since applications of this device are
       mainly stationary, don't use a tracker and just set the transform manually. */
   std::array<float, 16> imageToReferenceTransform = { 0 };
 


### PR DESCRIPTION
This changes the code so that instead of setting a different flat image for the different binnings, a single flat image is set and resized to match the size of the binned image. The resized image is saved in a container so the resizing doesn't have to happen every time an image is acquired.

the intensity at the corners of the corrected image is increased due to the correction image used:
![image](https://user-images.githubusercontent.com/20046115/108093983-52911f80-704c-11eb-943a-6d66350eb88b.png)


@adamaji @dzenanz 