### PR TITLE
ENH: Add OpenCV 4 support to Andor device

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorVideoSource.cxx
@@ -9,7 +9,11 @@ See License.txt for details.
 #include "vtkPlusAndorVideoSource.h"
 #include "ATMCD32D.h"
 #include "igtlOSUtil.h" // for Sleep
+#if CV_MAJOR_VERSION > 3
+#include "opencv2/calib3d.hpp"
+#else
 #include "opencv2/imgproc.hpp"
+#endif
 #include "opencv2/imgcodecs.hpp"
 
 


### PR DESCRIPTION
Undistort files were moved from imgproc to calib3d for Open CV 4. See https://github.com/opencv/opencv/commit/8f1f4273a2484d3191afce1ce5aed9d6ac5cd428