### PR TITLE
Clean up thread resources spawned from starting/stopping recording

### DIFF
--- a/src/PlusDataCollection/vtkPlusDevice.cxx
+++ b/src/PlusDataCollection/vtkPlusDevice.cxx
@@ -1323,7 +1323,6 @@ PlusStatus vtkPlusDevice::StopRecording()
     return PLUS_SUCCESS;
   }
 
-  this->ThreadId = -1;
   this->Recording = 0;
 
   if (this->GetStartThreadForInternalUpdates())
@@ -1334,7 +1333,9 @@ PlusStatus vtkPlusDevice::StopRecording()
     {
       vtkIGSIOAccurateTimer::Delay(0.1);
     }
+    int tempID = this->ThreadId;
     this->ThreadId = -1;
+    this->Threader->TerminateThread(tempID);
     LOCAL_LOG_DEBUG("Internal update thread terminated");
   }
 


### PR DESCRIPTION
[BUG: vtkPlusDevice does not clean up threads when stopping recording](https://github.com/PlusToolkit/PlusLib/commit/70aec801a78099004f4ad0f73375c83fd1b011ec) addresses an issue with stopping and starting recording of a device with the base `StartRecording`/`StopRecording` in `vtkPlusDevice` where doing so enough times will throw this error: https://github.com/Kitware/VTK/blob/5fc9b9d1f71b33d8f13e259f9c1fda4105fe00d5/Common/Core/vtkMultiThreader.cxx#L464-L468

Only setting the thread id to -1 does not clean up the associated resources from `vtkMultiThreader`. (Similar fix to https://github.com/PlusToolkit/PlusLib/pull/718)

This came up because we found that `vtkPlusCapistranoVideoSource::FreezeDevice` is not thread safe to call with the device's `InternalUpdate` call. A similar paradigm is in `vtkPlusIntersonVideoSource` so I wonder if the same is true there as well.

~~[BUG: IGSIO calibration ReadConfig methods are not overridden](https://github.com/PlusToolkit/PlusLib/commit/ff129ae82e5241962ec25ce983c868a8d6778aca) addresses build errors I was running into which I assume are related to recent changes: https://github.com/PlusToolkit/PlusLib/issues/914 https://github.com/PlusToolkit/PlusLib/commit/c9ef62b8db61caf75e20060c00cae9adbb69fa56.~~

cc @jamesobutler or @nathanbmnt / @adamrankin or @Sunderlandkyl for review