### PR TITLE
ENH: Return immediately after ARFIPush

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1907,7 +1907,6 @@ PlusStatus vtkPlusWinProbeVideoSource::ARFIPush()
       return PLUS_FAIL;
     }
     ::ARFIPush();
-    Sleep(8000);  // allow some time to buffer frames
     return PLUS_SUCCESS;
   }
   return PLUS_FAIL;


### PR DESCRIPTION
It was hardcoded to 8 seconds so that upon exiting the method the frame would be available in the frame list. This time was specific to the previously hardcoded 30 pushes method. Push configuration string can be customized now so a time to add to the frame list is dynamic.

If trying to get the frame from the frame list, the video source should be checked to see if it is empty before attempting to get the frame.

cc: @dzenanz @adamaji 