### PR TITLE
ENH Added ability to set Atracsys frame options from config file

### DIFF
--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
@@ -696,7 +696,10 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::Connect()
     return ERROR_CANNOT_CREATE_FRAME_INSTANCE;
   }
 
-  if (ftkSetFrameOptions(false, false, 128u, 128u, 4u * FTK_MAX_FIDUCIALS, 4u, this->Internal->Frame) != ftkError::FTK_OK)
+  if (ftkSetFrameOptions(false, this->MaxEventsNumber,
+    this->Max2dFiducialsNumber, this->Max2dFiducialsNumber,
+    this->Max3dFiducialsNumber, this->MaxMarkersNumber,
+    this->Internal->Frame) != ftkError::FTK_OK)
   {
     ftkDeleteFrame(this->Internal->Frame);
     this->Internal->Frame = nullptr;
@@ -1002,6 +1005,46 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerBatteryStr
   {
     return ERROR_ENABLE_WIRELESS_MARKER_BATTERY_STREAMING;
   }
+  return SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMaxEventsNumber(int n)
+{
+  if (n < 0) {
+    return ERROR_SET_OPTION;
+  }
+  this->MaxEventsNumber = n;
+  return SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMax2dFiducialsNumber(int n)
+{
+  if (n < 0) {
+    return ERROR_SET_OPTION;
+  }
+  this->Max2dFiducialsNumber = n;
+  return SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMax3dFiducialsNumber(int n)
+{
+  if (n < 0) {
+    return ERROR_SET_OPTION;
+  }
+  this->Max3dFiducialsNumber = n;
+  return SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMaxMarkersNumber(int n)
+{
+  if (n < 0) {
+    return ERROR_SET_OPTION;
+  }
+  this->MaxMarkersNumber = n;
   return SUCCESS;
 }
 

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.h
@@ -149,6 +149,25 @@ public:
   ATRACSYS_RESULT EnableWirelessMarkerBatteryStreaming(bool enabled);
 
   // ------------------------------------------
+  // frame options
+  // ------------------------------------------
+  /*! Set/get the maximum number of events per frame included in the device's output */
+  ATRACSYS_RESULT SetMaxEventsNumber(int n);
+  int GetMaxEventsNumber() { return MaxEventsNumber; }
+
+  /*! Set/get the maximum number of 2D fiducials (in either left or right frame) included in the device's output */
+  ATRACSYS_RESULT SetMax2dFiducialsNumber(int n);
+  int GetMax2dFiducialsNumber() { return Max2dFiducialsNumber; }
+
+  /*! Set/get the maximum number of 3D fiducials (after triangulation) included in the device's output */
+  ATRACSYS_RESULT SetMax3dFiducialsNumber(int n);
+  int GetMax3dFiducialsNumber() { return Max3dFiducialsNumber; }
+
+  /*! Set/get the maximum number of markers included in the device's output */
+  ATRACSYS_RESULT SetMaxMarkersNumber(int n);
+  int GetMaxMarkersNumber() { return MaxMarkersNumber; }
+
+  // ------------------------------------------
   // spryTrack only options
   // ------------------------------------------
 
@@ -178,6 +197,11 @@ protected:
 
 private:
   DEVICE_TYPE DeviceType = UNKNOWN_DEVICE;
+
+  int MaxEventsNumber = 0;
+  int Max2dFiducialsNumber = 0;
+  int Max3dFiducialsNumber = 64;
+  int MaxMarkersNumber = 16;
 
   class AtracsysInternal;
   AtracsysInternal* Internal;

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
@@ -249,8 +249,8 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
     }
   };
 
-  // handling options that are used only internally
   std::map<std::string, std::string>::const_iterator itd;
+  // handling options that are used only internally
   // ------- time allocated for activer marker pairing
   itd = this->Internal->DeviceOptions.find("ActiveMarkerPairingTimeSec");
   if (itd != this->Internal->DeviceOptions.cend())
@@ -297,9 +297,66 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
   {
     this->Internal->DeviceOptions.emplace("MaxMissingFiducials",
                                           std::to_string(this->Internal->MaxMissingFiducials));
+
+  // set frame options (internally passed to sdk during connection)
+  // ------- maximum number of events per frame included in the device's output
+  itd = this->Internal->DeviceOptions.find("MaxEventsNumber");
+  if (itd != this->Internal->DeviceOptions.cend())
+  {
+    int value = -1;
+    strToInt32(itd->second, value);
+    if (value < 0) {
+      LOG_WARNING("Invalid value for max events number per frame in output: " << itd->second
+        << ". Default value used (" << this->Internal->Tracker.GetMaxEventsNumber() << ")");
+    }
+    else {
+      this->Internal->Tracker.SetMaxEventsNumber(value);
+    }
+  }
+  // ------- maximum number of 2D fiducials (in either left or right frame) included in the device's output
+  itd = this->Internal->DeviceOptions.find("Max2dFiducialsNumber");
+  if (itd != this->Internal->DeviceOptions.cend())
+  {
+    int value = -1;
+    strToInt32(itd->second, value);
+    if (value < 0) {
+      LOG_WARNING("Invalid value for max 2D fiducials number in output: " << itd->second
+        << ". Default value used (" << this->Internal->Tracker.GetMax2dFiducialsNumber() << ")");
+    }
+    else {
+      this->Internal->Tracker.SetMax2dFiducialsNumber(value);
+    }
+  }
+  // ------- maximum number of 3D fiducials (after triangulation) included in the device's output
+  itd = this->Internal->DeviceOptions.find("Max3dFiducialsNumber");
+  if (itd != this->Internal->DeviceOptions.cend())
+  {
+    int value = -1;
+    strToInt32(itd->second, value);
+    if (value < 0) {
+      LOG_WARNING("Invalid value for max 3D fiducials number in output: " << itd->second
+        << ". Default value used (" << this->Internal->Tracker.GetMax3dFiducialsNumber() << ")");
+    }
+    else {
+      this->Internal->Tracker.SetMax3dFiducialsNumber(value);
+    }
+  }
+  // ------- maximum number of markers included in the device's output
+  itd = this->Internal->DeviceOptions.find("MaxMarkersNumber");
+  if (itd != this->Internal->DeviceOptions.cend())
+  {
+    int value = -1;
+    strToInt32(itd->second, value);
+    if (value < 0) {
+      LOG_WARNING("Invalid value for max markers number in output: " << itd->second
+        << ". Default value used (" << this->Internal->Tracker.GetMaxMarkersNumber() << ")");
+    }
+    else {
+      this->Internal->Tracker.SetMaxMarkersNumber(value);
+    }
   }
 
-  // set device options
+  // set actual device options
   for (const auto& i : this->Internal->DeviceOptions)
   {
     std::string translatedOptionName;


### PR DESCRIPTION
Frame options allow to control the output from Atracsys devices. For optimization purposes, one may want to control the maximum number of events, 2d/3d fiducials and markers that can be provided per frame in the output container.
So far, these options were hardcoded in the ftkSetFrameOptions call. For example, the max number of markers was set to 4 while Atracsys trackers are able to track more.