### PR TITLE
Feat/add pointscloud stream depth device

### DIFF
--- a/src/Documentation/UserManual/DeviceAzureKinect.dox
+++ b/src/Documentation/UserManual/DeviceAzureKinect.dox
@@ -1,6 +1,15 @@
 /*!
 \page DeviceAzureKinect Azure Kinect camera
-This device allow you to process two kind of images. The first image is in RGB and the second image is a Depth image.
+This device allow you to retrieve different kind of data from Azure Kinect RGB-D camera:
+
+- The rgb image
+- The depth map
+- The reconstructed points cloud
+
+The depth map resolution can be aligned to the rgb image resolution.
+
+The points cloud resolution matches the rgb image resolution or the depth map resolution if no rgb data
+is retrieved. In the first case, the color data of the rgb image can be used to enhance the points cloud.
 
 \section DeviceAzureKinectSupportedHwDevices Supported hardware devices
 
@@ -36,6 +45,7 @@ The Azure Kinect SDK is released under the MIT license (https://github.com/micro
   - \xmlAtt FrameType Type of stream to capture. \RequiredAtt
     - \c RGB
     - \c DEPTH
+    - \c PCL (The points cloud is sent as an image with 3 scalar components representing the x-y-z coordinates of the points)
   - \xmlAtt FrameSize Size of the video/depth stream. This must be the first number of the Color/Depth resolutions shown in the hardware specifications (https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/kinect-dk/hardware-specification.md).
   - \xmlAtt FrameRate Acquisition frequence for this stream. See hardware specifications (https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/kinect-dk/hardware-specification.md).
   - \xmlAtt \ref PortUsImageOrientation \OptionalAtt{UN}

--- a/src/Documentation/UserManual/DeviceRevopointSurface.dox
+++ b/src/Documentation/UserManual/DeviceRevopointSurface.dox
@@ -1,7 +1,11 @@
 /*!
 \page DeviceRevopoint3DCamera Revopoint 3D cameras
 
-This device allows you to process a depth image from Revopoint 3D cameras.
+This device allows you to process depth data from Revopoint 3D cameras. The following data
+can be retrieved:
+
+- The depth map
+- The points cloud
 
 \section DeviceRevopoint3DCameraSupportedHwDevices Supported hardware devices
 
@@ -26,8 +30,11 @@ This device allows you to process a depth image from Revopoint 3D cameras.
 
 - \xmlAtt \ref DeviceType "Type" = \c "Revopoint3DCamera" \RequiredAtt
 
-- \xmlElem \ref DataSources A single \c DataSource child element is required. \RequiredAtt
+- \xmlElem \ref DataSources One \c DataSource child element is required per stream. \RequiredAtt
   - \xmlElem \ref DataSource Unique data source \RequiredAtt
+  - \xmlAtt FrameType Type of stream to capture. \RequiredAtt
+    - \c DEPTH
+    - \c PCL (The points cloud is sent as an image with 3 scalar components representing the x-y-z coordinates of the points)
   - \xmlAtt FrameWidth Width of the depth stream. \RequiredAtt
     - Check Depth image in hardware specifications (https://3dcamera.revopoint3d.com/html/areascan/index.html).
   - \xmlAtt FrameRate Acquisition frequence for the depth stream. \RequiredAtt

--- a/src/PlusDataCollection/Revopoint3DCamera/vtkPlusRevopoint3DCamera.cxx
+++ b/src/PlusDataCollection/Revopoint3DCamera/vtkPlusRevopoint3DCamera.cxx
@@ -29,325 +29,448 @@ vtkStandardNewMacro(vtkPlusRevopoint3DCamera);
 
 namespace
 {
-struct SurfaceStreamConfig
-{
+  enum RevoSourceType
+  {
+    DEPTH = 1 << 0,
+    PCL = 1 << 1
+  };
+
+  struct StreamConfigBase
+  {
     std::string Id;
     StreamInfo StreamProps;
-    int DepthRange[2];
+    vtkPlusDataSource* Source{nullptr};
+  };
+
+  struct PCLStreamConfig : StreamConfigBase
+  {
+  };
+
+  struct ConcreteStreamConfig : StreamConfigBase
+  {
     Intrinsics Intr;
     Extrinsics Extr;
-    vtkPlusDataSource* Source{nullptr};
-};
+  };
 
-std::string convertErrorCode(ERROR_CODE error)
-{
+  struct DepthStreamConfig : ConcreteStreamConfig
+  {
+    int DepthRange[2];
+  };
+
+  std::string convertErrorCode(ERROR_CODE error)
+  {
     switch (error)
     {
-    case ERROR_CODE::ERROR_PARAM:
+      case ERROR_CODE::ERROR_PARAM:
         return "Bad param";
-    case ERROR_CODE::ERROR_DEVICE_NOT_FOUND:
+      case ERROR_CODE::ERROR_DEVICE_NOT_FOUND:
         return "Device not found";
-    case ERROR_CODE::ERROR_DEVICE_NOT_CONNECT:
+      case ERROR_CODE::ERROR_DEVICE_NOT_CONNECT:
         return "Device not connected";
-    case ERROR_CODE::ERROR_DEVICE_BUSY:
+      case ERROR_CODE::ERROR_DEVICE_BUSY:
         return "Device busy";
-    case ERROR_CODE::ERROR_STREAM_NOT_START:
+      case ERROR_CODE::ERROR_STREAM_NOT_START:
         return "Device not started";
-    case ERROR_CODE::ERROR_STREAM_BUSY:
+      case ERROR_CODE::ERROR_STREAM_BUSY:
         return "Stream busy";
-    case ERROR_CODE::ERROR_FRAME_TIMEOUT:
+      case ERROR_CODE::ERROR_FRAME_TIMEOUT:
         return "Frame timeout";
-    case ERROR_CODE::ERROR_NOT_SUPPORT:
+      case ERROR_CODE::ERROR_NOT_SUPPORT:
         return "Not supported";
-    case ERROR_CODE::ERROR_PROPERTY_GET_FAILED:
+      case ERROR_CODE::ERROR_PROPERTY_GET_FAILED:
         return "Getting property failed";
-    case ERROR_CODE::ERROR_PROPERTY_SET_FAILED:
+      case ERROR_CODE::ERROR_PROPERTY_SET_FAILED:
         return "Setting property failed";
-    default:
+      default:
         break;
     }
     return "Success";
-}
+  }
 }
 
 //----------------------------------------------------------------------------
 class vtkPlusRevopoint3DCamera::vtkInternal
 {
 public:
-    vtkPlusRevopoint3DCamera* External;
-    SurfaceStreamConfig DepthStream;
-    cs::ICameraPtr Camera;
-    cs::IFramePtr DepthFrame;
+  vtkPlusRevopoint3DCamera* External;
+  DepthStreamConfig DepthStream;
+  PCLStreamConfig PCLStream;
+  cs::ICameraPtr Camera;
+  cs::IFramePtr DepthFrame;
+  std::unique_ptr<float[]> PCLFrame;
+  int AvailableStreamsFlag{0};
 
-    vtkInternal(vtkPlusRevopoint3DCamera* external)
-        : External(external)
+  vtkInternal(vtkPlusRevopoint3DCamera* external)
+    : External(external)
+  {
+    this->Camera = cs::getCameraPtr();
+  }
+
+  PlusStatus CheckBasicConfig()
+  {
+    if (!this->DepthStream.Id.empty())
     {
-        this->Camera = cs::getCameraPtr();
+      this->AvailableStreamsFlag |= RevoSourceType::DEPTH;
     }
 
-    PlusStatus UpdateConfig()
+    if (!this->PCLStream.Id.empty())
     {
-        std::vector<StreamInfo> streamProps;
-        this->Camera->getStreamInfos(STREAM_TYPE::STREAM_TYPE_DEPTH, streamProps);
-
-        bool foundMatchingConfig{false};
-        for (auto streamProp : streamProps)
-        {
-            LOG_TRACE("New stream configuration for format: " << streamProp.format);
-            if (streamProp.format == this->DepthStream.StreamProps.format)
-            {
-                LOG_INFO("New depth stream compliant configuration: " << streamProp.width << "x" << streamProp.height << "@" << streamProp.fps);
-                if (this->DepthStream.StreamProps.width != streamProp.width)
-                {
-                    continue;
-                }
-
-                if (this->DepthStream.StreamProps.fps > streamProp.fps)
-                {
-                    this->DepthStream.StreamProps.fps = streamProp.fps;
-                    LOG_WARNING("Expected frame rate too high for current bandwidth. Actual framerate will be @" << streamProp.fps << " fps.");
-                }
-
-                this->DepthStream.StreamProps.height = streamProp.height;
-                foundMatchingConfig = true;
-                break;
-            }
-        }
-
-        if (!foundMatchingConfig)
-        {
-            LOG_ERROR("No matching configuration found");
-            LOG_ERROR("Available configurations:");
-            for (auto streamProp : streamProps)
-            {
-                if (streamProp.format == this->DepthStream.StreamProps.format)
-                {
-                    LOG_ERROR("- " << streamProp.width << "x" << streamProp.height << "@" << streamProp.fps);
-                }
-            }
-            return PLUS_FAIL;
-        }
-
-        this->Camera->getIntrinsics(STREAM_TYPE::STREAM_TYPE_DEPTH, this->DepthStream.Intr);
-        this->Camera->getExtrinsics(this->DepthStream.Extr);
-
-        PropertyExtension value;
-        value.depthRange.min = this->DepthStream.DepthRange[0];
-        value.depthRange.max = this->DepthStream.DepthRange[1];
-        value.algorithmContrast = 5;
-
-        auto ret = this->Camera->setPropertyExtension(PROPERTY_TYPE_EXTENSION::PROPERTY_EXT_DEPTH_RANGE, value);
-        if (ret != ERROR_CODE::SUCCESS)
-        {
-            LOG_ERROR("Failed to set camera depth range: " << convertErrorCode(ret));
-            return PLUS_FAIL;
-        }
-
-        ret = this->Camera->setPropertyExtension(PROPERTY_TYPE_EXTENSION::PROPERTY_EXT_CONTRAST_MIN, value);
-        if (ret != ERROR_CODE::SUCCESS)
-        {
-            LOG_ERROR("Failed to set camera internal parameters: " << convertErrorCode(ret));
-            return PLUS_FAIL;
-        }
-        this->External->InternalUpdateRate = this->DepthStream.StreamProps.fps;
-        this->External->AcquisitionRate = this->DepthStream.StreamProps.fps;
-
-        return PLUS_SUCCESS;
+      this->AvailableStreamsFlag |= RevoSourceType::PCL;
     }
 
-    PlusStatus Connect()
+    if ((this->AvailableStreamsFlag & RevoSourceType::PCL) && !(this->AvailableStreamsFlag & RevoSourceType::DEPTH))
     {
-        auto ret = this->Camera->connect();
-        if (ret != ERROR_CODE::SUCCESS)
+      LOG_ERROR("Invalid configuration: PCL stream is required but no Depth stream set");
+      return PLUS_FAIL;
+    }
+
+    return PLUS_SUCCESS;
+  }
+
+  PlusStatus UpdateDepthStreamConfig()
+  {
+    std::vector<StreamInfo> streamProps;
+    this->Camera->getStreamInfos(STREAM_TYPE::STREAM_TYPE_DEPTH, streamProps);
+
+    bool foundMatchingConfig{false};
+    for (auto streamProp : streamProps)
+    {
+      LOG_TRACE("New stream configuration for format: " << streamProp.format);
+      if (streamProp.format == this->DepthStream.StreamProps.format)
+      {
+        LOG_INFO("New depth stream compliant configuration: " << streamProp.width << "x" << streamProp.height << "@" << streamProp.fps);
+        if (this->DepthStream.StreamProps.width != streamProp.width)
         {
-            LOG_ERROR("Failed to connect camera: " << convertErrorCode(ret));
-            return PLUS_FAIL;
+          continue;
         }
 
-        return PLUS_SUCCESS;
-    }
-
-    PlusStatus Disconnect()
-    {
-        auto ret = this->Camera->disconnect();
-        if (ret != ERROR_CODE::SUCCESS)
+        if (this->DepthStream.StreamProps.fps > streamProp.fps)
         {
-            LOG_ERROR("Failed to disconnect camera: " << convertErrorCode(ret));
-            return PLUS_FAIL;
+          this->DepthStream.StreamProps.fps = streamProp.fps;
+          LOG_WARNING("Expected frame rate too high for current bandwidth. Actual framerate will be @" << streamProp.fps << " fps.");
         }
 
-        return PLUS_SUCCESS;
+        this->DepthStream.StreamProps.height = streamProp.height;
+        foundMatchingConfig = true;
+        break;
+      }
     }
 
-    PlusStatus Start()
+    if (!foundMatchingConfig)
     {
-        auto ret = this->Camera->startStream(STREAM_TYPE::STREAM_TYPE_DEPTH, this->DepthStream.StreamProps);
-        if (ret != ERROR_CODE::SUCCESS)
+      LOG_ERROR("No matching configuration found");
+      LOG_ERROR("Available configurations:");
+      for (auto streamProp : streamProps)
+      {
+        if (streamProp.format == this->DepthStream.StreamProps.format)
         {
-            LOG_ERROR("Failed to start camera: " << convertErrorCode(ret));
-            return PLUS_FAIL;
+          LOG_ERROR("- " << streamProp.width << "x" << streamProp.height << "@" << streamProp.fps);
         }
-
-        return PLUS_SUCCESS;
+      }
+      return PLUS_FAIL;
     }
 
-    PlusStatus Stop()
+    this->Camera->getIntrinsics(STREAM_TYPE::STREAM_TYPE_DEPTH, this->DepthStream.Intr);
+    this->Camera->getExtrinsics(this->DepthStream.Extr);
+
+    PropertyExtension value;
+    value.depthRange.min = this->DepthStream.DepthRange[0];
+    value.depthRange.max = this->DepthStream.DepthRange[1];
+    value.algorithmContrast = 5;
+
+    auto ret = this->Camera->setPropertyExtension(PROPERTY_TYPE_EXTENSION::PROPERTY_EXT_DEPTH_RANGE, value);
+    if (ret != ERROR_CODE::SUCCESS)
     {
-        auto ret = this->Camera->stopStream(STREAM_TYPE::STREAM_TYPE_DEPTH);
-        if (ret != ERROR_CODE::SUCCESS)
-        {
-            LOG_ERROR("Failed to stop camera: " << convertErrorCode(ret));
-            return PLUS_FAIL;
-        }
-
-        return PLUS_SUCCESS;
+      LOG_ERROR("Failed to set camera depth range: " << convertErrorCode(ret));
+      return PLUS_FAIL;
     }
 
-    void Update()
+    return PLUS_SUCCESS;
+  }
+
+  PlusStatus UpdatePCLStreamConfig()
+  {
+    this->PCLStream.StreamProps = this->DepthStream.StreamProps;
+    return PLUS_SUCCESS;
+  }
+
+  PlusStatus UpdateConfig()
+  {
+    if ((this->AvailableStreamsFlag & RevoSourceType::DEPTH) && this->UpdateDepthStreamConfig() != PLUS_SUCCESS)
     {
-        this->DepthFrame.reset();
-        auto ret = this->Camera->getFrame(STREAM_TYPE::STREAM_TYPE_DEPTH, DepthFrame);
-        if (ret != ERROR_CODE::SUCCESS)
-        {
-            LOG_ERROR("Failed to retrieve frame: " << convertErrorCode(ret));
-        }
+      return PLUS_FAIL;
     }
 
-    bool IsFrameValid() const
+    if ((this->AvailableStreamsFlag & RevoSourceType::PCL) && this->UpdatePCLStreamConfig() != PLUS_SUCCESS)
     {
-        return this->DepthFrame && !(this->DepthFrame->empty()) && (this->DepthFrame->getWidth() == this->DepthStream.StreamProps.width) &&
-               (this->DepthFrame->getHeight() == this->DepthStream.StreamProps.height);
+      return PLUS_FAIL;
     }
+
+    this->External->InternalUpdateRate = this->DepthStream.StreamProps.fps;
+    this->External->AcquisitionRate = this->DepthStream.StreamProps.fps;
+
+    return PLUS_SUCCESS;
+  }
+
+  PlusStatus Connect()
+  {
+    auto ret = this->Camera->connect();
+    if (ret != ERROR_CODE::SUCCESS)
+    {
+      LOG_ERROR("Failed to connect camera: " << convertErrorCode(ret));
+      return PLUS_FAIL;
+    }
+
+    return PLUS_SUCCESS;
+  }
+
+  PlusStatus Disconnect()
+  {
+    auto ret = this->Camera->disconnect();
+    if (ret != ERROR_CODE::SUCCESS)
+    {
+      LOG_ERROR("Failed to disconnect camera: " << convertErrorCode(ret));
+      return PLUS_FAIL;
+    }
+
+    return PLUS_SUCCESS;
+  }
+
+  PlusStatus Start()
+  {
+    auto ret = this->Camera->startStream(STREAM_TYPE::STREAM_TYPE_DEPTH, this->DepthStream.StreamProps);
+    if (ret != ERROR_CODE::SUCCESS)
+    {
+      LOG_ERROR("Failed to start camera: " << convertErrorCode(ret));
+      return PLUS_FAIL;
+    }
+
+    return PLUS_SUCCESS;
+  }
+
+  PlusStatus Stop()
+  {
+    auto ret = this->Camera->stopStream(STREAM_TYPE::STREAM_TYPE_DEPTH);
+    if (ret != ERROR_CODE::SUCCESS)
+    {
+      LOG_ERROR("Failed to stop camera: " << convertErrorCode(ret));
+      return PLUS_FAIL;
+    }
+
+    return PLUS_SUCCESS;
+  }
+
+  void Update()
+  {
+    if (this->AvailableStreamsFlag & RevoSourceType::DEPTH)
+    {
+      this->DepthFrame.reset();
+      auto ret = this->Camera->getFrame(STREAM_TYPE::STREAM_TYPE_DEPTH, DepthFrame);
+      if (ret != ERROR_CODE::SUCCESS)
+      {
+        LOG_ERROR("Failed to retrieve frame: " << convertErrorCode(ret));
+      }
+    }
+
+    if ((this->AvailableStreamsFlag & RevoSourceType::PCL) && this->IsDepthFrameValid())
+    {
+      float scale = 0.1f;
+      PropertyExtension value;
+      if (SUCCESS ==
+          this->Camera->getPropertyExtension(PROPERTY_EXT_DEPTH_SCALE, value))
+      {
+        scale = value.depthScale;
+      }
+
+      cs::Pointcloud pc;
+      pc.generatePoints(reinterpret_cast<unsigned short*>(const_cast<char*>(this->DepthFrame->getData())),
+                        this->DepthFrame->getWidth(), this->DepthFrame->getHeight(),
+                        scale, &this->DepthStream.Intr, nullptr, &this->DepthStream.Extr);
+      auto vertices = pc.getVertices();
+      this->PCLFrame.reset(new float[vertices.size() * 3]);
+
+      for (std::size_t idx = 0; idx < vertices.size(); ++idx)
+      {
+        this->PCLFrame[idx * 3] = vertices[idx].x;
+        this->PCLFrame[idx * 3 + 1] = vertices[idx].y;
+        this->PCLFrame[idx * 3 + 2] = vertices[idx].z;
+      }
+    }
+  }
+
+  bool IsDepthFrameValid() const
+  {
+    return this->DepthFrame && !(this->DepthFrame->empty()) && (this->DepthFrame->getWidth() == this->DepthStream.StreamProps.width) &&
+           (this->DepthFrame->getHeight() == this->DepthStream.StreamProps.height);
+  }
 };
 
 //----------------------------------------------------------------------------
 vtkPlusRevopoint3DCamera::vtkPlusRevopoint3DCamera()
-    : Internal(new vtkInternal(this))
+  : Internal(new vtkInternal(this))
 {
-    this->RequireImageOrientationInConfiguration = true;
-    this->StartThreadForInternalUpdates = true;
+  this->RequireImageOrientationInConfiguration = true;
+  this->StartThreadForInternalUpdates = true;
 }
 
 //----------------------------------------------------------------------------
 vtkPlusRevopoint3DCamera::~vtkPlusRevopoint3DCamera()
 {
-    delete this->Internal;
-    this->Internal = nullptr;
+  delete this->Internal;
+  this->Internal = nullptr;
 }
 
 //----------------------------------------------------------------------------
 void vtkPlusRevopoint3DCamera::PrintSelf(ostream& os, vtkIndent indent)
 {
-    this->Superclass::PrintSelf(os, indent);
+  this->Superclass::PrintSelf(os, indent);
 
-    os << indent << "Revopoint Surface Configuration" << std::endl;
+  os << indent << "Revopoint Surface Configuration" << std::endl;
+
+  if (this->Internal->AvailableStreamsFlag & RevoSourceType::DEPTH)
+  {
+    os << indent << "DEPTH Stream" << std::endl;
     os << indent << "Source: " << this->Internal->DepthStream.Id << std::endl;
     os << indent << indent << "Frame Rate: " << this->Internal->DepthStream.StreamProps.fps << std::endl;
     os << indent << indent << "Frame Width: " << this->Internal->DepthStream.StreamProps.width << std::endl;
     os << indent << indent << "Frame Height: " << this->Internal->DepthStream.StreamProps.height << std::endl;
     os << indent << indent << "Depth Range: [" << this->Internal->DepthStream.DepthRange[0] << "," << Internal->DepthStream.DepthRange[1] << "]" << std::endl;
+  }
+
+  if (this->Internal->AvailableStreamsFlag & RevoSourceType::PCL)
+  {
+    os << indent << "PCL Stream" << std::endl;
+    os << indent << "Source: " << this->Internal->PCLStream.Id << std::endl;
+  }
 }
 
 //-----------------------------------------------------------------------------
 PlusStatus vtkPlusRevopoint3DCamera::ReadConfiguration(vtkXMLDataElement* rootConfigElement)
 {
-    XML_FIND_DEVICE_ELEMENT_REQUIRED_FOR_READING(deviceConfig, rootConfigElement);
-    XML_FIND_NESTED_ELEMENT_REQUIRED(dataSourcesElement, deviceConfig, "DataSources");
+  XML_FIND_DEVICE_ELEMENT_REQUIRED_FOR_READING(deviceConfig, rootConfigElement);
+  XML_FIND_NESTED_ELEMENT_REQUIRED(dataSourcesElement, deviceConfig, "DataSources");
 
-    LOG_TRACE("Reading custom configuration fields in " << dataSourcesElement->GetNumberOfNestedElements() << " nested elements");
+  LOG_TRACE("Reading custom configuration fields in " << dataSourcesElement->GetNumberOfNestedElements() << " nested elements");
 
-    for (int nestedElementIndex = 0; nestedElementIndex < dataSourcesElement->GetNumberOfNestedElements(); ++nestedElementIndex)
+  for (int nestedElementIndex = 0; nestedElementIndex < dataSourcesElement->GetNumberOfNestedElements(); ++nestedElementIndex)
+  {
+    vtkXMLDataElement* dataElement = dataSourcesElement->GetNestedElement(nestedElementIndex);
+    if (std::string(dataElement->GetName()) != "DataSource")
     {
-        vtkXMLDataElement* dataElement = dataSourcesElement->GetNestedElement(nestedElementIndex);
-        if (std::string(dataElement->GetName()) != "DataSource")
-        {
-            continue;
-        }
-
-        LOG_TRACE("Found a new data source");
-        if (dataElement->GetAttribute("Type") != nullptr && std::string(dataElement->GetAttribute("Type")) == "Video")
-        {
-            const char* toolId = dataElement->GetAttribute("Id");
-            if (toolId == nullptr)
-            {
-                LOG_ERROR("Failed to initialize Revopoint Surface DataSource: Id is missing");
-                return PLUS_FAIL;
-            }
-
-            LOG_TRACE("Data source name: " << toolId);
-
-            SurfaceStreamConfig stream;
-            stream.Id = toolId;
-            stream.DepthRange[0] = 5;
-            stream.DepthRange[1] = 500;
-            XML_READ_SCALAR_ATTRIBUTE_NONMEMBER_REQUIRED(int, FrameRate, stream.StreamProps.fps, dataElement);
-            XML_READ_SCALAR_ATTRIBUTE_NONMEMBER_REQUIRED(int, FrameWidth, stream.StreamProps.width, dataElement);
-            XML_READ_VECTOR_ATTRIBUTE_NONMEMBER_OPTIONAL(int, 2, DepthRange, stream.DepthRange, dataElement);
-
-            stream.StreamProps.format = STREAM_FORMAT::STREAM_FORMAT_Z16;
-            this->Internal->DepthStream = stream;
-            break;
-        }
-        else
-        {
-            LOG_ERROR("DataSource with unknown type.");
-            return PLUS_FAIL;
-        }
+      continue;
     }
 
-    if (this->Internal->DepthStream.Id.empty())
+    LOG_TRACE("Found a new data source");
+    if (dataElement->GetAttribute("Type") != nullptr && std::string(dataElement->GetAttribute("Type")) == "Video")
     {
-        LOG_ERROR("No DataSource configured.");
+      const char* toolId = dataElement->GetAttribute("Id");
+      if (toolId == nullptr)
+      {
+        LOG_ERROR("Failed to initialize Revopoint Surface DataSource: Id is missing");
         return PLUS_FAIL;
-    }
+      }
 
-    return PLUS_SUCCESS;
+      LOG_TRACE("Data source name: " << toolId);
+
+      RevoSourceType sourceType;
+      XML_READ_ENUM2_ATTRIBUTE_NONMEMBER_REQUIRED(FrameType, sourceType, dataElement, "DEPTH", RevoSourceType::DEPTH, "PCL", RevoSourceType::PCL);
+
+      if (sourceType == RevoSourceType::DEPTH)
+      {
+        DepthStreamConfig stream;
+        stream.Id = toolId;
+        stream.DepthRange[0] = 5;
+        stream.DepthRange[1] = 500;
+        XML_READ_SCALAR_ATTRIBUTE_NONMEMBER_REQUIRED(int, FrameRate, stream.StreamProps.fps, dataElement);
+        XML_READ_SCALAR_ATTRIBUTE_NONMEMBER_REQUIRED(int, FrameWidth, stream.StreamProps.width, dataElement);
+        XML_READ_VECTOR_ATTRIBUTE_NONMEMBER_OPTIONAL(int, 2, DepthRange, stream.DepthRange, dataElement);
+        stream.StreamProps.format = STREAM_FORMAT::STREAM_FORMAT_Z16;
+        this->Internal->DepthStream = stream;
+      }
+      else
+      {
+        this->Internal->PCLStream.Id = toolId;
+      }
+    }
+    else
+    {
+      LOG_ERROR("DataSource with unknown type.");
+      return PLUS_FAIL;
+    }
+  }
+
+  if (this->Internal->DepthStream.Id.empty())
+  {
+    LOG_ERROR("Required DEPTH type data source is missing.");
+    return PLUS_FAIL;
+  }
+
+  return PLUS_SUCCESS;
 }
 
 //-----------------------------------------------------------------------------
 PlusStatus vtkPlusRevopoint3DCamera::WriteConfiguration(vtkXMLDataElement* rootConfigElement)
 {
-    XML_FIND_DEVICE_ELEMENT_REQUIRED_FOR_WRITING(deviceConfig, rootConfigElement);
-    return PLUS_SUCCESS;
+  XML_FIND_DEVICE_ELEMENT_REQUIRED_FOR_WRITING(deviceConfig, rootConfigElement);
+  return PLUS_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusRevopoint3DCamera::NotifyConfigured()
+{
+  return this->Internal->CheckBasicConfig();
 }
 
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusRevopoint3DCamera::InternalConnect()
 {
+  if (this->Internal->AvailableStreamsFlag & RevoSourceType::DEPTH)
+  {
     GetVideoSource(this->Internal->DepthStream.Id.c_str(), this->Internal->DepthStream.Source);
     if (Internal->DepthStream.Source == nullptr)
     {
-        LOG_ERROR("Invalid source for tool id " << this->Internal->DepthStream.Id);
-        return PLUS_FAIL;
+      LOG_ERROR("Invalid source for tool id " << this->Internal->DepthStream.Id);
+      return PLUS_FAIL;
     }
+  }
 
-    if (this->Internal->Connect() != PLUS_SUCCESS)
+  if (this->Internal->AvailableStreamsFlag & RevoSourceType::PCL)
+  {
+    GetVideoSource(this->Internal->PCLStream.Id.c_str(), this->Internal->PCLStream.Source);
+    if (Internal->PCLStream.Source == nullptr)
     {
-        return PLUS_FAIL;
+      LOG_ERROR("Invalid source for tool id " << this->Internal->PCLStream.Id);
+      return PLUS_FAIL;
     }
+  }
 
-    // Checking for configuration needs a connected camera
-    return this->Internal->UpdateConfig();
+  if (this->Internal->Connect() != PLUS_SUCCESS)
+  {
+    return PLUS_FAIL;
+  }
+
+  // Checking for configuration needs a connected camera
+  return this->Internal->UpdateConfig();
 }
 
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusRevopoint3DCamera::InternalDisconnect()
 {
-    return this->Internal->Disconnect();
+  return this->Internal->Disconnect();
 }
 
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusRevopoint3DCamera::InternalStartRecording()
 {
-    this->FrameNumber = 0;
+  this->FrameNumber = 0;
 
-    return this->Internal->Start();
+  return this->Internal->Start();
 }
 
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusRevopoint3DCamera::InternalStopRecording()
 {
-    return this->Internal->Stop();
+  return this->Internal->Stop();
 }
 
 //----------------------------------------------------------------------------
@@ -355,39 +478,61 @@ PlusStatus vtkPlusRevopoint3DCamera::InternalStopRecording()
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusRevopoint3DCamera::InternalUpdate()
 {
-    this->Internal->Update();
+  this->Internal->Update();
 
-    if (Internal->DepthStream.Source->GetNumberOfItems() == 0)
+  if ((this->Internal->AvailableStreamsFlag & RevoSourceType::DEPTH) && this->Internal->DepthStream.Source->GetNumberOfItems() == 0)
+  {
+    // depth output is raw depth data
+    LOG_TRACE("Setting up depth frame");
+    this->Internal->DepthStream.Source->SetImageType(US_IMG_BRIGHTNESS);
+    this->Internal->DepthStream.Source->SetPixelType(VTK_TYPE_UINT16);
+    this->Internal->DepthStream.Source->SetNumberOfScalarComponents(1);
+    this->Internal->DepthStream.Source->SetInputFrameSize(this->Internal->DepthStream.StreamProps.width, this->Internal->DepthStream.StreamProps.height, 1);
+  }
+  
+  if ((this->Internal->AvailableStreamsFlag & RevoSourceType::PCL) && this->Internal->PCLStream.Source->GetNumberOfItems() == 0)
+  {
+    LOG_TRACE("Setting up pcl frame");
+    this->Internal->PCLStream.Source->SetImageType(US_IMG_BRIGHTNESS);
+    this->Internal->PCLStream.Source->SetPixelType(VTK_TYPE_FLOAT32);
+    this->Internal->PCLStream.Source->SetNumberOfScalarComponents(3);
+    this->Internal->PCLStream.Source->SetInputFrameSize(this->Internal->PCLStream.StreamProps.width, this->Internal->PCLStream.StreamProps.height, 1);
+  }
+
+  if (this->Internal->AvailableStreamsFlag & RevoSourceType::DEPTH)
+  {
+    if (!this->Internal->IsDepthFrameValid())
     {
-        // depth output is raw depth data
-        LOG_TRACE("Setting up depth frame");
-        this->Internal->DepthStream.Source->SetImageType(US_IMG_BRIGHTNESS);
-        this->Internal->DepthStream.Source->SetPixelType(VTK_TYPE_UINT16);
-        this->Internal->DepthStream.Source->SetNumberOfScalarComponents(1);
-        this->Internal->DepthStream.Source->SetInputFrameSize(this->Internal->DepthStream.StreamProps.width, this->Internal->DepthStream.StreamProps.height, 1);
+      if (this->Internal->DepthStream.Source->GetNumberOfItems() == 0)
+      {
+        LOG_TRACE("Waiting for Revopoint Surface depth images");
+      }
+      else
+      {
+        LOG_WARNING("Failed to get Revopoint Surface depth image");
+      }
+      return PLUS_FAIL;
     }
-
-    if (!this->Internal->IsFrameValid())
-    {
-        if (this->Internal->DepthStream.Source->GetNumberOfItems() == 0)
-        {
-            LOG_TRACE("Waiting for Revopoint Surface depth images");
-        }
-        else
-        {
-            LOG_WARNING("Failed to get Revopoint Surface depth image");
-        }
-        return PLUS_FAIL;
-    }
-
     FrameSizeType frameSizeDepth = {static_cast<unsigned>(this->Internal->DepthStream.StreamProps.width), static_cast<unsigned>(this->Internal->DepthStream.StreamProps.height), 1};
-    if (this->Internal->DepthStream.Source->AddItem((void*)this->Internal->DepthFrame->getData(FRAME_DATA_FORMAT::FRAME_DATA_FORMAT_Z16), this->Internal->DepthStream.Source->GetInputImageOrientation(), frameSizeDepth, VTK_TYPE_UINT16, 1, US_IMG_BRIGHTNESS, 0, this->FrameNumber) == PLUS_FAIL)
+    if (this->Internal->DepthStream.Source->AddItem(reinterpret_cast<void*>(const_cast<char*>(this->Internal->DepthFrame->getData(FRAME_DATA_FORMAT::FRAME_DATA_FORMAT_Z16))), this->Internal->DepthStream.Source->GetInputImageOrientation(), frameSizeDepth, VTK_TYPE_UINT16, 1, US_IMG_BRIGHTNESS, 0, this->FrameNumber) == PLUS_FAIL)
     {
-        LOG_ERROR("Unable to send DEPTH image. Skipping frame.");
-        return PLUS_FAIL;
+      LOG_ERROR("Unable to send DEPTH image. Skipping frame.");
+      return PLUS_FAIL;
     }
     this->Modified();
+  }
 
-    this->FrameNumber++;
-    return PLUS_SUCCESS;
+  if (this->Internal->AvailableStreamsFlag & RevoSourceType::PCL)
+  {
+    FrameSizeType frameSizeDepth = {static_cast<unsigned>(this->Internal->PCLStream.StreamProps.width), static_cast<unsigned>(this->Internal->PCLStream.StreamProps.height), 1};
+    if (this->Internal->PCLStream.Source->AddItem(reinterpret_cast<void*>(this->Internal->PCLFrame.get()), this->Internal->PCLStream.Source->GetInputImageOrientation(), frameSizeDepth, VTK_TYPE_FLOAT32, 3, US_IMG_BRIGHTNESS, 0, this->FrameNumber) == PLUS_FAIL)
+    {
+      LOG_ERROR("Unable to send PCL image. Skipping frame.");
+      return PLUS_FAIL;
+    }
+    this->Modified();
+  }
+
+  this->FrameNumber++;
+  return PLUS_SUCCESS;
 }

--- a/src/PlusDataCollection/Revopoint3DCamera/vtkPlusRevopoint3DCamera.h
+++ b/src/PlusDataCollection/Revopoint3DCamera/vtkPlusRevopoint3DCamera.h
@@ -18,53 +18,56 @@
 class vtkPlusDataCollectionExport vtkPlusRevopoint3DCamera : public vtkPlusDevice
 {
 public:
-    static vtkPlusRevopoint3DCamera* New();
+  static vtkPlusRevopoint3DCamera* New();
 
-    vtkTypeMacro(vtkPlusRevopoint3DCamera, vtkPlusDevice);
-    virtual void PrintSelf(ostream& os, vtkIndent indent);
+  vtkTypeMacro(vtkPlusRevopoint3DCamera, vtkPlusDevice);
+  virtual void PrintSelf(ostream& os, vtkIndent indent);
 
-    /*! Read configuration from xml data */
-    virtual PlusStatus ReadConfiguration(vtkXMLDataElement* config);
-    /*! Write configuration to xml data */
-    PlusStatus WriteConfiguration(vtkXMLDataElement* config);
+  /*! Read configuration from xml data */
+  virtual PlusStatus ReadConfiguration(vtkXMLDataElement* config);
+  /*! Write configuration to xml data */
+  PlusStatus WriteConfiguration(vtkXMLDataElement* config);
 
