### PR TITLE
ENH: Tweaking Atracsys device options handling

### DIFF
--- a/src/Documentation/UserManual/DeviceAtracsys.dox
+++ b/src/Documentation/UserManual/DeviceAtracsys.dox
@@ -8,15 +8,14 @@
 
 \section AtracsysSupportedPlatforms Supported platforms
 
-- \ref PackageWin32
 - \ref PackageWin64
 - \ref PackageLinux
 
 \section AtracsysSDKVersions Atracsys SDK Versions
 Please build PLUS Atracsys support against the following Atracsys SDK versions. Other versions may work, but are not regularly tested by the PLUS developer team.
 
--spryTrack: RC7
--fusionTrack: 4.1.3
+-spryTrack: RC11
+-fusionTrack: 4.5.2
 
 \section AtracsysFirmwareUpdate Updating camera firmware
 Please check the release notes for your version of the Atracsys SDK to ensure that these notes are current.
@@ -88,6 +87,8 @@ commit \<tracker_SN\> 1 \<size\>   i.e.   commit * 1 2408603
 - \xmlAtt MaxMissingFiducials Max number of missing fiducials to still track a marker with. \OptionalAtt{1}
 - \xmlAtt MaxMeanRegistrationErrorMm Maximum error in fitting marker geometry to visible fiducials to consider a marker tracked. \OptionalAtt{2.0}
 - \xmlAtt ActiveMarkerPairingTimeSec Time tracker waits for active markers to pair before beginning tracking. \OptionalAtt{0}
+- \xmlAtt SymmetriseCoordinates Change the referential of the tracker from the left camera (0) to the center of the device (1). \OptionalAtt{0}
+- \xmlAtt EnableLasers Turn lasers on (1) or off (0). \OptionalAtt{0}
 - \xmlAtt \ref ToolReferenceFrame \OptionalAtt{Tracker}
 - \xmlElem \ref DataSources \RequiredAtt
   - \xmlElem \ref DataSource \RequiredAtt

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
@@ -127,7 +127,7 @@ public:
 
   // correspondence between atracsys option name and its actual id in the sdk
   // this map is filled automatically by the sdk, DO NOT hardcode/change any id
-  std::map<std::string, ftkOptionsInfo*> DeviceOptionMap{};
+  std::map<std::string, ftkOptionsInfo> DeviceOptionMap{};
 
   //----------------------------------------------------------------------------
   // callback function stores all option id
@@ -139,7 +139,7 @@ public:
     {
       return;
     }
-    ptr->DeviceOptionMap.emplace(option->name, option);
+    ptr->DeviceOptionMap.emplace(option->name, *option);
   }
 
   // Code from ATRACSYS
