### PR TITLE
ENH: Clarify ARFIPushConfigurationString usage

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1762,6 +1762,34 @@ int32_t vtkPlusWinProbeVideoSource::GetARFIStopSample()
 }
 
 //----------------------------------------------------------------------------
+void vtkPlusWinProbeVideoSource::SetARFIPushOffset(int32_t value)
+{
+  if(Connected)
+  {
+    if(quadBFCount != 1)
+    {
+      LOG_WARNING("ARFI Push offset is only used by X4BF devices. Use SetARFIPushConfigurationString instead.");
+    }
+    ::SetARFIPushOffset(value);
+    SetPendingRecreateTables(true);
+  }
+}
+
+//----------------------------------------------------------------------------
+int32_t vtkPlusWinProbeVideoSource::GetARFIPushOffset()
+{
+  if(Connected)
+  {
+    if(quadBFCount != 1)
+    {
+      LOG_WARNING("ARFI Push offset is only used by X4BF devices. Use SetARFIPushConfigurationString instead.");
+    }
+    m_ARFIPushOffset = ::GetARFIPushOffset();
+  }
+  return m_ARFIPushOffset;
+}
+
+//----------------------------------------------------------------------------
 void vtkPlusWinProbeVideoSource::SetARFIPushConfigurationString(std::string pushConfiguration)
 {
   if(Connected)

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1762,20 +1762,31 @@ int32_t vtkPlusWinProbeVideoSource::GetARFIStopSample()
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusWinProbeVideoSource::SetARFIPushConfigurationString(std::string pushConfiguration)
+void vtkPlusWinProbeVideoSource::SetARFIPushConfigurationString(std::string pushConfiguration)
 {
   if(Connected)
   {
     m_ARFIPushConfigurationCount = std::count(pushConfiguration.begin(), pushConfiguration.end(), ';') + 1;
-    if(quadBFCount == 1 && m_ARFIPushConfigurationCount != 30)
+    if(quadBFCount == 1)
     {
-      LOG_ERROR("A X4BF requires an ARFI Push Configuration string to have 30 pushes so that the buffers are sized correctly.");
-      return PLUS_FAIL;
+      if(m_ARFIPushConfigurationCount == 30)
+      {
+        LOG_WARNING("A X4BF will use an API hardcoded 30 push configuration rather than the custom specified configuration that was set.")
+      }
+      else
+      {
+        LOG_ERROR("A X4BF requires an ARFI Push Configuration string to have 30 pushes so that the buffers are sized correctly. "
+                  "An appropriate configuration length will be set instead.");
+        pushConfiguration = "1,40,48;1,48,56;1,56,64;1,64,72;1,72,80;1,80,88;"
+                            "2,40,48;2,48,56;2,56,64;2,64,72;2,72,80;2,80,88;"
+                            "3,40,48;3,48,56;3,56,64;3,64,72;3,72,80;3,80,88;"
+                            "4,40,48;4,48,56;4,56,64;4,64,72;4,72,80;4,80,88;"
+                            "5,40,48;5,48,56;5,56,64;5,64,72;5,72,80;5,80,88";
+      }
     }
     WPSetARFIPushConfigurationString(pushConfiguration.c_str());
     SetPendingRecreateTables(true);
   }
-  return PLUS_SUCCESS;
 }
 
 //----------------------------------------------------------------------------

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -244,6 +244,8 @@ public:
   int GetTransducerInternalID();
 
   /*!
+  Only for X8BF devices. Set a custom ARFI push configuration.
+
   The first number is the push focus depth number in the ARFI focal depths. (Index 1 through 5 are for push focus).
   The second number is the push line location. (int)
   The third number is the tracking line location. (int)
@@ -265,7 +267,7 @@ public:
    1,72,80;1,72,80;1,72,80;
    1,80,88;1,80,88;1,80,88"
   */
-  PlusStatus SetARFIPushConfigurationString(std::string pushConfiguration);
+  void SetARFIPushConfigurationString(std::string pushConfiguration);
   std::string GetARFIPushConfigurationString();
 
   enum class Mode

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -241,6 +241,10 @@ public:
   void SetARFIStopSample(int32_t value);
   int32_t GetARFIStopSample();
 
+  /*! Only for X4BF devices. Set the push offset for ARFI.*/
+  void SetARFIPushOffset(int32_t value);
+  int32_t GetARFIPushOffset();
+
   int GetTransducerInternalID();
 
   /*!
@@ -367,6 +371,7 @@ protected:
   int32_t m_ARFIMultiTxCount = 1;
   uint16_t m_ARFITxTxCycleCount = 2;
   uint8_t m_ARFITxTxCycleWidth = 10;
+  int32_t m_ARFIPushOffset = -12;
   uint16_t m_ARFITxCycleCount = 4096;
   uint8_t m_ARFITxCycleWidth = 15;
   std::string m_ARFIPushConfigurationString = "1,40,48;1,48,56;1,56,64;1,64,72;1,72,80;1,80,88";


### PR DESCRIPTION
This includes some clarifications when using a X4BF WinProbe device when doing ARFI. The X4BF continues to use the older API such as ARFIPushOffset, while the X8BF can use the custom specification of that ARFIPushConfigurationString supports.

Dual support will be maintained until X4BF devices are nearly phased out. X4BF devices have not been in production for awhile , but are still used occasionally.

cc: @dzenanz 