-    /*!
-    Record incoming data at the specified acquisition rate.  The recording
-    continues indefinitely until StopRecording() is called.
-    */
-    PlusStatus InternalStartRecording();
+  /*!
+  Record incoming data at the specified acquisition rate.  The recording
+  continues indefinitely until StopRecording() is called.
+  */
+  PlusStatus InternalStartRecording();
 
-    /*! Stop recording */
-    PlusStatus InternalStopRecording();
+  /*! Stop recording */
+  PlusStatus InternalStopRecording();
 
-    /*! Is this device a tracker */
-    bool IsTracker() const
-    {
-        return false;
-    }
-    bool IsVirtual() const
-    {
-        return false;
-    }
+  /*! Is this device a tracker */
+  bool IsTracker() const
+  {
+    return false;
+  }
+  bool IsVirtual() const
+  {
+    return false;
+  }
 
-    /*! Get an update from the tracking system and push the new transforms to the tools. This function is called by the tracker thread.*/
-    virtual PlusStatus InternalUpdate();
+  /*! Get an update from the tracking system and push the new transforms to the tools. This function is called by the tracker thread.*/
+  virtual PlusStatus InternalUpdate();
 
-    virtual PlusStatus InternalConnect();
-    virtual PlusStatus InternalDisconnect();
+  virtual PlusStatus InternalConnect();
+  virtual PlusStatus InternalDisconnect();
+
+  /*! Verify the device is correctly configured */
+  virtual PlusStatus NotifyConfigured();
 
 protected:
