### PR TITLE
BUG: Fix usage of auto

### DIFF
--- a/src/PlusDataCollection/GenericSensor/vtkPlusGenericSensorTracker.cxx
+++ b/src/PlusDataCollection/GenericSensor/vtkPlusGenericSensorTracker.cxx
@@ -863,7 +863,7 @@ PlusStatus vtkPlusGenericSensorTracker::InternalUpdate()
 
     auto safeReport = createSafePointer(report);
 
-    auto transform = vtkSmartPointer<vtkMatrix4x4>::New();
+    vtkNew<vtkMatrix4x4> transform;
     if (sensorStream.Type == SensorType::Accelerometer)
     {
       if (vtkInternal::RetrieveAccData(safeReport.get(), transform) != PLUS_SUCCESS)

--- a/src/PlusDataCollection/Testing/vtkAzureKinectTest.cxx
+++ b/src/PlusDataCollection/Testing/vtkAzureKinectTest.cxx
@@ -108,8 +108,8 @@ namespace
       }
 
       int* dims = imageData->GetDimensions();
-      auto points = vtkSmartPointer<vtkPoints>::New();
-      auto colors = vtkSmartPointer<vtkUnsignedCharArray>::New();
+      vtkNew<vtkPoints> points;
+      vtkNew<vtkUnsignedCharArray> colors;
       colors->SetNumberOfComponents(3);
       colors->SetName("Colors");
 
@@ -144,11 +144,11 @@ namespace
         }
       }
 
-      auto poly = vtkSmartPointer<vtkPolyData>::New();
+      vtkNew<vtkPolyData> poly;
       poly->SetPoints(points);
       poly->GetPointData()->SetScalars(colors);
 
-      auto vertexGenerator = vtkSmartPointer<vtkVertexGlyphFilter>::New();
+      vtkNew<vtkVertexGlyphFilter> vertexGenerator;
       vertexGenerator->SetInputData(poly);
       vertexGenerator->Update();
 