@@ -511,7 +511,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::AtracsysInternal::LoadFtkGeome
   {
     ftkBuffer buffer;
     buffer.reset();
-    if (ftkGetData(this->FtkLib, this->TrackerSN, this->DeviceOptionMap["Data Directory"]->id, &buffer) != ftkError::FTK_OK || buffer.size < 1u)
+    if (ftkGetData(this->FtkLib, this->TrackerSN, this->DeviceOptionMap["Data Directory"].id, &buffer) != ftkError::FTK_OK || buffer.size < 1u)
     {
       return ERROR_FAILURE_TO_LOAD_INI;
     }
@@ -545,16 +545,16 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::AtracsysInternal::LoadFtkGeome
 // provided an option name with Atracsys' nomenclature, this method returns the pointer
 // to the corresponding ftkOptionsInfo which contains various information about the option
 // (notably its id and value type)
-bool AtracsysTracker::GetOptionInfo(const std::string& optionName, ftkOptionsInfo*& info)
+bool AtracsysTracker::GetOptionInfo(const std::string& optionName, const ftkOptionsInfo*& info)
 {
-  std::map<std::string, ftkOptionsInfo*>::const_iterator it = this->Internal->DeviceOptionMap.find(optionName);
+  std::map<std::string, ftkOptionsInfo>::const_iterator it = this->Internal->DeviceOptionMap.find(optionName);
   if (it == this->Internal->DeviceOptionMap.cend())
   {
     return false;
   }
   else
   {
-    info = it->second;
+    info = &(it->second);
     return true;
   }
 }
@@ -563,7 +563,8 @@ bool AtracsysTracker::GetOptionInfo(const std::string& optionName, ftkOptionsInf
 // this method sets a value to an option in the device. The option name follows Atracsys' nomenclature.
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetOption(const std::string& optionName, const std::string& attributeValue)
 {
-  ftkOptionsInfo* info;
+  const ftkOptionsInfo * info;
+
   if (!this->GetOptionInfo(optionName, info))
   {
     return ERROR_OPTION_NOT_FOUND;
@@ -769,7 +770,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::LoadMarkerGeometryFromString(s
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetMarkerInfo(std::string& markerInfo)
 {
   // get correct device option number
-  ftkOptionsInfo* info;
+  const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Active Wireless Markers info", info))
   {
     return ERROR_OPTION_NOT_FOUND;
@@ -887,7 +888,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetMarkersInFrame(std::vector<
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetUserLEDState(int red, int green, int blue, int frequency, bool enabled /* = true */)
 {
   // get correct device option number
-  ftkOptionsInfo* info;
+  const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("User-LED frequency", info))
   {
     return ERROR_OPTION_NOT_FOUND;
@@ -922,7 +923,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetUserLEDState(int red, int g
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableUserLED(bool enabled)
 {
   // get correct device option number
-  ftkOptionsInfo* info;
+  const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Enables the user-LED", info))
   {
     return ERROR_OPTION_NOT_FOUND;
@@ -938,7 +939,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableUserLED(bool enabled)
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetLaserEnabled(bool enabled)
 {
   // get correct device option number
-  ftkOptionsInfo* info;
+  const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Enables lasers", info))
   {
     return ERROR_OPTION_NOT_FOUND;
@@ -957,7 +958,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetLaserEnabled(bool enabled)
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerPairing(bool enabled)
 {
   // get correct device option number
-  ftkOptionsInfo* info;
+  const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Active Wireless Pairing Enable", info))
   {
     return ERROR_OPTION_NOT_FOUND;
@@ -974,7 +975,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerPairing(bo
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerStatusStreaming(bool enabled)
 {
   // get correct device option number
-  ftkOptionsInfo* info;
+  const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Active Wireless button statuses streaming", info))
   {
     return ERROR_OPTION_NOT_FOUND;
@@ -991,7 +992,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerStatusStre
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerBatteryStreaming(bool enabled)
 {
   // get correct device option number
-  ftkOptionsInfo* info;
+  const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Active Wireless battery state streaming", info))
   {
     return ERROR_OPTION_NOT_FOUND;
@@ -1011,7 +1012,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerBatteryStr
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableOnboardProcessing(bool enabled)
 {
   // get correct device option number
-  ftkOptionsInfo* info;
+  const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Enable embedded processing", info))
   {
     return ERROR_OPTION_NOT_FOUND;
@@ -1028,7 +1029,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableOnboardProcessing(bool e
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableImageStreaming(bool enabled)
 {
   // get correct device option number
-  ftkOptionsInfo* info;
+  const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Enable images sending", info))
   {
     return ERROR_OPTION_NOT_FOUND;
@@ -1077,7 +1078,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetDroppedFrameCount(int& drop
   {
     int32 lost = 0, corrupted = 0;
     // get correct device option number
-    ftkOptionsInfo* info;
+    const ftkOptionsInfo* info;
     if (!this->GetOptionInfo("Counter of lost frames", info))
     { return ERROR_OPTION_NOT_FOUND; }
     ftkGetInt32(this->Internal->FtkLib, this->Internal->TrackerSN, info->id, &lost, ftkOptionGetter::FTK_VALUE);
@@ -1097,7 +1098,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::ResetLostFrameCount()
   if (this->DeviceType == FUSIONTRACK_250 || this->DeviceType == FUSIONTRACK_500)
   {
     // get correct device option number
-    ftkOptionsInfo* info;
+    const ftkOptionsInfo* info;
     if (!this->GetOptionInfo("Resets lost counters", info))
     { return ERROR_OPTION_NOT_FOUND; }
     ftkSetInt32(this->Internal->FtkLib, this->Internal->TrackerSN, info->id, RESET_DROPPED_FRAME_COUNT);

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
@@ -128,7 +128,7 @@ public:
   // correspondence between atracsys option name and its actual id in the sdk
   // this map is filled automatically by the sdk, DO NOT hardcode/change any id
   std::map<std::string, ftkOptionsInfo*> DeviceOptionMap{};
-  
+
   //----------------------------------------------------------------------------
   // callback function stores all option id
   static void DeviceOptionEnumerator(uint64_t serialNumber, void* userData, ftkOptionsInfo* option)
@@ -164,22 +164,22 @@ public:
     bool parseLine(std::string& line)
     {
       size_t first_bracket = line.find_first_of("["),
-        last_bracket = line.find_last_of("]"),
-        equal = line.find_first_of("=");
+             last_bracket = line.find_last_of("]"),
+             equal = line.find_first_of("=");
 
       if (first_bracket != std::string::npos &&
-        last_bracket != std::string::npos)
+          last_bracket != std::string::npos)
       {
         // Found section
         _currentSection = line.substr(first_bracket + 1,
-          last_bracket - first_bracket - 1);
+                                      last_bracket - first_bracket - 1);
         sections[_currentSection] = KeyValues();
       }
       else if (equal != std::string::npos && _currentSection != "")
       {
         // Found property in a section
         std::string key = line.substr(0, equal),
-          val = line.substr(equal + 1);
+                    val = line.substr(equal + 1);
         sections[_currentSection][key] = val;
       }
       else
@@ -188,7 +188,7 @@ public:
         // skip it
         // as well, otherwise the parsing cannot be done.
         line.erase(remove_if(line.begin(),
-          line.end(), isspace), line.end());
+                             line.end(), isspace), line.end());
         if (!line.empty() && line.substr(0, 1) != ";")
         {
           return false;
@@ -271,7 +271,7 @@ public:
         while (iterK != kw.end())
         {
           fprintf(file, "%s=%s\n",
-            iterK->first.c_str(), iterK->second.c_str());
+                  iterK->first.c_str(), iterK->second.c_str());
           iterK++;
         }
         iterS++;
@@ -304,7 +304,7 @@ public:
         while (iterK != kw.end())
         {
           sprintf(temp, "%s=%s\n",
-            iterK->first.c_str(), iterK->second.c_str());
+                  iterK->first.c_str(), iterK->second.c_str());
           buffer += temp;
           iterK++;
         }
@@ -350,8 +350,8 @@ public:
 
   //----------------------------------------------------------------------------
   bool assignUint32(IniFile& p, const std::string& section,
-    const std::string& key,
-    uint32* variable)
+                    const std::string& key,
+                    uint32* variable)
   {
     if (!checkKey(p, section, key))
     {
@@ -368,8 +368,8 @@ public:
 
   //----------------------------------------------------------------------------
   bool assignFloatXX(IniFile& p, const std::string& section,
-    const std::string& key,
-    floatXX* variable)
+                     const std::string& key,
+                     floatXX* variable)
   {
     if (!checkKey(p, section, key))
     {
@@ -397,7 +397,7 @@ public:
 
     return ParseIniFile(fileContent, geometry);
   }
-  
+
   //----------------------------------------------------------------------------
   // this method from https://thispointer.com/find-and-replace-all-occurrences-of-a-sub-string-in-c/
   void stringFindAndReplaceAll(std::string& data, std::string toSearch, std::string replaceStr)
@@ -414,7 +414,7 @@ public:
       pos = data.find(toSearch, pos + replaceStr.size());
     }
   }
-  
+
   //----------------------------------------------------------------------------
   bool ParseIniFile(std::string fileContent, ftkGeometry& geometry)
   {
@@ -423,7 +423,7 @@ public:
     IniFile parser;
 
     if (!parser.parse(const_cast<char*>(fileContent.c_str()),
-      fileContent.size()))
+                      fileContent.size()))
     {
       return false;
     }
@@ -458,17 +458,17 @@ public:
       }
 
       if (!assignFloatXX(parser, sectionName, "x",
-        &geometry.positions[i].x))
+                         &geometry.positions[i].x))
       {
         return false;
       }
       if (!assignFloatXX(parser, sectionName, "y",
-        &geometry.positions[i].y))
+                         &geometry.positions[i].y))
       {
         return false;
       }
       if (!assignFloatXX(parser, sectionName, "z",
-        &geometry.positions[i].z))
+                         &geometry.positions[i].z))
       {
         return false;
       }
@@ -545,7 +545,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::AtracsysInternal::LoadFtkGeome
 // provided an option name with Atracsys' nomenclature, this method returns the pointer
 // to the corresponding ftkOptionsInfo which contains various information about the option
 // (notably its id and value type)
-bool AtracsysTracker::GetOptionInfo(const std::string& optionName, ftkOptionsInfo* &info)
+bool AtracsysTracker::GetOptionInfo(const std::string& optionName, ftkOptionsInfo*& info)
 {
   std::map<std::string, ftkOptionsInfo*>::const_iterator it = this->Internal->DeviceOptionMap.find(optionName);
   if (it == this->Internal->DeviceOptionMap.cend())
@@ -672,17 +672,17 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::Connect()
 
   switch (device.Type)
   {
-  case ftkDeviceType::DEV_SPRYTRACK_180:
-    this->DeviceType = SPRYTRACK_180;
-    break;
-  case ftkDeviceType::DEV_FUSIONTRACK_500:
-    this->DeviceType = FUSIONTRACK_500;
-    break;
-  case ftkDeviceType::DEV_FUSIONTRACK_250:
-    this->DeviceType = FUSIONTRACK_250;
-    break;
-  default:
-    this->DeviceType = UNKNOWN_DEVICE;
+    case ftkDeviceType::DEV_SPRYTRACK_180:
+      this->DeviceType = SPRYTRACK_180;
+      break;
+    case ftkDeviceType::DEV_FUSIONTRACK_500:
+      this->DeviceType = FUSIONTRACK_500;
+      break;
+    case ftkDeviceType::DEV_FUSIONTRACK_250:
+      this->DeviceType = FUSIONTRACK_250;
+      break;
+    default:
+      this->DeviceType = UNKNOWN_DEVICE;
   }
 
   // allocate memory for ftk frame to be used throughout life of the object
@@ -703,8 +703,8 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::Connect()
   }
 
   if (ftkEnumerateOptions(this->Internal->FtkLib, this->Internal->TrackerSN,
-    &AtracsysTracker::AtracsysInternal::DeviceOptionEnumerator, this->Internal) != ftkError::FTK_OK
-    || this->Internal->DeviceOptionMap.find("Data Directory") == this->Internal->DeviceOptionMap.cend())
+                          &AtracsysTracker::AtracsysInternal::DeviceOptionEnumerator, this->Internal) != ftkError::FTK_OK
+      || this->Internal->DeviceOptionMap.find("Data Directory") == this->Internal->DeviceOptionMap.cend())
   {
     return ERROR_OPTION_NOT_FOUND;
   }
@@ -807,14 +807,14 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetFiducialsInFrame(std::vecto
 
   switch (this->Internal->Frame->markersStat)
   {
-  case ftkQueryStatus::QS_WAR_SKIPPED:
-    return ERROR_INVALID_FRAME;
-  case ftkQueryStatus::QS_ERR_INVALID_RESERVED_SIZE:
-    return ERROR_INVALID_FRAME;
-  case ftkQueryStatus::QS_OK:
-    break;
-  default:
-    return ERROR_INVALID_FRAME;
+    case ftkQueryStatus::QS_WAR_SKIPPED:
+      return ERROR_INVALID_FRAME;
+    case ftkQueryStatus::QS_ERR_INVALID_RESERVED_SIZE:
+      return ERROR_INVALID_FRAME;
+    case ftkQueryStatus::QS_OK:
+      break;
+    default:
+      return ERROR_INVALID_FRAME;
   }
 
   if (this->Internal->Frame->markersStat == ftkQueryStatus::QS_ERR_OVERFLOW)
@@ -845,14 +845,14 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetMarkersInFrame(std::vector<
 
   switch (this->Internal->Frame->markersStat)
   {
-  case ftkQueryStatus::QS_WAR_SKIPPED:
-    return ERROR_INVALID_FRAME;
-  case ftkQueryStatus::QS_ERR_INVALID_RESERVED_SIZE:
-    return ERROR_INVALID_FRAME;
-  case ftkQueryStatus::QS_OK:
-    break;
-  default:
-    return ERROR_INVALID_FRAME;
+    case ftkQueryStatus::QS_WAR_SKIPPED:
+      return ERROR_INVALID_FRAME;
+    case ftkQueryStatus::QS_ERR_INVALID_RESERVED_SIZE:
+      return ERROR_INVALID_FRAME;
+    case ftkQueryStatus::QS_OK:
+      break;
+    default:
+      return ERROR_INVALID_FRAME;
   }
 
   if (this->Internal->Frame->markersStat == ftkQueryStatus::QS_ERR_OVERFLOW)
@@ -897,19 +897,19 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetUserLEDState(int red, int g
     return ERROR_SET_USER_LED;
   }
   if (!this->GetOptionInfo("User-LED red component", info))
-    return ERROR_OPTION_NOT_FOUND;
+  { return ERROR_OPTION_NOT_FOUND; }
   if (ftkSetInt32(this->Internal->FtkLib, this->Internal->TrackerSN, info->id, red) != ftkError::FTK_OK)
   {
     return ERROR_SET_USER_LED;
   }
   if (!this->GetOptionInfo("User-LED green component", info))
-    return ERROR_OPTION_NOT_FOUND;
+  { return ERROR_OPTION_NOT_FOUND; }
   if (ftkSetInt32(this->Internal->FtkLib, this->Internal->TrackerSN, info->id, green) != ftkError::FTK_OK)
   {
     return ERROR_SET_USER_LED;
   }
   if (!this->GetOptionInfo("User-LED blue component", info))
-    return ERROR_OPTION_NOT_FOUND;
+  { return ERROR_OPTION_NOT_FOUND; }
   if (ftkSetInt32(this->Internal->FtkLib, this->Internal->TrackerSN, info->id, blue) != ftkError::FTK_OK)
   {
     return ERROR_SET_USER_LED;
@@ -1079,10 +1079,10 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetDroppedFrameCount(int& drop
     // get correct device option number
     ftkOptionsInfo* info;
     if (!this->GetOptionInfo("Counter of lost frames", info))
-      return ERROR_OPTION_NOT_FOUND;
+    { return ERROR_OPTION_NOT_FOUND; }
     ftkGetInt32(this->Internal->FtkLib, this->Internal->TrackerSN, info->id, &lost, ftkOptionGetter::FTK_VALUE);
     if (!this->GetOptionInfo("Counter of corrupted frames", info))
-      return ERROR_OPTION_NOT_FOUND;
+    { return ERROR_OPTION_NOT_FOUND; }
     ftkGetInt32(this->Internal->FtkLib, this->Internal->TrackerSN, info->id, &corrupted, ftkOptionGetter::FTK_VALUE);
 
     droppedFrameCount = lost + corrupted;
@@ -1099,7 +1099,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::ResetLostFrameCount()
     // get correct device option number
     ftkOptionsInfo* info;
     if (!this->GetOptionInfo("Resets lost counters", info))
-      return ERROR_OPTION_NOT_FOUND;
+    { return ERROR_OPTION_NOT_FOUND; }
     ftkSetInt32(this->Internal->FtkLib, this->Internal->TrackerSN, info->id, RESET_DROPPED_FRAME_COUNT);
     return SUCCESS;
   }

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
@@ -542,6 +542,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::AtracsysInternal::LoadFtkGeome
 }
 
 //----------------------------------------------------------------------------
+// provided an option name with Atracsys' nomenclature, this method returns the pointer
+// to the corresponding ftkOptionsInfo which contains various information about the option
+// (notably its id and value type)
 bool AtracsysTracker::GetOptionInfo(const std::string& optionName, ftkOptionsInfo* &info)
 {
   std::map<std::string, ftkOptionsInfo*>::const_iterator it = this->Internal->DeviceOptionMap.find(optionName);
@@ -557,6 +560,7 @@ bool AtracsysTracker::GetOptionInfo(const std::string& optionName, ftkOptionsInf
 }
 
 //----------------------------------------------------------------------------
+// this method sets a value to an option in the device. The option name follows Atracsys' nomenclature.
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetOption(const std::string& optionName, const std::string& attributeValue)
 {
   ftkOptionsInfo* info;

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.h
@@ -174,7 +174,7 @@ public:
   ATRACSYS_RESULT SetOption(const std::string&, const std::string&);
 
 protected:
-  bool GetOptionInfo(const std::string&, ftkOptionsInfo*&);
+  bool GetOptionInfo(const std::string&, const ftkOptionsInfo*&);
 
 private:
   DEVICE_TYPE DeviceType = UNKNOWN_DEVICE;

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.h
@@ -101,7 +101,7 @@ public:
     int GeometryId;
     vtkNew<vtkMatrix4x4> ToolToTracker;
     int GeometryPresenceMask; // presence mask of fiducials expressed as their numerical indices
-    float RegistrationErrorMM; // Mean fiducial registration error (unit mm) 
+    float RegistrationErrorMM; // Mean fiducial registration error (unit mm)
   };
 
   /*! Connect to Atracsys tracker, must be called before any other function in this wrapper API. */

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.h
@@ -11,8 +11,12 @@ See License.txt for details.
 #include <vector>
 #include <vtkNew.h>
 
-
+struct ftkOptionsInfo;
 class vtkMatrix4x4;
+
+// Functions to safely convert string to int32 or float
+bool strToInt32(const std::string& str, int& var);
+bool strToFloat32(const std::string& str, float& var);
 
 class AtracsysTracker
 {
@@ -37,11 +41,9 @@ public:
     ERROR_NO_FRAME_AVAILABLE,
     ERROR_INVALID_FRAME,
     ERROR_TOO_MANY_MARKERS,
-    ERROR_ENABLE_IR_STROBE,
     ERROR_ENABLE_LASER,
     ERROR_SET_USER_LED,
     ERROR_ENABLE_USER_LED,
-    ERROR_SET_MAX_MISSING_FIDUCIALS,
     ERROR_ENABLE_ONBOARD_PROCESSING,
     ERROR_ENABLE_IMAGE_STREAMING,
     ERROR_ENABLE_WIRELESS_MARKER_PAIRING,
@@ -50,16 +52,16 @@ public:
     ERROR_DISCONNECT_ATTEMPT_WHEN_NOT_CONNECTED,
     ERROR_CANNOT_GET_MARKER_INFO,
     ERROR_FAILED_TO_SET_STK_PROCESSING_TYPE,
-    ERROR_FAILED_TO_SET_MAX_MISSING_FIDS,
-    ERROR_OPTION_NOT_FOUND
+    ERROR_OPTION_NOT_FOUND,
+    ERROR_SET_OPTION
   };
 
   enum DEVICE_TYPE
   {
     UNKNOWN_DEVICE = 0,
-    SPRYTRACK_180 = 1,
-    FUSIONTRACK_500 = 2,
-    FUSIONTRACK_250 = 3
+    SPRYTRACK_180,
+    FUSIONTRACK_500,
+    FUSIONTRACK_250
   };
 
   enum SPRYTRACK_IMAGE_PROCESSING_TYPE
@@ -129,17 +131,13 @@ public:
   ATRACSYS_RESULT GetMarkersInFrame(std::vector<Marker>& markers);
 
   /*! */
-  ATRACSYS_RESULT EnableIRStrobe(bool enabled);
-
-  /*! */
   ATRACSYS_RESULT SetUserLEDState(int red, int green, int blue, int frequency, bool enabled = true);
-
 
   /*! */
   ATRACSYS_RESULT EnableUserLED(bool enabled);
 
   /*! */
-  ATRACSYS_RESULT SetMaxMissingFiducials(int maxMissingFids);
+  ATRACSYS_RESULT SetLaserEnabled(bool enabled);
 
   /*! */
   ATRACSYS_RESULT EnableWirelessMarkerPairing(bool enabled);
@@ -161,9 +159,6 @@ public:
   ATRACSYS_RESULT EnableImageStreaming(bool enabled);
 
   /*! */
-  ATRACSYS_RESULT SetLaserEnabled(bool enabled);
-
-  /*! */
   ATRACSYS_RESULT SetSpryTrackProcessingType(SPRYTRACK_IMAGE_PROCESSING_TYPE processingType);
 
   // ------------------------------------------
@@ -176,51 +171,15 @@ public:
   /*! */
   ATRACSYS_RESULT ResetLostFrameCount();
 
-  enum OPTIONS
-  {
-    OPTION_DATA_SENDING = 20,
-    OPTION_FTK_WIRELESS_MARKER_PAIRING_ENABLE = 40,
-    OPTION_FTK_WIRELESS_MARKER_STATUS_STREAMING = 45,
-    OPTION_FTK_WIRELESS_MARKER_BATTERY_STREAMING = 46,
-    OPTION_FTK_DEV_MARKERS_INFO = 47,
-    OPTION_IR_STROBE = 50,
-    OPTION_LOST_FRAME_COUNT = 60,
-    OPTION_CORRUPTED_FRAME_COUNT = 61,
-    OPTION_RESET_LOST_FRAME_COUNT = 69,
-    OPTION_ENABLE_LASER = 80,
-    OPTION_LED_RED_COMPONENT = 90,
-    OPTION_LED_GREEN_COMPONENT = 91,
-    OPTION_LED_BLUE_COMPONENT = 92,
-    OPTION_LED_FREQUENCY = 93,
-    OPTION_LED_ENABLE = 94,
-    OPTION_EPIPOLAR_MIN_DISTANCE = 2001,
-    OPTION_MATCHING_TOLERANCE = 3002,
-    OPTION_MAX_MEAN_REGISTRATION_ERROR = 3003,
-    OPTION_MAX_MISSING_POINTS = 3004,
-    OPTION_MAX_TRACKING_RANGE = 3005,
-    OPTION_ONBOARD_PROCESSING = 6000,
-    OPTION_IMAGE_STREAMING = 6003,
-    OPTION_STK_WIRELESS_MARKER_PAIRING_ENABLE = 7000,
-    OPTION_STK_WIRELESS_MARKER_STATUS_STREAMING = 7001,
-    OPTION_STK_WIRELESS_MARKER_BATTERY_STREAMING = 7002,
-    OPTION_STK_DEV_MARKERS_INFO = 7005,
-  };
+  ATRACSYS_RESULT SetOption(const std::string&, const std::string&);
 
-
+protected:
+  bool GetOptionInfo(const std::string&, ftkOptionsInfo*&);
 
 private:
   DEVICE_TYPE DeviceType = UNKNOWN_DEVICE;
-  
+
   class AtracsysInternal;
   AtracsysInternal* Internal;
-
-  // load Atracsys marker geometry ini file
-  //bool LoadIniFile(std::ifstream& is, ftkGeometry& geometry);
-
-  // helper function to set spryTrack only options
-  ATRACSYS_RESULT SetSpryTrackOnlyOption(int option, int value, ATRACSYS_RESULT errorResult);
-
-  // helper function to set fusionTrack only options
-  ATRACSYS_RESULT SetFusionTrackOnlyOption(int option, int value, ATRACSYS_RESULT errorResult);
 };
 #endif

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
@@ -300,8 +300,20 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
   for (const auto& i : this->Internal->DeviceOptions)
   {
     std::string translatedOptionName;
-    if (translateOptionName(i.first, translatedOptionName))
-    { this->Internal->Tracker.SetOption(translatedOptionName, i.second); }
+
+    /* Dirty hack circumventing a nomenclature discrepancy between ftk and stk API's, this will be fixed in the next API release */
+    if (i.first == "EnableLasers" && this->Internal->DeviceType == AtracsysTracker::DEVICE_TYPE::SPRYTRACK_180)
+    {
+      this->Internal->Tracker.SetOption("Enable lasers", i.second);
+    }
+    else if (i.first == "SymmetriseCoordinates" && this->Internal->DeviceType == AtracsysTracker::DEVICE_TYPE::SPRYTRACK_180)
+    {
+      this->Internal->Tracker.SetOption("Embedded Symmetrise coordinates", i.second);
+    }
+    else/* end of hack*/ if (translateOptionName(i.first, translatedOptionName))
+    {
+      this->Internal->Tracker.SetOption(translatedOptionName, i.second);
+    }
   }
 
   // if spryTrack, setup for onboard processing and disable extraneous marker info streaming

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
@@ -233,11 +233,12 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
   this->Internal->Tracker.GetDeviceType(this->Internal->DeviceType);
 
   // helper to translate option names from Plus nomenclature to Atracsys' one
-  auto translateOptionName = [this](const std::string& optionName, std::string& translatedOptionName) {
+  auto translateOptionName = [this](const std::string & optionName, std::string & translatedOptionName)
+  {
     std::map<std::string, std::string>::const_iterator itt =
       this->Internal->DeviceOptionTranslator.find(optionName);
     if (itt == this->Internal->DeviceOptionTranslator.cend())
-      return false;
+    { return false; }
     else
     {
       translatedOptionName = itt->second;
@@ -277,7 +278,7 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
   else
   {
     this->Internal->DeviceOptions.emplace("MaxMeanRegistrationErrorMm",
-      std::to_string(this->Internal->MaxMeanRegistrationErrorMm));
+                                          std::to_string(this->Internal->MaxMeanRegistrationErrorMm));
   }
   // ------- max number of missing fiducials
   itd = this->Internal->DeviceOptions.find("MaxMissingFiducials");
@@ -295,7 +296,7 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
   else
   {
     this->Internal->DeviceOptions.emplace("MaxMissingFiducials",
-      std::to_string(this->Internal->MaxMissingFiducials));
+                                          std::to_string(this->Internal->MaxMissingFiducials));
   }
 
   // set device options
@@ -303,7 +304,7 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
   {
     std::string translatedOptionName;
     if (translateOptionName(i.first, translatedOptionName))
-      this->Internal->Tracker.SetOption(translatedOptionName, i.second);
+    { this->Internal->Tracker.SetOption(translatedOptionName, i.second); }
   }
 
   // if spryTrack, setup for onboard processing and disable extraneous marker info streaming

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
@@ -59,11 +59,11 @@ public:
     : External(external)
   {
     // stores correspondences between config file option names and atracsys option names
-    DeviceOptionTranslator["MaxMeanRegistrationErrorMm"] = "Registration Mean Error";
-    DeviceOptionTranslator["MaxMissingFiducials"] = "Matching Maximum Missing Points";
-    DeviceOptionTranslator["SymmetriseCoordinates"] = "Symmetrise coordinates";
-    DeviceOptionTranslator["EnableLasers"] = "Enables lasers";
-    DeviceOptionTranslator["EnableUserLED"] = "Enables the user-LED";
+    this->DeviceOptionTranslator["MaxMeanRegistrationErrorMm"] = "Registration Mean Error";
+    this->DeviceOptionTranslator["MaxMissingFiducials"] = "Matching Maximum Missing Points";
+    this->DeviceOptionTranslator["SymmetriseCoordinates"] = "Symmetrise coordinates";
+    this->DeviceOptionTranslator["EnableLasers"] = "Enables lasers";
+    this->DeviceOptionTranslator["EnableUserLED"] = "Enables the user-LED";
   }
 
   virtual ~vtkInternal()

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
@@ -254,10 +254,7 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
   {
     if (strToInt32(itd->second, this->Internal->ActiveMarkerPairingTimeSec))
     {
-      if (this->Internal->ActiveMarkerPairingTimeSec > 15)
-      {
-        LOG_WARNING("Marker pairing time is set to " << this->Internal->ActiveMarkerPairingTimeSec << "seconds, tracking will not start until this period is over.");
-      }
+      LOG_INFO("Marker pairing time is set to " << this->Internal->ActiveMarkerPairingTimeSec << " seconds, tracking will not start until this period is over.");
     }
   }
 
@@ -352,7 +349,7 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
     LOG_ERROR(this->Internal->Tracker.ResultToString(result));
     return PLUS_FAIL;
   }
-  LOG_INFO("Active marker pairing period started.");
+  LOG_INFO("Active marker pairing period started for " << this->Internal->ActiveMarkerPairingTimeSec << " seconds.");
 
   // sleep while waiting for tracker to pair active markers
   vtkIGSIOAccurateTimer::Delay(this->Internal->ActiveMarkerPairingTimeSec);

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.h
@@ -22,7 +22,7 @@ Requires PLUS_USE_ATRACSYS option in CMake.
 class vtkPlusDataCollectionExport vtkPlusAtracsysTracker : public vtkPlusDevice
 {
 public:
-  static vtkPlusAtracsysTracker *New();
+  static vtkPlusAtracsysTracker* New();
   vtkTypeMacro(vtkPlusAtracsysTracker, vtkPlusDevice);
   void PrintSelf(ostream& os, vtkIndent indent);
 
@@ -49,7 +49,7 @@ public:
   PlusStatus InternalUpdate();
 
 public:
-   // Commands
+  // Commands
   static const char* ATRACSYS_COMMAND_SET_FLAG;
   static const char* ATRACSYS_COMMAND_LED_ENABLED;
   static const char* ATRACSYS_COMMAND_LASER_ENABLED;


### PR DESCRIPTION
For Atracsys devices, there is an option called "Symmetrise Coordinates" to change the tracker referential from the left camera to the (more conventional) center of the device. This parameter was not included in the device options which are hardcoded in the `enum OPTIONS` in AtracsysTracker.h, so I could have just added it there.
However, after discussion with the sdk devs, we realized that hardcoding the option ids was not really future-proof since these ids could change someday. So we went ahead and rewrote some of the device option handling. This includes an automatic generation of all available options for the connected device, a translator for option names from Plus' nomenclature to Atracsys' one and some robustness improvement for setting the actual values.
The translator is unfortunately mandatory here, since Atracsys option names contain spaces and the config file entries cannot.
However, with this approach, if an option id changes in the SDK, it's automatically handled. If a new option is introduced in the sdk, there is only one entry to add to the translator which is just a simple map<string, string>.