### PR TITLE
Do not initialize Capistrano in constructor

### DIFF
--- a/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
+++ b/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
@@ -696,6 +696,14 @@ void vtkPlusCapistranoVideoSource::PrintSelf(ostream& os, vtkIndent indent)
 PlusStatus vtkPlusCapistranoVideoSource::ReadConfiguration(vtkXMLDataElement* rootConfigElement)
 {
   LOG_TRACE("vtkPlusCapistranoVideoSource::ReadConfiguration");
+  if (!this->Initialized)
+  {
+    if (InitializeCapistranoProbe() == PLUS_FAIL)
+    {
+      LOG_ERROR("Failed to initialize Capistrano US Probe");
+    }
+    this->Initialized = true;
+  }
   XML_FIND_DEVICE_ELEMENT_REQUIRED_FOR_READING(deviceConfig, rootConfigElement);
 
   // Load US probe parameters -----------------------------------------------
@@ -869,12 +877,6 @@ vtkPlusCapistranoVideoSource::vtkPlusCapistranoVideoSource()
   this->CurrentPixelSpacingMm[0]               = 1.0;
   this->CurrentPixelSpacingMm[1]               = 1.0;
   this->CurrentPixelSpacingMm[2]               = 1.0;
-
-  // Initialize Capistrano US Probe ----------------------------------------
-  if (InitializeCapistranoProbe() == PLUS_FAIL)
-  {
-    LOG_ERROR("Failed to initialize Capistrano US Probe");
-  }
 }
 
 // ----------------------------------------------------------------------------
@@ -1104,7 +1106,7 @@ PlusStatus vtkPlusCapistranoVideoSource::InitializeTGC()
 
 // Device-specific functions --------------------------------------------------
 
-PlusStatus vtkPlusCapistranoVideoSource::InitializeCapistranoVideoSource(bool probeConnected)
+PlusStatus vtkPlusCapistranoVideoSource::InitializeCapistranoVideoSource()
 {
   // Initialize vtkPlusDataSource ---------------------------------------------
   vtkPlusDataSource* aSource = NULL;
@@ -1129,6 +1131,16 @@ PlusStatus vtkPlusCapistranoVideoSource::InitializeCapistranoVideoSource(bool pr
   {
     LOG_ERROR("Failed to initialize Image Window");
     return PLUS_FAIL;
+  }
+
+  // Initialize Capistrano US Probe ----------------------------------------
+  if (!this->Initialized)
+  {
+    if (InitializeCapistranoProbe() == PLUS_FAIL)
+    {
+      LOG_ERROR("Failed to initialize Capistrano US Probe");
+    }
+    this->Initialized = true;
   }
 
   // Update US parameters --------------------------------------------------

--- a/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.h
+++ b/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.h
@@ -228,7 +228,7 @@ protected:
   PlusStatus InternalStopRecording() override;
 
   /*! Initialize vtkPlusCapistranoVideoSource */
-  PlusStatus InitializeCapistranoVideoSource(bool probeConnected = false);
+  PlusStatus InitializeCapistranoVideoSource();
 
   /*! The internal function which actually does the grab. */
   PlusStatus InternalUpdate();
@@ -286,6 +286,7 @@ protected:
   class        vtkInternal;
   vtkInternal* Internal;
 
+  bool                           Initialized = false;
   bool                           Frozen;
   bool                           UpdateParameters;
   bool                           MISMode;


### PR DESCRIPTION
Wait until it is needed, either by ReadConfiguration or Connect.

Without this, PlusVersion tries to connect to the Wobbler resulting in the following output:
```text
|ERROR|001.025000| Capistrano finding probes failed| in C:\SP\SPR19_x64b\PlusLib\src\PlusDataCollection\Capistrano\vtkPlusCapistranoVideoSource.cxx(913)
|ERROR|001.029000| Failed to initialize Capistrano US Probe| in C:\SP\SPR19_x64b\PlusLib\src\PlusDataCollection\Capistrano\vtkPlusCapistranoVideoSource.cxx(876)
Supported devices:
  - AndorCamera (ver: Andor SDK version: 2.102.30001.0)
  - CapistranoVideo (ver: Capistrano BmodeUSB DLL v316, USBprobe DLL v159)
  - ChRobotics (ver: Plus-2.9.0)
  - FakeTracker (ver: Plus-2.9.0)
  - GenericSerialDevice (ver: Plus-2.9.0)
  - ImageProcessor (ver: Plus-2.9.0)
  - Microchip (ver: Plus-2.9.0)
  - MmfVideo (ver: Plus-2.9.0)
  - NoiseVideo (ver: Plus-2.9.0)
  - OpenIGTLinkTracker (ver: OpenIGTLink v3.1.0)
  - OpenIGTLinkVideo (ver: OpenIGTLink v3.1.0)
  - SavedDataSource (ver: Plus-2.9.0)
  - USDigitalEncodersTracker (ver: Plus-2.9.0)
  - UsSimulator (ver: Plus-2.9.0)
  - VirtualBufferedCapture (ver: Plus-2.9.0)
  - VirtualCapture (ver: Plus-2.9.0)
  - VirtualDeinterlacer (ver: Plus-2.9.0)
  - VirtualDiscCapture (ver: Plus-2.9.0)
  - VirtualMixer (ver: Plus-2.9.0)
  - VirtualSwitcher (ver: Plus-2.9.0)
  - VirtualVolumeReconstructor (ver: Plus-2.9.0)
  - WinProbeVideo (ver: Plus-2.9.0)
```