### PR TITLE
BUG: Fix set ARFI config string not always returning a PlusStatus

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1774,8 +1774,8 @@ PlusStatus vtkPlusWinProbeVideoSource::SetARFIPushConfigurationString(std::strin
     }
     WPSetARFIPushConfigurationString(pushConfiguration.c_str());
     SetPendingRecreateTables(true);
-    return PLUS_SUCCESS;
   }
+  return PLUS_SUCCESS;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Originally discovered by @dzenanz in https://github.com/PlusToolkit/PlusLib/pull/838#discussion_r684377965.