-    vtkPlusRevopoint3DCamera();
-    ~vtkPlusRevopoint3DCamera();
+  vtkPlusRevopoint3DCamera();
+  ~vtkPlusRevopoint3DCamera();
 
 private:
-    vtkPlusRevopoint3DCamera(const vtkPlusRevopoint3DCamera&);
-    void operator=(const vtkPlusRevopoint3DCamera&);
+  vtkPlusRevopoint3DCamera(const vtkPlusRevopoint3DCamera&);
+  void operator=(const vtkPlusRevopoint3DCamera&);
 
-    class vtkInternal;
-    vtkInternal* Internal;
+  class vtkInternal;
+  vtkInternal* Internal;
 
-    unsigned long FrameNumber;
+  unsigned long FrameNumber;
 };
 
 #endif

--- a/src/PlusDataCollection/Testing/vtkAzureKinectTest.cxx
+++ b/src/PlusDataCollection/Testing/vtkAzureKinectTest.cxx
@@ -3,7 +3,7 @@
   Copyright (c) Laboratory for Percutaneous Surgery. All rights reserved.
   See License.txt for details.
 
-  Developed by MACBIOIDI & IACTEC group  
+  Developed by MACBIOIDI & IACTEC group
 =========================================================Plus=header=end*/
 
 #include "PlusConfigure.h"
