### PR TITLE
ENH: Added option to change the tracking frequency in NDICAPI

### DIFF
--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.h
@@ -37,6 +37,8 @@ public:
     ERROR_OPTION_AVAILABLE_ONLY_ON_FTK,
     ERROR_OPTION_AVAILABLE_ONLY_ON_STK,
     ERROR_FAILED_TO_CLOSE_SDK,
+    ERROR_FAILED_TO_EXPORT_CALIB,
+    ERROR_FAILED_TO_EXTRACT_FRAME_INFO,
     ERROR_CANNOT_CREATE_FRAME_INSTANCE,
     ERROR_CANNOT_INITIALIZE_FRAME,
     ERROR_NO_FRAME_AVAILABLE,
@@ -149,6 +151,9 @@ public:
 
   /*! */
   ATRACSYS_RESULT GetDeviceId(uint64_t& id);
+
+  /*! */
+  ATRACSYS_RESULT GetCamerasCalibration(std::vector<float>& calib);
 
   /*! */
   ATRACSYS_RESULT LoadMarkerGeometryFromFile(std::string filePath, int& geometryId);

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.h
@@ -32,6 +32,9 @@ public:
   /* Get device type */
   std::string GetDeviceType();
 
+  /* Get cameras calibration */
+  PlusStatus GetCamerasCalibration(std::vector<float>& calib);
+
   /* Device is a hardware tracker. */
   virtual bool IsTracker() const { return true; }
   virtual bool IsVirtual() const { return false; }
@@ -64,6 +67,8 @@ public:
   static const char* ATRACSYS_COMMAND_ENABLE_TOOL;
   static const char* ATRACSYS_COMMAND_ADD_TOOL;
 
+  PlusStatus GetOptionValue(const std::string& optionName, std::string& optionValue);
+
   // Command methods
   // LED
   PlusStatus SetLedEnabled(bool enabled);
@@ -78,6 +83,9 @@ public:
 protected:
   vtkPlusAtracsysTracker();
   ~vtkPlusAtracsysTracker();
+
+  // helper to translate option names from Plus nomenclature to Atracsys' one
+  bool translateOptionName(const std::string& optionName, std::string& translatedOptionName);
 
 private: // Functions
   vtkPlusAtracsysTracker(const vtkPlusAtracsysTracker&);


### PR DESCRIPTION
Tracking frequency can now be changed similarly to the measurement volume i.e. by specifying the setting in the configuration file.
Example:
<Device
Id="SomeTrackerDevice"
Type="PolarisTracker"
NetworkHostname="169.254.x.x"
NetworkPort="8765"
**MeasurementVolumeNumber="1"
TrackingFrequencyNumber="2"**
ToolReferenceFrame="Tracker" >

This sets the Extended Volume and a tracking frequency of 60Hz for a Vega Polaris tracker.