### PR TITLE
ENH: Expose overall gain adjustment for WinProbe device

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -126,6 +126,7 @@ PlusStatus vtkPlusWinProbeVideoSource::ReadConfiguration(vtkXMLDataElement* root
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(unsigned long, LogMax, deviceConfig); //implicit type conversion
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(unsigned long, SSDecimation, deviceConfig); //implicit type conversion
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(double, FirstGainValue, deviceConfig);
+  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(double, OverallTimeGainCompensation, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, BFrameRateLimit, deviceConfig);
 
 
@@ -192,6 +193,7 @@ PlusStatus vtkPlusWinProbeVideoSource::WriteConfiguration(vtkXMLDataElement* roo
   deviceConfig->SetUnsignedLongAttribute("SSDecimation", this->GetSSDecimation());
   deviceConfig->SetAttribute("Mode", ModeToString(this->m_Mode).c_str());
   deviceConfig->SetDoubleAttribute("FirstGainValue", this->GetFirstGainValue());
+  deviceConfig->SetDoubleAttribute("OverallTimeGainCompensation", this->GetOverallTimeGainCompensation());
   deviceConfig->SetIntAttribute("BFrameRateLimit", this->GetBFrameRateLimit());
 
   deviceConfig->SetVectorAttribute("TimeGainCompensation", 8, m_TimeGainCompensation);
@@ -1180,6 +1182,31 @@ PlusStatus vtkPlusWinProbeVideoSource::SetFirstGainValue(double value)
   return PLUS_SUCCESS;
 }
 
+//----------------------------------------------------------------------------
+double vtkPlusWinProbeVideoSource::GetOverallTimeGainCompensation()
+{
+  if(Connected)
+  {
+    m_OverallTimeGainCompensation = GetTGCOverallGain();
+  }
+  return m_OverallTimeGainCompensation;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusWinProbeVideoSource::SetOverallTimeGainCompensation(double value)
+{
+  if(Connected)
+  {
+    SetTGCOverallGain(value);
+    SetPendingTGCUpdate(true);
+    //what we requested might be only approximately satisfied
+    for (int tgcIndex=0; tgcIndex < 8; tgcIndex += 1)
+    {
+      m_TimeGainCompensation[tgcIndex] = GetTGC(tgcIndex);
+    }
+  }
+  return PLUS_SUCCESS;
+}
 
 //----------------------------------------------------------------------------
 float vtkPlusWinProbeVideoSource::GetFocalPointDepth(int index)

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -81,6 +81,12 @@ public:
   /* Set the TGC First Gain Value near transducer face */
   PlusStatus SetFirstGainValue(double value);
 
+  /* Get the current overall gain value, value 0.0 to 40.0 */
+  double GetOverallTimeGainCompensation();
+
+  /* Set an overall gain value, value 0.0 to 40.0 */
+  PlusStatus SetOverallTimeGainCompensation(double value);
+
   /* Get the B-Mode focal depth at a specific index, index 0 to 3 */
   float GetFocalPointDepth(int index);
 
@@ -379,6 +385,7 @@ protected:
   bool m_UseDeviceFrameReconstruction = true;
   igsioFieldMapType m_CustomFields;
   double m_TimeGainCompensation[8];
+  double m_OverallTimeGainCompensation = 0;
   float m_FocalPointDepth[4];
   float m_ARFIFocalPointDepth[6];
   uint16_t m_MinValue = 16; //noise floor


### PR DESCRIPTION
Small change for exposing overall time gain compensation adjustment for WinProbe devices.

cc @jamesobutler or @nathanbmnt for review