@@ -21,43 +21,144 @@
 #include "vtkRenderWindow.h"
 #include "vtkRenderWindowInteractor.h"
 #include "vtkRenderer.h"
-#include "igtlOSUtil.h" 
+#include "vtkRendererCollection.h"
+#include "vtkPolyDataMapper.h"
+#include "vtkPolyData.h"
+#include "vtkPoints.h"
+#include "vtkVertexGlyphFilter.h"
+#include "vtkPointData.h"
+#include "vtkActor.h"
+#include "vtkUnsignedCharArray.h"
+#include "igtlOSUtil.h"
+
 
 void PrintLogsCallback(vtkObject* obj, unsigned long eid, void* clientdata, void* calldata);
 
-namespace {
-class vtkMyCallback : public vtkCommand
+namespace
 {
-public:
-  static vtkMyCallback* New()
+  class vtkMyImageViewerCallback : public vtkCommand
   {
-    return new vtkMyCallback;
-  }
+  public:
+    static vtkMyImageViewerCallback* New()
+    {
+      return new vtkMyImageViewerCallback;
+    }
 
-  virtual void Execute(vtkObject* caller, unsigned long, void*)
+    virtual void Execute(vtkObject* caller, unsigned long, void*)
+    {
+      if (m_Channel->GetVideoDataAvailable())
+      {
+        m_Viewer->SetInputData(m_Channel->GetBrightnessOutput());
+      }
+
+      //update the timer so it will trigger again
+      m_Viewer->Render();
+      m_Interactor->CreateTimer(VTKI_TIMER_UPDATE);
+    }
+
+    vtkRenderWindowInteractor* m_Interactor{nullptr};
+    vtkImageViewer* m_Viewer{nullptr};
+    vtkPlusChannel* m_Channel{nullptr};
+  };
+
+  class vtkMyMeshViewerCallback : public vtkCommand
   {
-    m_Viewer->Render();
+  public:
+    static vtkMyMeshViewerCallback* New()
+    {
+      return new vtkMyMeshViewerCallback;
+    }
 
-    //update the timer so it will trigger again
-    m_Interactor->CreateTimer(VTKI_TIMER_UPDATE);
-  }
+    virtual void Execute(vtkObject* caller, unsigned long, void*)
+    {
+      static bool firstDisplay{true};
+      vtkImageData* texture{nullptr};
 
-  vtkRenderWindowInteractor* m_Interactor;
-  vtkImageViewer* m_Viewer;
+      if (m_Texture && m_Texture->GetVideoDataAvailable())
+      {
+        texture = m_Texture->GetBrightnessOutput();
+      }
 
-private:
+      if (m_Channel->GetVideoDataAvailable())
+      {
+        m_Mapper->SetInputData(ConvertToPCL(m_Channel->GetBrightnessOutput(), texture));
+        m_Mapper->Modified();
 
-  vtkMyCallback()
-  {
-    m_Interactor = NULL;
-    m_Viewer = NULL;
-  }
-};
+        if (firstDisplay)
+        {
+          m_Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer()->ResetCamera();
+          firstDisplay = false;
+        }
+      }
+
+      m_Interactor->Render();
+    }
+
+    vtkRenderWindowInteractor* m_Interactor{nullptr};
+    vtkPlusChannel* m_Channel{nullptr};
+    vtkPolyDataMapper* m_Mapper{nullptr};
+    vtkPlusChannel* m_Texture{nullptr};
+
+  private:
+    vtkSmartPointer<vtkPolyData> ConvertToPCL(vtkImageData* imageData, vtkImageData* texture)
+    {
+      if (imageData->GetNumberOfScalarComponents() != 3)
+      {
+        return nullptr;
+      }
+
+      int* dims = imageData->GetDimensions();
+      auto points = vtkSmartPointer<vtkPoints>::New();
+      auto colors = vtkSmartPointer<vtkUnsignedCharArray>::New();
+      colors->SetNumberOfComponents(3);
+      colors->SetName("Colors");
+
+      for (int x = 0; x < dims[0]; x++)
+      {
+        for (int y = 0; y < dims[1]; y++)
+        {
+          for (int z = 0; z < dims[2]; z++)
+          {
+            auto* coords =
+              static_cast<int16_t*>(imageData->GetScalarPointer(x, y, z));
+
+            if (coords[2] == 0)
+            {
+              continue;
+            }
+
+            points->InsertNextPoint(coords[0], coords[1], coords[2]);
+
+            if (texture)
+            {
+              auto* color =
+                static_cast<uint8_t*>(texture->GetScalarPointer(x, y, z));
+              colors->InsertNextTypedTuple(color);
+            }
+            else
+            {
+              uint8_t color[3] = {255, 255, 255};
+              colors->InsertNextTypedTuple(color);
+            }
+          }
+        }
+      }
+
+      auto poly = vtkSmartPointer<vtkPolyData>::New();
+      poly->SetPoints(points);
+      poly->GetPointData()->SetScalars(colors);
+
+      auto vertexGenerator = vtkSmartPointer<vtkVertexGlyphFilter>::New();
+      vertexGenerator->SetInputData(poly);
+      vertexGenerator->Update();
+
+      return vertexGenerator->GetOutput();
+    }
+  };
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
-
   bool printHelp(false);
   std::string inputConfigFileName = "Testing/PlusDeviceSet_DataCollectionOnly_AzureKinect.xml";
 
