### PR TITLE
BUG: Fix WinProbe frequency not being set appropriately

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1000,11 +1000,11 @@ PlusStatus vtkPlusWinProbeVideoSource::SetTransmitFrequencyMHz(float frequency)
   m_Frequency = frequency;
   if(Connected)
   {
-    ::SetTxTxFrequency(frequency);
+    ::SetTxFreq(frequency);
     SetPendingRecreateTables(true);
 
     //what we requested might be only approximately satisfied
-    m_Frequency = ::GetTxTxFrequency();
+    m_Frequency = ::GetTxFreq();
   }
   return PLUS_SUCCESS;
 }
@@ -1014,7 +1014,7 @@ float vtkPlusWinProbeVideoSource::GetTransmitFrequencyMHz()
 {
   if(Connected)
   {
-    m_Frequency = ::GetTxTxFrequency();
+    m_Frequency = ::GetTxFreq();
   }
   return m_Frequency;
 }


### PR DESCRIPTION
With the latest WinProbe API, it was observed that frequency was not being set appropriately. 

The WinProbe API now uses SetTxFreq/GetTxFreq instead of SetTxTxFrequency/GetTxTxFrequency. Using hardware it was confirmed that frequency is now being set appropriately as observed by the image changing.

@adamrankin Can you help proceed with merging? Thanks!