### PR TITLE
Fix preproc definition issue on Linux

### DIFF
--- a/src/PlusConfigure.h.in
+++ b/src/PlusConfigure.h.in
@@ -11,10 +11,12 @@
 #ifndef __PlusConfigure_h
 #define __PlusConfigure_h
 
+#if defined(_WIN32)
 #ifdef _WIN32_WINNT
 #undef _WIN32_WINNT
 #endif
 #define _WIN32_WINNT @RUNTIME_MINIMUM_WINDOWS_VERSION@
+#endif
 
 // disable warnings for sprintf
 #define _CRT_SECURE_NO_WARNINGS


### PR DESCRIPTION
The windows preproc definition on Linux causes some issues with
external libs headers using this preproc conditionnally.

Fix #924