@@ -67,12 +168,12 @@ int main(int argc, char **argv)
   int verboseLevel = vtkPlusLogger::LOG_LEVEL_UNDEFINED;
   bool renderingOff(false);
 
-  args.AddArgument("--help", vtksys::CommandLineArguments::NO_ARGUMENT, &printHelp, "Print this help.");  
-  args.AddArgument("--verbose", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &verboseLevel, "Verbose level (1=error only, 2=warning, 3=info, 4=debug, 5=trace)");  
+  args.AddArgument("--help", vtksys::CommandLineArguments::NO_ARGUMENT, &printHelp, "Print this help.");
+  args.AddArgument("--verbose", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &verboseLevel, "Verbose level (1=error only, 2=warning, 3=info, 4=debug, 5=trace)");
   args.AddArgument("--config-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &inputConfigFileName, "Config file containing the device configuration.");
   args.AddArgument("--rendering-off", vtksys::CommandLineArguments::NO_ARGUMENT, &renderingOff, "Run test without rendering.");
-  
-  if ( !args.Parse() )
+
+  if (!args.Parse())
   {
     std::cerr << "Problem parsing arguments" << std::endl;
     std::cout << "\n\nHelp:" << args.GetHelp() << std::endl;
@@ -80,95 +181,149 @@ int main(int argc, char **argv)
   }
 
   vtkPlusLogger::Instance()->SetLogLevel(verboseLevel);
-  
-  if ( printHelp ) 
+
+  if (printHelp)
   {
     std::cout << "\n\nHelp:" << args.GetHelp() << std::endl;
-    exit(EXIT_SUCCESS); 
+    exit(EXIT_SUCCESS);
   }
 
   vtkNew<vtkPlusAzureKinect> azureKinectDevice;
   azureKinectDevice->SetDeviceId("VideoDevice");
 
-  if (!vtksys::SystemTools::FileExists(inputConfigFileName)) {
-    LOG_ERROR( "Bad configuration file: " << inputConfigFileName); 
-    exit(EXIT_FAILURE); 
+  if (!vtksys::SystemTools::FileExists(inputConfigFileName))
+  {
+    LOG_ERROR("Bad configuration file: " << inputConfigFileName);
+    exit(EXIT_FAILURE);
   }
 
   LOG_DEBUG("Reading config file: " << inputConfigFileName);
   auto* configRead = vtkXMLUtilities::ReadElementFromFile(inputConfigFileName.c_str());
-  
-  if (!configRead) {
-    LOG_ERROR( "Failed to read configuration file"); 
-    exit(EXIT_FAILURE); 
+
+  if (!configRead)
+  {
+    LOG_ERROR("Failed to read configuration file");
+    exit(EXIT_FAILURE);
   }
 
   LOG_TRACE("Config file: " << *configRead);
   if (azureKinectDevice->ReadConfiguration(configRead) != PLUS_SUCCESS)
   {
-    LOG_ERROR( "Failed to read configuration"); 
-    exit(EXIT_FAILURE); 
+    LOG_ERROR("Failed to read configuration");
+    exit(EXIT_FAILURE);
   }
 
   if (azureKinectDevice->NotifyConfigured() != PLUS_SUCCESS)
   {
-    LOG_ERROR( "Invalid configuration"); 
-    exit(EXIT_FAILURE); 
-  }
-
-  azureKinectDevice->CreateDefaultOutputChannel(NULL, true);
-  vtkPlusDataSource* videoSource = NULL;
-  if (azureKinectDevice->GetFirstActiveOutputVideoSource(videoSource) != PLUS_SUCCESS)
-  {
-    LOG_ERROR("Unable to retrieve the video source.");
+    LOG_ERROR("Invalid configuration");
     exit(EXIT_FAILURE);
   }
-  videoSource->SetInputImageOrientation(US_IMG_ORIENT_UN);
+
+  vtkPlusChannel* rgbChannel{nullptr};
+  azureKinectDevice->GetOutputChannelByName(rgbChannel, "VideoStreamRGB");
+
+  vtkPlusChannel* depthChannel{nullptr};
+  azureKinectDevice->GetOutputChannelByName(depthChannel, "VideoStreamDEPTH");
+
+
+  vtkPlusChannel* pclChannel{nullptr};
+  azureKinectDevice->GetOutputChannelByName(pclChannel, "VideoStreamPCL");
 
   vtkIndent indent;
   azureKinectDevice->PrintSelf(std::cout, indent);
 
-  // Add an observer to warning and error events for redirecting it to the stdout 
+  // Add an observer to warning and error events for redirecting it to the stdout
   vtkNew<vtkCallbackCommand> callbackCommand;
   callbackCommand->SetCallback(PrintLogsCallback);
-  azureKinectDevice->AddObserver("WarningEvent", callbackCommand); 
-  azureKinectDevice->AddObserver("ErrorEvent", callbackCommand); 
-  
-  if (azureKinectDevice->Connect() != PLUS_SUCCESS) {
-    LOG_ERROR( "Failed to connect"); 
-    exit(EXIT_FAILURE); 
+  azureKinectDevice->AddObserver("WarningEvent", callbackCommand);
+  azureKinectDevice->AddObserver("ErrorEvent", callbackCommand);
+
+  if (azureKinectDevice->Connect() != PLUS_SUCCESS)
+  {
+    LOG_ERROR("Failed to connect");
+    exit(EXIT_FAILURE);
   }
 
   if (azureKinectDevice->StartRecording() != PLUS_SUCCESS)
   {
-    LOG_INFO("Failed to start recording"); 
-    exit(EXIT_FAILURE); 
+    LOG_INFO("Failed to start recording");
+    exit(EXIT_FAILURE);
   }
 
-  if (!renderingOff) {
-    auto viewer = vtkSmartPointer<vtkImageViewer>::New();
-    viewer->SetInputConnection(azureKinectDevice->GetOutputPort());   //set image to the render and window
-    viewer->SetColorWindow(255);
-    viewer->SetColorLevel(127.5);
-    viewer->SetZSlice(0);
+  if (!renderingOff)
+  {
+    auto imageViewer = vtkSmartPointer<vtkImageViewer>::New();
+    imageViewer->SetColorWindow(255);
+    imageViewer->SetColorLevel(127.5);
+    imageViewer->SetZSlice(0);
 
-    //Create the interactor that handles the event loop
-    vtkSmartPointer<vtkRenderWindowInteractor> iren = vtkSmartPointer<vtkRenderWindowInteractor>::New();
-    iren->SetRenderWindow(viewer->GetRenderWindow());
-    viewer->SetupInteractor(iren);
+    // Create the interactor that handles the event loop
+    auto imageInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+    imageInteractor->SetRenderWindow(imageViewer->GetRenderWindow());
+    imageViewer->SetupInteractor(imageInteractor);
 
-    viewer->Render(); //must be called after iren and viewer are linked or there will be problems
+    imageViewer->Render(); //must be called after iren and viewer are linked or there will be problems
 
     // Establish timer event and create timer to update the live image
-    auto call = vtkSmartPointer<vtkMyCallback>::New();
-    call->m_Interactor = iren;
-    call->m_Viewer = viewer;
-    iren->AddObserver(vtkCommand::TimerEvent, call);
-    iren->CreateTimer(VTKI_TIMER_FIRST);
+    auto call = vtkSmartPointer<vtkMyImageViewerCallback>::New();
+    call->m_Interactor = imageInteractor;
+    call->m_Viewer = imageViewer;
+    imageInteractor->AddObserver(vtkCommand::TimerEvent, call);
+    imageInteractor->CreateTimer(VTKI_TIMER_FIRST);
 
-    //iren must be initialized so that it can handle events
-    iren->Initialize();
-    iren->Start();
+    // Display rgb image
+    if (rgbChannel)
+    {
+      call->m_Channel = rgbChannel;
+      imageInteractor->Initialize();
+      imageInteractor->Start();
+    }
+
+    // Display depth image
+    if (depthChannel)
+    {
+      call->m_Channel = depthChannel;
+      imageInteractor->Start();
+    }
+
+    imageInteractor->GetRenderWindow()->Finalize();
+
+    // Display points cloud
+    if (pclChannel)
+    {
+      auto pclRenderer = vtkSmartPointer<vtkRenderer>::New();
+      auto pclRenderWindow = vtkSmartPointer<vtkRenderWindow>::New();
+      pclRenderWindow->SetSize(640, 480);
+      pclRenderWindow->AddRenderer(pclRenderer);
+      auto pclInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+      pclInteractor->SetRenderWindow(pclRenderWindow);
+
+      auto mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+      mapper->SetInputData(vtkSmartPointer<vtkPolyData>::New());
+      auto actor = vtkSmartPointer<vtkActor>::New();
+      actor->SetMapper(mapper);
+      pclRenderer->SetBackground(0., 0., 0.);
+      pclRenderer->AddActor(actor);
+
+      pclRenderWindow->Render();
+      pclInteractor->Initialize();
+
+      auto call2 = vtkSmartPointer<vtkMyMeshViewerCallback>::New();
+      call2->m_Interactor = pclInteractor;
+      call2->m_Mapper = mapper;
+      call2->m_Channel = pclChannel;
+
+      if (rgbChannel)
+      {
+        call2->m_Texture = rgbChannel;
+      }
+
+      pclInteractor->AddObserver(vtkCommand::TimerEvent, call2);
+      pclInteractor->CreateRepeatingTimer(100);
+
+      pclInteractor->Start();
+      pclInteractor->GetRenderWindow()->Finalize();
+    }
   }
   else
   {
@@ -177,28 +332,29 @@ int main(int argc, char **argv)
 
   if (azureKinectDevice->StopRecording() != PLUS_SUCCESS)
   {
-    LOG_INFO("Failed to stop recording"); 
-    exit(EXIT_FAILURE); 
+    LOG_INFO("Failed to stop recording");
+    exit(EXIT_FAILURE);
   }
 
-  if (azureKinectDevice->Disconnect() != PLUS_SUCCESS) {
-    LOG_ERROR( "Failed to disconnect"); 
-    exit(EXIT_FAILURE); 
+  if (azureKinectDevice->Disconnect() != PLUS_SUCCESS)
+  {
+    LOG_ERROR("Failed to disconnect");
+    exit(EXIT_FAILURE);
   }
 
-  LOG_INFO("Exit successfully"); 
-  exit(EXIT_SUCCESS); 
+  LOG_INFO("Exit successfully");
+  exit(EXIT_SUCCESS);
 }
 
 
- // Callback function for error and warning redirects
+// Callback function for error and warning redirects
 void PrintLogsCallback(vtkObject* obj, unsigned long eid, void* clientdata, void* calldata)
 {
-  if ( eid == vtkCommand::GetEventIdFromString("WarningEvent") )
+  if (eid == vtkCommand::GetEventIdFromString("WarningEvent"))
   {
     LOG_WARNING((const char*)calldata);
   }
-  else if ( eid == vtkCommand::GetEventIdFromString("ErrorEvent") )
+  else if (eid == vtkCommand::GetEventIdFromString("ErrorEvent"))
   {
     LOG_ERROR((const char*)calldata);
   }

--- a/src/PlusDataCollection/Testing/vtkRevopoint3DCameraTest.cxx
+++ b/src/PlusDataCollection/Testing/vtkRevopoint3DCameraTest.cxx
@@ -11,208 +11,311 @@
 #include "vtkCommand.h"
 #include "vtkPlusDataSource.h"
 #include "vtkSmartPointer.h"
-#include "vtkVersion.h"
 #include "vtkPlusRevopoint3DCamera.h"
 #include "vtksys/CommandLineArguments.hxx"
 #include "vtksys/SystemTools.hxx"
 #include "vtkImageData.h"
-#include "vtkPolyData.h"
-#include "vtkPolyDataMapper.h"
-#include "vtkProperty.h"
-#include "vtkRenderWindow.h"
-#include "vtkRenderWindowInteractor.h"
-#include "vtkRenderer.h"
+#include "vtkImageViewer.h"
 #include "vtkInformation.h"
 #include "vtkInformationVector.h"
 #include "vtkRenderWindow.h"
 #include "vtkRenderWindowInteractor.h"
 #include "vtkRenderer.h"
-#include "vtkImageViewer.h"
+#include "vtkRendererCollection.h"
+#include "vtkPolyDataMapper.h"
+#include "vtkPolyData.h"
+#include "vtkPoints.h"
+#include "vtkVertexGlyphFilter.h"
+#include "vtkPointData.h"
+#include "vtkActor.h"
 #include "igtlOSUtil.h"
 
 void PrintLogsCallback(vtkObject* obj, unsigned long eid, void* clientdata, void* calldata);
 
 namespace
 {
-class vtkMyCallback : public vtkCommand
-{
-public:
-    static vtkMyCallback* New()
+  class vtkMyImageViewerCallback : public vtkCommand
+  {
+  public:
+    static vtkMyImageViewerCallback* New()
     {
-        return new vtkMyCallback;
+      return new vtkMyImageViewerCallback;
     }
 
     virtual void Execute(vtkObject* caller, unsigned long, void*)
     {
-        m_Viewer->Render();
+      if (m_Channel->GetVideoDataAvailable())
+      {
+        m_Viewer->SetInputData(m_Channel->GetBrightnessOutput());
+      }
 
-        //update the timer so it will trigger again
-        m_Interactor->CreateTimer(VTKI_TIMER_UPDATE);
+      //update the timer so it will trigger again
+      m_Viewer->Render();
+      m_Interactor->CreateTimer(VTKI_TIMER_UPDATE);
     }
 
-    vtkRenderWindowInteractor* m_Interactor;
-    vtkImageViewer* m_Viewer;
-
-private:
-
-    vtkMyCallback()
+    vtkRenderWindowInteractor* m_Interactor{nullptr};
+    vtkImageViewer* m_Viewer{nullptr};
+    vtkPlusChannel* m_Channel{nullptr};
+  };
+  class vtkMyMeshViewerCallback : public vtkCommand
+  {
+  public:
+    static vtkMyMeshViewerCallback* New()
     {
-        m_Interactor = NULL;
-        m_Viewer = NULL;
+      return new vtkMyMeshViewerCallback;
     }
-};
+
+    virtual void Execute(vtkObject* caller, unsigned long, void*)
+    {
+      static bool firstDisplay{true};
+
+      if (m_Channel->GetVideoDataAvailable())
+      {
+        m_Mapper->SetInputData(ConvertToPCL(m_Channel->GetBrightnessOutput()));
+        m_Mapper->Modified();
+
+        if (firstDisplay)
+        {
+          m_Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer()->ResetCamera();
+          firstDisplay = false;
+        }
+      }
+
+      m_Interactor->Render();
+    }
+
+    vtkRenderWindowInteractor* m_Interactor{nullptr};
+    vtkPlusChannel* m_Channel{nullptr};
+    vtkPolyDataMapper* m_Mapper{nullptr};
+
+  private:
+    vtkSmartPointer<vtkPolyData> ConvertToPCL(vtkImageData* imageData)
+    {
+      if (imageData->GetNumberOfScalarComponents() != 3)
+      {
+        return nullptr;
+      }
+
+      int* dims = imageData->GetDimensions();
+      auto points = vtkSmartPointer<vtkPoints>::New();
+
+      for (int x = 0; x < dims[0]; x++)
+      {
+        for (int y = 0; y < dims[1]; y++)
+        {
+          for (int z = 0; z < dims[2]; z++)
+          {
+            auto* coords =
+              static_cast<float*>(imageData->GetScalarPointer(x, y, z));
+
+            if (coords[2] == 0)
+            {
+              continue;
+            }
+
+            points->InsertNextPoint(coords[0], coords[1], coords[2]);
+          }
+        }
+      }
+
+      auto poly = vtkSmartPointer<vtkPolyData>::New();
+      poly->SetPoints(points);
+
+      auto vertexGenerator = vtkSmartPointer<vtkVertexGlyphFilter>::New();
+      vertexGenerator->SetInputData(poly);
+      vertexGenerator->Update();
+
+      return vertexGenerator->GetOutput();
+    }
+  };
 }
 
 int main(int argc, char** argv)
 {
 
-    bool printHelp(false);
-    std::string inputConfigFileName = "Testing/PlusDeviceSet_DataCollectionOnly_Revopoint3DCamera.xml";
+  bool printHelp(false);
+  std::string inputConfigFileName = "Testing/PlusDeviceSet_DataCollectionOnly_Revopoint3DCamera.xml";
 
-    vtksys::CommandLineArguments args;
-    args.Initialize(argc, argv);
+  vtksys::CommandLineArguments args;
+  args.Initialize(argc, argv);
 
-    int verboseLevel = vtkPlusLogger::LOG_LEVEL_UNDEFINED;
-    bool renderingOff(false);
+  int verboseLevel = vtkPlusLogger::LOG_LEVEL_UNDEFINED;
+  bool renderingOff(false);
 
-    args.AddArgument("--help", vtksys::CommandLineArguments::NO_ARGUMENT, &printHelp, "Print this help.");
-    args.AddArgument("--verbose", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &verboseLevel, "Verbose level (1=error only, 2=warning, 3=info, 4=debug, 5=trace)");
-    args.AddArgument("--config-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &inputConfigFileName, "Config file containing the device configuration.");
-    args.AddArgument("--rendering-off", vtksys::CommandLineArguments::NO_ARGUMENT, &renderingOff, "Run test without rendering.");
+  args.AddArgument("--help", vtksys::CommandLineArguments::NO_ARGUMENT, &printHelp, "Print this help.");
+  args.AddArgument("--verbose", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &verboseLevel, "Verbose level (1=error only, 2=warning, 3=info, 4=debug, 5=trace)");
+  args.AddArgument("--config-file", vtksys::CommandLineArguments::EQUAL_ARGUMENT, &inputConfigFileName, "Config file containing the device configuration.");
+  args.AddArgument("--rendering-off", vtksys::CommandLineArguments::NO_ARGUMENT, &renderingOff, "Run test without rendering.");
 
-    if (!args.Parse())
-    {
-        std::cerr << "Problem parsing arguments" << std::endl;
-        std::cout << "\n\nHelp:" << args.GetHelp() << std::endl;
-        exit(EXIT_FAILURE);
-    }
+  if (!args.Parse())
+  {
+    std::cerr << "Problem parsing arguments" << std::endl;
+    std::cout << "\n\nHelp:" << args.GetHelp() << std::endl;
+    exit(EXIT_FAILURE);
+  }
 
-    vtkPlusLogger::Instance()->SetLogLevel(verboseLevel);
+  vtkPlusLogger::Instance()->SetLogLevel(verboseLevel);
 
-    if (printHelp)
-    {
-        std::cout << "\n\nHelp:" << args.GetHelp() << std::endl;
-        exit(EXIT_SUCCESS);
-    }
-
-    vtkNew<vtkPlusRevopoint3DCamera> revopoint3DCameraDevice;
-    revopoint3DCameraDevice->SetDeviceId("VideoDevice");
-
-    if (!vtksys::SystemTools::FileExists(inputConfigFileName))
-    {
-        LOG_ERROR("Bad configuration file: " << inputConfigFileName);
-        exit(EXIT_FAILURE);
-    }
-
-    LOG_DEBUG("Reading config file: " << inputConfigFileName);
-    auto* configRead = vtkXMLUtilities::ReadElementFromFile(inputConfigFileName.c_str());
-
-    if (!configRead)
-    {
-        LOG_ERROR("Failed to read configuration file");
-        exit(EXIT_FAILURE);
-    }
-
-    LOG_TRACE("Config file: " << *configRead);
-    if (revopoint3DCameraDevice->ReadConfiguration(configRead) != PLUS_SUCCESS)
-    {
-        LOG_ERROR("Failed to read configuration");
-        exit(EXIT_FAILURE);
-    }
-
-    if (revopoint3DCameraDevice->NotifyConfigured() != PLUS_SUCCESS)
-    {
-        LOG_ERROR("Invalid configuration");
-        exit(EXIT_FAILURE);
-    }
-
-    revopoint3DCameraDevice->CreateDefaultOutputChannel(NULL, true);
-    vtkPlusDataSource* videoSource = NULL;
-    if (revopoint3DCameraDevice->GetFirstActiveOutputVideoSource(videoSource) != PLUS_SUCCESS)
-    {
-        LOG_ERROR("Unable to retrieve the video source.");
-        exit(EXIT_FAILURE);
-    }
-    videoSource->SetInputImageOrientation(US_IMG_ORIENT_UN);
-
-    vtkIndent indent;
-    revopoint3DCameraDevice->PrintSelf(std::cout, indent);
-
-    // Add an observer to warning and error events for redirecting it to the stdout
-    vtkNew<vtkCallbackCommand> callbackCommand;
-    callbackCommand->SetCallback(PrintLogsCallback);
-    revopoint3DCameraDevice->AddObserver("WarningEvent", callbackCommand);
-    revopoint3DCameraDevice->AddObserver("ErrorEvent", callbackCommand);
-
-    if (revopoint3DCameraDevice->Connect() != PLUS_SUCCESS)
-    {
-        LOG_ERROR("Failed to connect");
-        exit(EXIT_FAILURE);
-    }
-
-    if (revopoint3DCameraDevice->StartRecording() != PLUS_SUCCESS)
-    {
-        LOG_INFO("Failed to start recording");
-        exit(EXIT_FAILURE);
-    }
-
-    if (!renderingOff)
-    {
-        auto viewer = vtkSmartPointer<vtkImageViewer>::New();
-        viewer->SetInputConnection(revopoint3DCameraDevice->GetOutputPort());   //set image to the render and window
-        viewer->SetColorWindow(500);
-        viewer->SetColorLevel(250);
-        viewer->SetZSlice(0);
-
-        //Create the interactor that handles the event loop
-        vtkSmartPointer<vtkRenderWindowInteractor> iren = vtkSmartPointer<vtkRenderWindowInteractor>::New();
-        iren->SetRenderWindow(viewer->GetRenderWindow());
-        viewer->SetupInteractor(iren);
-
-        viewer->Render(); //must be called after iren and viewer are linked or there will be problems
-
-        // Establish timer event and create timer to update the live image
-        auto call = vtkSmartPointer<vtkMyCallback>::New();
-        call->m_Interactor = iren;
-        call->m_Viewer = viewer;
-        iren->AddObserver(vtkCommand::TimerEvent, call);
-        iren->CreateTimer(VTKI_TIMER_FIRST);
-
-        //iren must be initialized so that it can handle events
-        iren->Initialize();
-        iren->Start();
-    }
-    else
-    {
-        igtl::Sleep(2000);
-    }
-
-    if (revopoint3DCameraDevice->StopRecording() != PLUS_SUCCESS)
-    {
-        LOG_INFO("Failed to stop recording");
-        exit(EXIT_FAILURE);
-    }
-
-    if (revopoint3DCameraDevice->Disconnect() != PLUS_SUCCESS)
-    {
-        LOG_ERROR("Failed to disconnect");
-        exit(EXIT_FAILURE);
-    }
-
-    LOG_INFO("Exit successfully");
+  if (printHelp)
+  {
+    std::cout << "\n\nHelp:" << args.GetHelp() << std::endl;
     exit(EXIT_SUCCESS);
+  }
+
+  vtkNew<vtkPlusRevopoint3DCamera> revopoint3DCameraDevice;
+  revopoint3DCameraDevice->SetDeviceId("VideoDevice");
+
+  if (!vtksys::SystemTools::FileExists(inputConfigFileName))
+  {
+    LOG_ERROR("Bad configuration file: " << inputConfigFileName);
+    exit(EXIT_FAILURE);
+  }
+
+  LOG_DEBUG("Reading config file: " << inputConfigFileName);
+  auto* configRead = vtkXMLUtilities::ReadElementFromFile(inputConfigFileName.c_str());
+
+  if (!configRead)
+  {
+    LOG_ERROR("Failed to read configuration file");
+    exit(EXIT_FAILURE);
+  }
+
+  LOG_TRACE("Config file: " << *configRead);
+  if (revopoint3DCameraDevice->ReadConfiguration(configRead) != PLUS_SUCCESS)
+  {
+    LOG_ERROR("Failed to read configuration");
+    exit(EXIT_FAILURE);
+  }
+
+  if (revopoint3DCameraDevice->NotifyConfigured() != PLUS_SUCCESS)
+  {
+    LOG_ERROR("Invalid configuration");
+    exit(EXIT_FAILURE);
+  }
+
+  vtkPlusChannel* depthChannel{nullptr};
+  revopoint3DCameraDevice->GetOutputChannelByName(depthChannel, "VideoStreamDEPTH");
+
+
+  vtkPlusChannel* pclChannel{nullptr};
+  revopoint3DCameraDevice->GetOutputChannelByName(pclChannel, "VideoStreamPCL");
+
+  vtkIndent indent;
+  revopoint3DCameraDevice->PrintSelf(std::cout, indent);
+
+  // Add an observer to warning and error events for redirecting it to the stdout
+  vtkNew<vtkCallbackCommand> callbackCommand;
+  callbackCommand->SetCallback(PrintLogsCallback);
+  revopoint3DCameraDevice->AddObserver("WarningEvent", callbackCommand);
+  revopoint3DCameraDevice->AddObserver("ErrorEvent", callbackCommand);
+
+  if (revopoint3DCameraDevice->Connect() != PLUS_SUCCESS)
+  {
+    LOG_ERROR("Failed to connect");
+    exit(EXIT_FAILURE);
+  }
+
+  if (revopoint3DCameraDevice->StartRecording() != PLUS_SUCCESS)
+  {
+    LOG_INFO("Failed to start recording");
+    exit(EXIT_FAILURE);
+  }
+
+  if (!renderingOff)
+  {
+    auto imageViewer = vtkSmartPointer<vtkImageViewer>::New();
+    imageViewer->SetColorWindow(255);
+    imageViewer->SetColorLevel(127.5);
+    imageViewer->SetZSlice(0);
+
+    // Create the interactor that handles the event loop
+    auto imageInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+    imageInteractor->SetRenderWindow(imageViewer->GetRenderWindow());
+    imageViewer->SetupInteractor(imageInteractor);
+
+    imageViewer->Render(); //must be called after iren and viewer are linked or there will be problems
+
+    // Establish timer event and create timer to update the live image
+    auto call = vtkSmartPointer<vtkMyImageViewerCallback>::New();
+    call->m_Interactor = imageInteractor;
+    call->m_Viewer = imageViewer;
+    imageInteractor->AddObserver(vtkCommand::TimerEvent, call);
+    imageInteractor->CreateTimer(VTKI_TIMER_FIRST);
+
+    // Display depth image
+    if (depthChannel)
+    {
+      call->m_Channel = depthChannel;
+      imageInteractor->Initialize();
+      imageInteractor->Start();
+    }
+
+    imageInteractor->GetRenderWindow()->Finalize();
+
+    // Display points cloud
+    if (pclChannel)
+    {
+      auto pclRenderer = vtkSmartPointer<vtkRenderer>::New();
+      auto pclRenderWindow = vtkSmartPointer<vtkRenderWindow>::New();
+      pclRenderWindow->SetSize(640, 480);
+      pclRenderWindow->AddRenderer(pclRenderer);
+      auto pclInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+      pclInteractor->SetRenderWindow(pclRenderWindow);
+
+      auto mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+      mapper->SetInputData(vtkSmartPointer<vtkPolyData>::New());
+      auto actor = vtkSmartPointer<vtkActor>::New();
+      actor->SetMapper(mapper);
+      pclRenderer->SetBackground(0., 0., 0.);
+      pclRenderer->AddActor(actor);
+
+      pclRenderWindow->Render();
+      pclInteractor->Initialize();
+
+      auto call2 = vtkSmartPointer<vtkMyMeshViewerCallback>::New();
+      call2->m_Interactor = pclInteractor;
+      call2->m_Mapper = mapper;
+      call2->m_Channel = pclChannel;
+
+      pclInteractor->AddObserver(vtkCommand::TimerEvent, call2);
+      pclInteractor->CreateRepeatingTimer(100);
+
+      pclInteractor->Start();
+      pclInteractor->GetRenderWindow()->Finalize();
+    }
+  }
+  else
+  {
+    igtl::Sleep(2000);
+  }
+
+  if (revopoint3DCameraDevice->StopRecording() != PLUS_SUCCESS)
+  {
+    LOG_INFO("Failed to stop recording");
+    exit(EXIT_FAILURE);
+  }
+
+  if (revopoint3DCameraDevice->Disconnect() != PLUS_SUCCESS)
+  {
+    LOG_ERROR("Failed to disconnect");
+    exit(EXIT_FAILURE);
+  }
+
+  LOG_INFO("Exit successfully");
+  exit(EXIT_SUCCESS);
 }
 
 
 // Callback function for error and warning redirects
 void PrintLogsCallback(vtkObject* obj, unsigned long eid, void* clientdata, void* calldata)
 {
-    if (eid == vtkCommand::GetEventIdFromString("WarningEvent"))
-    {
-        LOG_WARNING((const char*)calldata);
-    }
-    else if (eid == vtkCommand::GetEventIdFromString("ErrorEvent"))
-    {
-        LOG_ERROR((const char*)calldata);
-    }
+  if (eid == vtkCommand::GetEventIdFromString("WarningEvent"))
+  {
+    LOG_WARNING((const char*)calldata);
+  }
+  else if (eid == vtkCommand::GetEventIdFromString("ErrorEvent"))
+  {
+    LOG_ERROR((const char*)calldata);
+  }
 }


### PR DESCRIPTION
Add reconstructed points cloud to the possible data source for depth camera. It is interesting to do it in the driver as the camera calibration data is needed to compute the points cloud from the depth map.

- [x] windows tests (lib) http://perkdata.cs.queensu.ca/CDash/viewTest.php?onlypassed&buildid=2174040
- [x] windows tests (app) http://perkdata.cs.queensu.ca/CDash/viewTest.php?onlypassed&buildid=217408
- [x] linux tests (lib) http://perkdata.cs.queensu.ca/CDash/viewTest.php?onlypassed&buildid=217412
- [x] Generated documentation
- [x] Kinect and revopoint streaming via plus server generated with CreatePackage on Windows

Linked to [PlusLibData PR](https://github.com/PlusToolkit/PlusLibData/pull/50)