### PR TITLE
Winprobe ARFI update regarding timeblock size

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -383,10 +383,9 @@ void vtkPlusWinProbeVideoSource::FrameCallback(int length, char* data, char* hHe
   }
   else if(usMode & ARFI)
   {
-    int bytesPerTimestamp = sizeof(int32_t) * 2;
     int timestampsPerLineRepeat = (4 / quadBFCount);
     int lineRepeatCount = arfiGeometry->PrePushLineRepeatCount + arfiGeometry->PostPushLineRepeatCount;
-    int timeblock = timestampsPerLineRepeat * lineRepeatCount * m_ARFIPushConfigurationCount * bytesPerTimestamp;
+    int timeblock = timestampsPerLineRepeat * lineRepeatCount * m_ARFIPushConfigurationCount * sizeof(int32_t);
     int arfiDataSize = arfiGeometry->SamplesPerLine * arfiGeometry->LineCount * lineRepeatCount * m_ARFIPushConfigurationCount * sizeof(int32_t);
     assert(length == arfiDataSize + timeblock);
     frameSize[0] = (arfiDataSize + timeblock) / sizeof(int32_t);  // we want to include all data to be saved
@@ -1440,9 +1439,8 @@ PlusStatus vtkPlusWinProbeVideoSource::SetExtraSourceMode(Mode mode)
     int lineRepeatCount = m_ARFIPrePushLineRepeatCount + m_ARFIPostPushLineRepeatCount;
     unsigned arfiDataSize = samplesPerLine * lineCount * lineRepeatCount * m_ARFIPushConfigurationCount;
 
-    int fourByteCountsPerTimestamp = 2;
     int timestampsPerLineRepeat = (4 / quadBFCount);
-    unsigned timeblockSize = timestampsPerLineRepeat * lineRepeatCount * m_ARFIPushConfigurationCount * fourByteCountsPerTimestamp;
+    unsigned timeblockSize = timestampsPerLineRepeat * lineRepeatCount * m_ARFIPushConfigurationCount;
     m_ExtraFrameSize = { arfiDataSize + timeblockSize, 1, 1 };
     this->AdjustBufferSizes();
     std::vector<int32_t> zeroData(m_ExtraFrameSize[0] * m_ExtraFrameSize[1] * m_ExtraFrameSize[2], 0);

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -380,10 +380,10 @@ protected:
   uint8_t m_ARFITxTxCycleWidth = 10;
   uint16_t m_ARFITxCycleCount = 4096;
   uint8_t m_ARFITxCycleWidth = 15;
-  uint16_t m_ARFILineTimer = 75;
-  int32_t m_ARFIPrePushLineRepeatCount = 16;
-  int32_t m_ARFIPostPushLineRepeatCount = 112;
-  std::string m_ARFIPushConfigurationString = "1,40,48;1,48,56;1,56,64;1,64,72;1,72,80;1,80,88";
+  uint16_t m_ARFILineTimer = 100;
+  int32_t m_ARFIPrePushLineRepeatCount = 8;
+  int32_t m_ARFIPostPushLineRepeatCount = 56;
+  std::string m_ARFIPushConfigurationString = "1,33,44;1,41,52;1,49,60;1,57,68;1,65,76;1,73,84";
   int m_ARFIPushConfigurationCount = 6;
   int32_t m_MPRF = 100;
   int32_t m_MLineIndex = 60;


### PR DESCRIPTION
These are additional updates based on latest changes to WinProbe API. Main one is that the timeblock for ARFI data is not half of what is used to be. 

When there was ARFI support for X4 and X8BF, the timeblock size was the same for both where the X4 needed to use the full size and X8 used half the size and filled in the other half with zeros.  Since X4BF ARFI support was recently removed, the data now has a timeblock size that is half of what is was before.

I've tested this with hardware and everything works nicely.

@adamaji or @Sunderlandkyl Can you approve and merge? Thanks!