### PR TITLE
ENH: Support ARFI samples per line not equal to 1024

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -386,7 +386,7 @@ void vtkPlusWinProbeVideoSource::FrameCallback(int length, char* data, char* hHe
     int timestampsPerLineRepeat = (4 / quadBFCount);
     int lineRepeatCount = arfiGeometry->PrePushLineRepeatCount + arfiGeometry->PostPushLineRepeatCount;
     int timeblock = timestampsPerLineRepeat * lineRepeatCount * m_ARFIPushConfigurationCount * sizeof(int32_t);
-    int arfiDataSize = arfiGeometry->SamplesPerLine * arfiGeometry->LineCount * lineRepeatCount * m_ARFIPushConfigurationCount * sizeof(int32_t);
+    int arfiDataSize = (m_ARFIStopSample - m_ARFIStartSample) * arfiGeometry->LineCount * lineRepeatCount * m_ARFIPushConfigurationCount * sizeof(int32_t);
     assert(length == arfiDataSize + timeblock);
     frameSize[0] = (arfiDataSize + timeblock) / sizeof(int32_t);  // we want to include all data to be saved
     frameSize[1] = 1;
@@ -882,6 +882,8 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
     SetARFITxCycleCount(m_ARFITxCycleCount);
     SetARFITxCycleWidth(m_ARFITxCycleWidth);
     SetARFILineTimer(m_ARFILineTimer);
+    SetARFIStartSample(m_ARFIStartSample);
+    SetARFIStopSample(m_ARFIStopSample);
     SetARFIPrePushLineRepeatCount(m_ARFIPrePushLineRepeatCount);
     SetARFIPostPushLineRepeatCount(m_ARFIPostPushLineRepeatCount);
     SetARFIPushConfigurationString(m_ARFIPushConfigurationString);
@@ -1434,7 +1436,7 @@ PlusStatus vtkPlusWinProbeVideoSource::SetExtraSourceMode(Mode mode)
   else if(mode == Mode::ARFI)
   {
     m_Mode = Mode::ARFI;
-    int samplesPerLine = 1024;
+    int samplesPerLine = m_ARFIStopSample - m_ARFIStartSample;
     int lineCount = 16;
     int lineRepeatCount = m_ARFIPrePushLineRepeatCount + m_ARFIPostPushLineRepeatCount;
     unsigned arfiDataSize = samplesPerLine * lineCount * lineRepeatCount * m_ARFIPushConfigurationCount;
@@ -1695,10 +1697,12 @@ int32_t vtkPlusWinProbeVideoSource::GetMDepth()
   return m_MDepth;
 }
 
+//----------------------------------------------------------------------------
 void vtkPlusWinProbeVideoSource::SetARFIStartSample(int32_t value)
 {
   if(Connected)
   {
+    m_ARFIStartSample = value;
     ::SetARFIStartSample(value);
     SetPendingRecreateTables(true);
   }
@@ -1706,18 +1710,19 @@ void vtkPlusWinProbeVideoSource::SetARFIStartSample(int32_t value)
 
 int32_t vtkPlusWinProbeVideoSource::GetARFIStartSample()
 {
-  int32_t startSample = -1;
   if(Connected)
   {
-    startSample = ::GetARFIStartSample();
+    m_ARFIStartSample = ::GetARFIStartSample();
   }
-  return startSample;
+  return m_ARFIStartSample;
 }
 
+//----------------------------------------------------------------------------
 void vtkPlusWinProbeVideoSource::SetARFIStopSample(int32_t value)
 {
   if(Connected)
   {
+    m_ARFIStopSample = value;
     ::SetARFIStopSample(value);
     SetPendingRecreateTables(true);
   }
@@ -1725,12 +1730,11 @@ void vtkPlusWinProbeVideoSource::SetARFIStopSample(int32_t value)
 
 int32_t vtkPlusWinProbeVideoSource::GetARFIStopSample()
 {
-  int32_t stopSample = -1;
   if(Connected)
   {
-    stopSample = ::GetARFIStopSample();
+    m_ARFIStopSample = ::GetARFIStopSample();
   }
-  return stopSample;
+  return m_ARFIStopSample;
 }
 
 //----------------------------------------------------------------------------

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -380,6 +380,8 @@ protected:
   uint8_t m_ARFITxTxCycleWidth = 10;
   uint16_t m_ARFITxCycleCount = 4096;
   uint8_t m_ARFITxCycleWidth = 15;
+  int32_t m_ARFIStartSample = 0;
+  int32_t m_ARFIStopSample = 1024;
   uint16_t m_ARFILineTimer = 100;
   int32_t m_ARFIPrePushLineRepeatCount = 8;
   int32_t m_ARFIPostPushLineRepeatCount = 56;


### PR DESCRIPTION
This makes sure the expected data size is correct when using a start/stop sample range of something other than 1024 when collecting ARFI data with the WinProbe device.

This has been tested with hardware and works nicely. 

@adamrankin or @Sunderlandkyl Can you please merge this PR? Thanks!