### PR TITLE
BUG: Andor drops frames after filtered timestamp stops being valid

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -580,7 +580,7 @@ void vtkPlusAndorVideoSource::AddFrameToDataSource(DataSourceArray& ds)
                       1, US_IMG_BRIGHTNESS, 0,
                       this->FrameNumber,
                       currentTime,
-                      UNDEFINED_TIMESTAMP,
+                      currentTime,  // just use the unfiltered timestamp so we don't drop frames
                       &this->CustomFields
                      ) != PLUS_SUCCESS)
     {


### PR DESCRIPTION
This PR fixes an issue with the Andor device where after a set number of captures (around 20 for one data source), no new frames would be added to the data source. This is because the computed filtered timestamp was found as not "`filteredTimestampProbablyValid`". The major change here is to just send the clock as our timestamp. This device generally acquires single frames a few seconds apart, so this should be fine.

A question for maintainers though, what's the motivation for returning `PLUS_SUCCESS` when the created filtered timestamp is found to be probably invalid, and thus the frame isn't added to the data source?
https://github.com/PlusToolkit/PlusLib/blob/master/src/PlusDataCollection/vtkPlusBuffer.cxx#L341-L345