@@ -252,20 +252,20 @@ int main(int argc, char** argv)
 
   if (!renderingOff)
   {
-    auto imageViewer = vtkSmartPointer<vtkImageViewer>::New();
+    vtkNew<vtkImageViewer> imageViewer;
     imageViewer->SetColorWindow(255);
     imageViewer->SetColorLevel(127.5);
     imageViewer->SetZSlice(0);
 
     // Create the interactor that handles the event loop
-    auto imageInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+    vtkNew<vtkRenderWindowInteractor> imageInteractor;
     imageInteractor->SetRenderWindow(imageViewer->GetRenderWindow());
     imageViewer->SetupInteractor(imageInteractor);
 
     imageViewer->Render(); //must be called after iren and viewer are linked or there will be problems
 
     // Establish timer event and create timer to update the live image
-    auto call = vtkSmartPointer<vtkMyImageViewerCallback>::New();
+    vtkNew<vtkMyImageViewerCallback> call;
     call->m_Interactor = imageInteractor;
     call->m_Viewer = imageViewer;
     imageInteractor->AddObserver(vtkCommand::TimerEvent, call);
@@ -291,16 +291,16 @@ int main(int argc, char** argv)
     // Display points cloud
     if (pclChannel)
     {
-      auto pclRenderer = vtkSmartPointer<vtkRenderer>::New();
-      auto pclRenderWindow = vtkSmartPointer<vtkRenderWindow>::New();
+      vtkNew<vtkRenderer> pclRenderer;
+      vtkNew<vtkRenderWindow> pclRenderWindow;
       pclRenderWindow->SetSize(640, 480);
       pclRenderWindow->AddRenderer(pclRenderer);
-      auto pclInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+      vtkNew<vtkRenderWindowInteractor> pclInteractor;
       pclInteractor->SetRenderWindow(pclRenderWindow);
 
-      auto mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+      vtkNew<vtkPolyDataMapper> mapper;
       mapper->SetInputData(vtkSmartPointer<vtkPolyData>::New());
-      auto actor = vtkSmartPointer<vtkActor>::New();
+      vtkNew<vtkActor> actor;
       actor->SetMapper(mapper);
       pclRenderer->SetBackground(0., 0., 0.);
       pclRenderer->AddActor(actor);
@@ -308,7 +308,7 @@ int main(int argc, char** argv)
       pclRenderWindow->Render();
       pclInteractor->Initialize();
 
-      auto call2 = vtkSmartPointer<vtkMyMeshViewerCallback>::New();
+      vtkNew<vtkMyMeshViewerCallback> call2;
       call2->m_Interactor = pclInteractor;
       call2->m_Mapper = mapper;
       call2->m_Channel = pclChannel;

--- a/src/PlusDataCollection/Testing/vtkOpenIGTLinkTrackerTest.cxx
+++ b/src/PlusDataCollection/Testing/vtkOpenIGTLinkTrackerTest.cxx
@@ -21,7 +21,7 @@
 //#include <chrono>
 //#include <thread>
 
-auto server = vtkSmartPointer<vtkPlusOpenIGTLinkServer>::New();
+vtkNew<vtkPlusOpenIGTLinkServer> server;
 
 void PrintLogsCallback(vtkObject* obj, unsigned long eid, void* clientdata, void* calldata);
 
@@ -102,7 +102,7 @@ int main(int argc, char** argv)
 
   // Read server config file
   LOG_INFO("Reading server config file...");
-  auto serverConfigRootElement = vtkSmartPointer<vtkXMLDataElement>::New();
+  vtkNew<vtkXMLDataElement> serverConfigRootElement;
   if (PlusXmlUtils::ReadDeviceSetConfigurationFromFile(serverConfigRootElement, serverConfigFileName.c_str()) == PLUS_FAIL)
   {
     LOG_ERROR("Unable to read configuration from file " << serverConfigFileName.c_str());
@@ -117,16 +117,16 @@ int main(int argc, char** argv)
 
   // Read client config file
   LOG_INFO("Reading client config file...");
-  auto clientConfigRootElement = vtkSmartPointer<vtkXMLDataElement>::New();
+  vtkNew<vtkXMLDataElement> clientConfigRootElement;
   if (PlusXmlUtils::ReadDeviceSetConfigurationFromFile(clientConfigRootElement, clientConfigFileName.c_str()) == PLUS_FAIL)
   {
     LOG_ERROR("Unable to read configuration from file " << clientConfigFileName.c_str());
     return EXIT_FAILURE;
   }
-  auto client = vtkSmartPointer<vtkPlusOpenIGTLinkTracker>::New();
+  vtkNew<vtkPlusOpenIGTLinkTracker> client;
 
   // Add an observer to warning and error events for redirecting it to the stdout
-  auto callbackCommand = vtkSmartPointer<vtkCallbackCommand>::New();
+  vtkNew<vtkCallbackCommand> callbackCommand;
   callbackCommand->SetCallback(PrintLogsCallback);
   client->AddObserver("WarningEvent", callbackCommand);
   client->AddObserver("ErrorEvent", callbackCommand);

--- a/src/PlusDataCollection/Testing/vtkRevopoint3DCameraTest.cxx
+++ b/src/PlusDataCollection/Testing/vtkRevopoint3DCameraTest.cxx
@@ -98,7 +98,7 @@ namespace
       }
 
       int* dims = imageData->GetDimensions();
-      auto points = vtkSmartPointer<vtkPoints>::New();
+      vtkNew<vtkPoints> points;
 
       for (int x = 0; x < dims[0]; x++)
       {
@@ -119,10 +119,10 @@ namespace
         }
       }
 
-      auto poly = vtkSmartPointer<vtkPolyData>::New();
+      vtkNew<vtkPolyData> poly;
       poly->SetPoints(points);
 
-      auto vertexGenerator = vtkSmartPointer<vtkVertexGlyphFilter>::New();
+      vtkNew<vtkVertexGlyphFilter> vertexGenerator;
       vertexGenerator->SetInputData(poly);
       vertexGenerator->Update();
 
@@ -224,20 +224,20 @@ int main(int argc, char** argv)
 
   if (!renderingOff)
   {
-    auto imageViewer = vtkSmartPointer<vtkImageViewer>::New();
+    vtkNew<vtkImageViewer> imageViewer;
     imageViewer->SetColorWindow(255);
     imageViewer->SetColorLevel(127.5);
     imageViewer->SetZSlice(0);
 
     // Create the interactor that handles the event loop
-    auto imageInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+    vtkNew<vtkRenderWindowInteractor> imageInteractor;
     imageInteractor->SetRenderWindow(imageViewer->GetRenderWindow());
     imageViewer->SetupInteractor(imageInteractor);
 
     imageViewer->Render(); //must be called after iren and viewer are linked or there will be problems
 
     // Establish timer event and create timer to update the live image
-    auto call = vtkSmartPointer<vtkMyImageViewerCallback>::New();
+    vtkNew<vtkMyImageViewerCallback> call;
     call->m_Interactor = imageInteractor;
     call->m_Viewer = imageViewer;
     imageInteractor->AddObserver(vtkCommand::TimerEvent, call);
@@ -256,16 +256,16 @@ int main(int argc, char** argv)
     // Display points cloud
     if (pclChannel)
     {
-      auto pclRenderer = vtkSmartPointer<vtkRenderer>::New();
-      auto pclRenderWindow = vtkSmartPointer<vtkRenderWindow>::New();
+      vtkNew<vtkRenderer> pclRenderer;
+      vtkNew<vtkRenderWindow> pclRenderWindow;
       pclRenderWindow->SetSize(640, 480);
       pclRenderWindow->AddRenderer(pclRenderer);
-      auto pclInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+      vtkNew<vtkRenderWindowInteractor> pclInteractor;
       pclInteractor->SetRenderWindow(pclRenderWindow);
 
-      auto mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+      vtkNew<vtkPolyDataMapper> mapper;
       mapper->SetInputData(vtkSmartPointer<vtkPolyData>::New());
-      auto actor = vtkSmartPointer<vtkActor>::New();
+      vtkNew<vtkActor> actor;
       actor->SetMapper(mapper);
       pclRenderer->SetBackground(0., 0., 0.);
       pclRenderer->AddActor(actor);
@@ -273,7 +273,7 @@ int main(int argc, char** argv)
       pclRenderWindow->Render();
       pclInteractor->Initialize();
 
-      auto call2 = vtkSmartPointer<vtkMyMeshViewerCallback>::New();
+      vtkNew<vtkMyMeshViewerCallback> call2;
       call2->m_Interactor = pclInteractor;
       call2->m_Mapper = mapper;
       call2->m_Channel = pclChannel;

--- a/src/PlusWidgets/QPlusDeviceSetSelectorWidget.cxx
+++ b/src/PlusWidgets/QPlusDeviceSetSelectorWidget.cxx
@@ -387,7 +387,7 @@ PlusStatus QPlusDeviceSetSelectorWidget::ParseDirectory(const QString& aDirector
       vtkSmartPointer<vtkXMLDataElement> configRootElement = vtkSmartPointer<vtkXMLDataElement>::Take(vtkXMLUtilities::ReadElementFromFile(fileName.toStdString().c_str()));
       if (configRootElement != NULL)
       {
-        auto tr = vtkSmartPointer<vtkIGSIOTransformRepository>::New();
+        vtkNew<vtkIGSIOTransformRepository> tr;
         if (tr->ReadConfiguration(configRootElement) == PLUS_SUCCESS)
         {
           QString pivotString;


### PR DESCRIPTION
cc: @lassoan 

Based on same type changes made in https://github.com/Slicer/Slicer/commit/fd9b4da85853731fb2497095e71b86d7eb848d64.

> Instead of
> 
>     auto testLineNode = vtkSmartPointer<vtkMRMLMarkupsTestLineNode>::New();
> 
> the preferred style is
> 
>     vtkNew<vtkMRMLMarkupsTestLineNode> testLineNode;