### PR TITLE
ENH: Add vtkPlusCommand for GenericSerial devices

### DIFF
--- a/src/PlusDataCollection/vtkPlusGenericSerialDevice.cxx
+++ b/src/PlusDataCollection/vtkPlusGenericSerialDevice.cxx
@@ -24,6 +24,12 @@ See License.txt for details.
 vtkStandardNewMacro(vtkPlusGenericSerialDevice);
 
 //----------------------------------------------------------------------------
+// Define command strings
+const char* vtkPlusGenericSerialDevice::SERIAL_COMMAND_GET_RTS = "GetRTS";
+const char* vtkPlusGenericSerialDevice::SERIAL_COMMAND_SET_RTS = "SetRTS";
+const char* vtkPlusGenericSerialDevice::SERIAL_COMMAND_GET_CTS = "GetCTS";
+
+//----------------------------------------------------------------------------
 void bin2hex(const std::string& inputBinary, std::string& outputHexEncoded)
 {
   std::stringstream ss;

--- a/src/PlusDataCollection/vtkPlusGenericSerialDevice.h
+++ b/src/PlusDataCollection/vtkPlusGenericSerialDevice.h
@@ -30,6 +30,10 @@ public:
   vtkTypeMacro(vtkPlusGenericSerialDevice, vtkPlusDevice);
   void PrintSelf(ostream& os, vtkIndent indent);
 
+  static const char* SERIAL_COMMAND_GET_RTS;
+  static const char* SERIAL_COMMAND_SET_RTS;
+  static const char* SERIAL_COMMAND_GET_CTS;
+
   /*! Connect to device */
   PlusStatus InternalConnect();
 
@@ -105,7 +109,7 @@ public:
   /*! Gets the DTR (data-set-ready) line. */
   PlusStatus GetDSR(bool& onOff);
 
-  /*! Gets the RTS (clear-to-send) line. */
+  /*! Gets the CTS (clear-to-send) line. */
   PlusStatus GetCTS(bool& onOff);
 
 protected:

--- a/src/PlusServer/CMakeLists.txt
+++ b/src/PlusServer/CMakeLists.txt
@@ -17,6 +17,7 @@ SET(${PROJECT_NAME}_CMD_SRCS
   Commands/vtkPlusSetUsParameterCommand.cxx
   Commands/vtkPlusGetUsParameterCommand.cxx
   Commands/vtkPlusAddRecordingDeviceCommand.cxx
+  Commands/vtkPlusGenericSerialCommand.cxx
   )
 SET(${PROJECT_NAME}_SRCS
   vtkPlusOpenIGTLinkServer.cxx
@@ -41,6 +42,7 @@ SET(${PROJECT_NAME}_CMD_HDRS
   Commands/vtkPlusSetUsParameterCommand.h
   Commands/vtkPlusGetUsParameterCommand.h
   Commands/vtkPlusAddRecordingDeviceCommand.h
+  Commands/vtkPlusGenericSerialCommand.h
   )
 SET(${PROJECT_NAME}_HDRS
   vtkPlusOpenIGTLinkServer.h

--- a/src/PlusServer/Commands/vtkPlusGenericSerialCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusGenericSerialCommand.cxx
@@ -1,0 +1,193 @@
+/*=Plus=header=begin======================================================
+Program: Plus
+Copyright (c) Laboratory for Percutaneous Surgery. All rights reserved.
+See License.txt for details.
+=========================================================Plus=header=end*/
+
+#include "PlusConfigure.h"
+#include "vtkPlusGenericSerialCommand.h"
+#include "vtkPlusGenericSerialDevice.h"
+
+#include "vtkPlusDataCollector.h"
+
+vtkStandardNewMacro(vtkPlusGenericSerialCommand);
+
+namespace
+{
+  static const std::string SERIAL_CMD_NAME = "SerialCommand";
+}
+
+//----------------------------------------------------------------------------
+vtkPlusGenericSerialCommand::vtkPlusGenericSerialCommand()
+  : ResponseExpected(true)
+{
+  // It handles only one command, set its name by default
+  this->SetName(SERIAL_CMD_NAME);
+}
+
+//----------------------------------------------------------------------------
+vtkPlusGenericSerialCommand::~vtkPlusGenericSerialCommand()
+{
+}
+
+//----------------------------------------------------------------------------
+void vtkPlusGenericSerialCommand::SetNameToSerial()
+{
+  this->SetName(SERIAL_CMD_NAME);
+}
+
+//----------------------------------------------------------------------------
+void vtkPlusGenericSerialCommand::GetCommandNames(std::list<std::string>& cmdNames)
+{
+  cmdNames.clear();
+  cmdNames.push_back(SERIAL_CMD_NAME);
+}
+
+//----------------------------------------------------------------------------
+std::string vtkPlusGenericSerialCommand::GetDescription(const std::string& commandName)
+{
+  std::string desc;
+  if (commandName.empty() || igsioCommon::IsEqualInsensitive(commandName, SERIAL_CMD_NAME))
+  {
+    desc += SERIAL_CMD_NAME;
+    desc += ": Send text data to the device.";
+  }
+  return desc;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkPlusGenericSerialCommand::GetDeviceId() const
+{
+  return this->DeviceId;
+}
+
+//----------------------------------------------------------------------------
+void vtkPlusGenericSerialCommand::SetDeviceId(const std::string& deviceId)
+{
+  this->DeviceId = deviceId;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkPlusGenericSerialCommand::GetCommandName() const
+{
+  return this->CommandName;
+}
+
+//----------------------------------------------------------------------------
+void vtkPlusGenericSerialCommand::SetCommandName(const std::string& text)
+{
+  this->CommandName = text;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkPlusGenericSerialCommand::GetCommandValue() const
+{
+  return this->CommandValue;
+}
+
+//----------------------------------------------------------------------------
+void vtkPlusGenericSerialCommand::SetCommandValue(const std::string& text)
+{
+  this->CommandValue = text;
+}
+
+//----------------------------------------------------------------------------
+void vtkPlusGenericSerialCommand::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusGenericSerialCommand::ReadConfiguration(vtkXMLDataElement* aConfig)
+{
+  if (vtkPlusCommand::ReadConfiguration(aConfig) != PLUS_SUCCESS)
+  {
+    return PLUS_FAIL;
+  }
+
+  XML_READ_STRING_ATTRIBUTE_OPTIONAL(DeviceId, aConfig);
+  XML_READ_STRING_ATTRIBUTE_OPTIONAL(CommandName, aConfig);
+  XML_READ_STRING_ATTRIBUTE_OPTIONAL(CommandValue, aConfig);
+  return PLUS_SUCCESS;
+
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusGenericSerialCommand::WriteConfiguration(vtkXMLDataElement* aConfig)
+{
+  if (vtkPlusCommand::WriteConfiguration(aConfig) != PLUS_SUCCESS)
+  {
+    return PLUS_FAIL;
+  }
+  XML_WRITE_STRING_ATTRIBUTE_IF_NOT_EMPTY(DeviceId, aConfig);
+  XML_WRITE_STRING_ATTRIBUTE_IF_NOT_EMPTY(CommandName, aConfig);
+  XML_WRITE_STRING_ATTRIBUTE_IF_NOT_EMPTY(CommandValue, aConfig);
+  return PLUS_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusGenericSerialCommand::Execute()
+{
+  LOG_DEBUG("vtkPlusGenericSerialCommand::Execute: " << (!this->CommandName.empty() ? this->CommandName : "(undefined)")
+            << ", device: " << (this->DeviceId.empty() ? "(undefined)" : this->DeviceId)
+            << ", value: " << (this->CommandValue.empty() ? "(undefined)" : this->CommandValue));
+
+  vtkPlusDataCollector* dataCollector = GetDataCollector();
+  if (dataCollector == NULL)
+  {
+    this->QueueCommandResponse(PLUS_FAIL, "Command failed. See error message.", "Invalid data collector.");
+    return PLUS_FAIL;
+  }
+
+  // Get device pointer
+  if (this->DeviceId.empty())
+  {
+    this->QueueCommandResponse(PLUS_FAIL, "Command failed. See error message.", "No DeviceId specified.");
+    return PLUS_FAIL;
+  }
+  vtkPlusDevice* aDevice = NULL;
+  if (dataCollector->GetDevice(aDevice, this->DeviceId) != PLUS_SUCCESS)
+  {
+    this->QueueCommandResponse(PLUS_FAIL, "Command failed. See error message.", std::string("Device ")
+                               + (this->DeviceId.empty() ? "(undefined)" : this->DeviceId) + std::string(" is not found."));
+    return PLUS_FAIL;
+  }
+  vtkPlusGenericSerialDevice* device = dynamic_cast<vtkPlusGenericSerialDevice*>(aDevice);  
+
+  // Send text (and receive response)
+  std::string textToSend;
+  std::string response;
+  if (!this->GetCommandValue().empty())
+  {
+    textToSend = GetCommandValue();
+  }
+  PlusStatus status;
+  if (igsioCommon::IsEqualInsensitive(this->GetCommandName(), vtkPlusGenericSerialDevice::SERIAL_COMMAND_GET_RTS))
+  {
+    response = device->GetRTS() ? "True" : "False";
+    status = PLUS_SUCCESS;
+  }
+  else if (igsioCommon::IsEqualInsensitive(this->GetCommandName(), vtkPlusGenericSerialDevice::SERIAL_COMMAND_SET_RTS))
+  {
+    bool onOff = textToSend == "True" ? true : false;
+    status = device->SetRTS(onOff);
+  }
+  else if (igsioCommon::IsEqualInsensitive(this->GetCommandName(), vtkPlusGenericSerialDevice::SERIAL_COMMAND_GET_CTS))
+  {
+    bool onOff;
+    status = device->GetCTS(onOff);
+    response = onOff ? "True" : "False";
+  }
+  else
+  {
+    status = PLUS_FAIL;
+  }
+  if (status != PLUS_SUCCESS)
+  {
+    this->QueueCommandResponse(PLUS_FAIL, "Command failed. See error message.", std::string("Failed to execute command '") + GetCommandName() + "'"
+                               + " on device " + (this->DeviceId.empty() ? "(undefined)" : this->DeviceId));
+    return PLUS_FAIL;
+  }
+  this->QueueCommandResponse(PLUS_SUCCESS, response);
+  return PLUS_SUCCESS;
+}

--- a/src/PlusServer/Commands/vtkPlusGenericSerialCommand.h
+++ b/src/PlusServer/Commands/vtkPlusGenericSerialCommand.h
@@ -1,0 +1,80 @@
+/*=Plus=header=begin======================================================
+  Program: Plus
+  Copyright (c) Laboratory for Percutaneous Surgery. All rights reserved.
+  See License.txt for details.
+=========================================================Plus=header=end*/
+
+#ifndef __vtkPlusGenericSerialCommand_h
+#define __vtkPlusGenericSerialCommand_h
+
+#include "vtkPlusServerExport.h"
+
+#include "vtkPlusCommand.h"
+
+class vtkMatrix4x4;
+
+/*!
+  \class vtkPlusGenericSerialCommand
+  \brief This command is for communicating with vtkPlusGenericSerialDevices.
+  \ingroup PlusLibPlusServer
+
+  This command is used for communicating with a generic serial device.
+ */
+class vtkPlusServerExport vtkPlusGenericSerialCommand : public vtkPlusCommand
+{
+public:
+
+  static vtkPlusGenericSerialCommand* New();
+  vtkTypeMacro(vtkPlusGenericSerialCommand, vtkPlusCommand);
+  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual vtkPlusCommand* Clone() { return New(); }
+
+  /*! Executes the command  */
+  virtual PlusStatus Execute();
+
+  /*! Read command parameters from XML */
+  virtual PlusStatus ReadConfiguration(vtkXMLDataElement* aConfig);
+
+  /*! Write command parameters to XML */
+  virtual PlusStatus WriteConfiguration(vtkXMLDataElement* aConfig);
+
+  /*! Get all the command names that this class can execute */
+  virtual void GetCommandNames(std::list<std::string>& cmdNames);
+
+  /*! Gets the description for the specified command name. */
+  virtual std::string GetDescription(const std::string& commandName);
+
+  /*! Id of the device that the text will be sent to */
+  virtual std::string GetDeviceId() const;
+  virtual void SetDeviceId(const std::string& deviceId);
+
+  /*!
+    If true then the command waits for a response and returns with the received text in the command response.
+  */
+  vtkSetMacro(ResponseExpected, bool);
+  vtkGetMacro(ResponseExpected, bool);
+  vtkBooleanMacro(ResponseExpected, bool);
+
+  void SetNameToSerial();
+
+protected:
+  vtkPlusGenericSerialCommand();
+  virtual ~vtkPlusGenericSerialCommand();
+
+  std::string vtkPlusGenericSerialCommand::GetCommandName() const;
+  void vtkPlusGenericSerialCommand::SetCommandName(const std::string& text);
+  std::string vtkPlusGenericSerialCommand::GetCommandValue() const;
+  void vtkPlusGenericSerialCommand::SetCommandValue(const std::string& text);
+
+private:
+  std::string DeviceId;
+  std::string CommandName;
+  std::string CommandValue;
+  bool ResponseExpected;
+
+  vtkPlusGenericSerialCommand(const vtkPlusGenericSerialCommand&);
+  void operator=(const vtkPlusGenericSerialCommand&);
+};
+
+
+#endif

--- a/src/PlusServer/vtkPlusCommandProcessor.cxx
+++ b/src/PlusServer/vtkPlusCommandProcessor.cxx
@@ -27,6 +27,7 @@ See License.txt for details.
 #endif
 
 #include "vtkPlusAddRecordingDeviceCommand.h"
+#include "vtkPlusGenericSerialCommand.h"
 #include "vtkPlusGetPolydataCommand.h"
 #include "vtkPlusGetTransformCommand.h"
 #include "vtkPlusGetUsParameterCommand.h"
@@ -71,6 +72,7 @@ vtkPlusCommandProcessor::vtkPlusCommandProcessor()
   RegisterPlusCommand(vtkSmartPointer<vtkPlusSetUsParameterCommand>::New());
   RegisterPlusCommand(vtkSmartPointer<vtkPlusGetUsParameterCommand>::New());
   RegisterPlusCommand(vtkSmartPointer<vtkPlusAddRecordingDeviceCommand>::New());
+  RegisterPlusCommand(vtkSmartPointer<vtkPlusGenericSerialCommand>::New());
 #ifdef PLUS_USE_STEALTHLINK
   RegisterPlusCommand(vtkSmartPointer<vtkPlusStealthLinkCommand>::New());
 #endif


### PR DESCRIPTION
This PR adds vtkPlusCommand functionality for some GenericSerial device commands. Specifically get/set for the RTS line and get for the CTS line.

cc @jamesobutler who's run these changes with hardware.

btw, we've created a separate `GenericSerialRemoteControl` Slicer module based off of https://github.com/openigtlink/SlicerOpenIGTLink/tree/master/UltrasoundRemoteControl to match these commands. Would something like that be helpful to include in SlicerOpenIGTLink?