### PR TITLE
BUG: Incorrect spacing frame field from winprobe rf capture

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -356,15 +356,7 @@ void vtkPlusWinProbeVideoSource::FrameCallback(int length, char* data, char* hHe
   ARFIGeometryStruct* arfiGeometry = (ARFIGeometryStruct*)hGeometry;
   this->FrameNumber = header->TotalFrameCounter;
   InputSourceBindings usMode = header->InputSourceBinding;
-  FrameSizeType frameSize;
-  if(usMode & BFRFALineImage_RFData)
-  {
-    frameSize = { m_PrimaryFrameSize[1]* m_SSDecimation, m_PrimaryFrameSize[0], 1 };
-  }
-  else
-  {
-    frameSize = m_PrimaryFrameSize;
-  }
+  FrameSizeType frameSize = { 1, 1, 1 };
 
   if(usMode & CFD)
   {
@@ -1809,8 +1801,8 @@ std::vector<double> vtkPlusWinProbeVideoSource::GetExtraSourceSpacing()
   {
     if(GetBRFEnabled())
     {
-      spacing[0] = m_ScanDepth / (m_ExtraFrameSize[1] * m_SSDecimation - 1);
-      spacing[1] = this->GetTransducerWidthMm() / (m_ExtraFrameSize[0] - 1);
+      spacing[0] = m_ScanDepth / (m_ExtraFrameSize[0] - 1);
+      spacing[1] = this->GetTransducerWidthMm() / (m_ExtraFrameSize[1] - 1);
     }
     else
     {

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -397,7 +397,7 @@ void vtkPlusWinProbeVideoSource::FrameCallback(int length, char* data, char* hHe
       AdjustBufferSizes();
       AdjustSpacing(true);
     }
-    else if(this->CurrentPixelSpacingMm[0] = m_ScanDepth / (m_ExtraFrameSize[1] * 1)) // we might need approximate equality check
+    else if(this->CurrentPixelSpacingMm[0] != m_ScanDepth / (m_ExtraFrameSize[1] * 1)) // we might need approximate equality check
     {
       LOG_INFO("Scan Depth changed. Adjusting spacing.");
       AdjustSpacing(true);
@@ -416,7 +416,7 @@ void vtkPlusWinProbeVideoSource::FrameCallback(int length, char* data, char* hHe
       AdjustBufferSizes();
       AdjustSpacing(true);
     }
-    else if(this->CurrentPixelSpacingMm[0] = m_ScanDepth / (m_ExtraFrameSize[1] * m_SSDecimation - 1)) // we might need approximate equality check
+    else if(this->CurrentPixelSpacingMm[0] != m_ScanDepth / (m_ExtraFrameSize[1] * m_SSDecimation - 1)) // we might need approximate equality check
     {
       LOG_INFO("Scan Depth changed. Adjusting spacing.");
       AdjustSpacing(true);


### PR DESCRIPTION
Minor bug in the winprobe device which saved incorrect element spacings to rf extra source captures. Also cleaned up what seem to be some copy paste typos in conditionals.

cc @jamesobutler for review