### PR TITLE
BUG: Fix WinProbe spatial compounding angle allowed to change

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -112,7 +112,6 @@ PlusStatus vtkPlusWinProbeVideoSource::ReadConfiguration(vtkXMLDataElement* root
   XML_READ_BOOL_ATTRIBUTE_OPTIONAL(MRevolvingEnabled, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(float, TransmitFrequencyMHz, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(float, ScanDepthMm, deviceConfig);
-  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(float, SpatialCompoundAngle, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, SpatialCompoundCount, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, MPRFrequency, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, MLineIndex, deviceConfig);
@@ -1344,14 +1343,12 @@ void vtkPlusWinProbeVideoSource::SetSpatialCompoundEnabled(bool value)
     SetSCIsEnabled(value);
     if(value)
     {
-      SetSCCompoundAngle(m_SpatialCompoundAngle);
-      SetSCCompoundAngleCount(m_SpatialCompoundCount);
+      SetSpatialCompoundCount(m_SpatialCompoundCount);
     }
     else
     {
-      SetSCCompoundAngleCount(0);
+      SetSpatialCompoundCount(0);
     }
-    SetPendingRecreateTables(true);
   }
   m_SpatialCompoundEnabled = value;
 }
@@ -1363,17 +1360,6 @@ bool vtkPlusWinProbeVideoSource::GetSpatialCompoundEnabled()
     m_SpatialCompoundEnabled = GetSCIsEnabled();
   }
   return m_SpatialCompoundEnabled;
-}
-
-void vtkPlusWinProbeVideoSource::SetSpatialCompoundAngle(float value)
-{
-  m_SpatialCompoundAngle = value;
-  if(Connected)
-  {
-    SetSCCompoundAngle(value);
-    SetPendingRecreateTables(true);
-    m_SpatialCompoundAngle = GetSCCompoundAngle(); //in case it was not exactly satisfied
-  }
 }
 
 float vtkPlusWinProbeVideoSource::GetSpatialCompoundAngle()

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -186,11 +186,25 @@ public:
   void SetSpatialCompoundEnabled(bool value);
   bool GetSpatialCompoundEnabled();
 
-  void SetSpatialCompoundAngle(float value);
-  float GetSpatialCompoundAngle();
+  /*!
+  Sets the number of +/- degree angles to use.
 
+  Spatial Compounding Count of:
+  1 -> 0 degrees and +/- 10 degrees
+  2 -> 0 degrees and +/- 6 degrees and +/- 12 degrees
+  3 -> 0 degrees and +/- 4 degrees and +/- 8 degrees and +/- 12 degrees
+  4 -> 0 degrees and +/- 3 degrees and +/- 6 degrees and +/- 9 degrees and +/- 12 degrees
+  */
   void SetSpatialCompoundCount(int32_t value);
   int32_t GetSpatialCompoundCount();
+
+  /*!
+  Gets the delta between angle values used.
+
+  The beamformers assume a static array of possible angles.
+  Spatial Compounding Count=3 will return a Spatial Compound Angle of 4 degrees.
+  */
+  float GetSpatialCompoundAngle();
 
   void SetBHarmonicEnabled(bool value);
   bool GetBHarmonicEnabled();


### PR DESCRIPTION
Using the latest UltraVisionAPI, the beamformers assume a static array of possible angles based on the number of angles requested. Spatial compounding angle should not be set directly.

I tested this with hardware and things work as intended. Changing spatial compound angle will change spatial compound angle automatically by the API.

cc: @adamrankin or @Sunderlandkyl Can you help with merging this? Thanks!