### PR TITLE
ENH: Add command to read frame rate from channel data source

### DIFF
--- a/src/PlusServer/CMakeLists.txt
+++ b/src/PlusServer/CMakeLists.txt
@@ -18,6 +18,7 @@ SET(${PROJECT_NAME}_CMD_SRCS
   Commands/vtkPlusGetUsParameterCommand.cxx
   Commands/vtkPlusAddRecordingDeviceCommand.cxx
   Commands/vtkPlusGenericSerialCommand.cxx
+  Commands/vtkPlusGetFrameRateCommand.cxx
   )
 SET(${PROJECT_NAME}_SRCS
   vtkPlusOpenIGTLinkServer.cxx
@@ -43,6 +44,7 @@ SET(${PROJECT_NAME}_CMD_HDRS
   Commands/vtkPlusGetUsParameterCommand.h
   Commands/vtkPlusAddRecordingDeviceCommand.h
   Commands/vtkPlusGenericSerialCommand.h
+  Commands/vtkPlusGetFrameRateCommand.h
   )
 SET(${PROJECT_NAME}_HDRS
   vtkPlusOpenIGTLinkServer.h

--- a/src/PlusServer/Commands/vtkPlusGetFrameRateCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusGetFrameRateCommand.cxx
@@ -1,0 +1,153 @@
+/*=Plus=header=begin======================================================
+Program: Plus
+Copyright (c) Laboratory for Percutaneous Surgery. All rights reserved.
+See License.txt for details.
+=========================================================Plus=header=end*/
+
+#include "PlusConfigure.h"
+#include "vtkPlusGetFrameRateCommand.h"
+
+#include "vtkPlusDataCollector.h"
+#include "vtkPlusChannel.h"
+#include "vtkPlusDataSource.h"
+
+vtkStandardNewMacro(vtkPlusGetFrameRateCommand);
+
+namespace
+{
+  static const std::string GET_FRAME_RATE_CMD = "GetFrameRate";
+}
+
+//----------------------------------------------------------------------------
+vtkPlusGetFrameRateCommand::vtkPlusGetFrameRateCommand()
+  : ResponseExpected(true)
+{
+  // It handles only one command, set its name by default
+  this->SetName(GET_FRAME_RATE_CMD);
+}
+
+//----------------------------------------------------------------------------
+vtkPlusGetFrameRateCommand::~vtkPlusGetFrameRateCommand()
+{
+}
+
+//----------------------------------------------------------------------------
+void vtkPlusGetFrameRateCommand::SetNameToGetFrameRate()
+{
+  this->SetName(GET_FRAME_RATE_CMD);
+}
+
+//----------------------------------------------------------------------------
+void vtkPlusGetFrameRateCommand::GetCommandNames(std::list<std::string>& cmdNames)
+{
+  cmdNames.clear();
+  cmdNames.push_back(GET_FRAME_RATE_CMD);
+}
+
+//----------------------------------------------------------------------------
+std::string vtkPlusGetFrameRateCommand::GetDescription(const std::string& commandName)
+{
+  std::string desc;
+  if (commandName.empty() || igsioCommon::IsEqualInsensitive(commandName, GET_FRAME_RATE_CMD))
+  {
+    desc += GET_FRAME_RATE_CMD;
+    desc += ": Get frame rate from a data channel.";
+  }
+  return desc;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkPlusGetFrameRateCommand::GetChannelId() const
+{
+  return this->ChannelId;
+}
+
+//----------------------------------------------------------------------------
+void vtkPlusGetFrameRateCommand::SetChannelId(const std::string& channelId)
+{
+  this->ChannelId = channelId;
+}
+
+//----------------------------------------------------------------------------
+void vtkPlusGetFrameRateCommand::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusGetFrameRateCommand::ReadConfiguration(vtkXMLDataElement* aConfig)
+{
+  if (vtkPlusCommand::ReadConfiguration(aConfig) != PLUS_SUCCESS)
+  {
+    return PLUS_FAIL;
+  }
+  XML_READ_STRING_ATTRIBUTE_OPTIONAL(ChannelId, aConfig);
+  return PLUS_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusGetFrameRateCommand::WriteConfiguration(vtkXMLDataElement* aConfig)
+{
+  if (vtkPlusCommand::WriteConfiguration(aConfig) != PLUS_SUCCESS)
+  {
+    return PLUS_FAIL;
+  }
+  XML_WRITE_STRING_ATTRIBUTE_IF_NOT_EMPTY(ChannelId, aConfig);
+  return PLUS_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusGetFrameRateCommand::Execute()
+{
+  LOG_DEBUG("vtkPlusGetFrameRateCommand::Execute: " << (!this->Name.empty() ? this->Name : "(undefined)")
+            << ", channel: " << (this->ChannelId.empty() ? "(undefined)" : this->ChannelId));
+
+  vtkPlusDataCollector* dataCollector = GetDataCollector();
+  if (dataCollector == NULL)
+  {
+    this->QueueCommandResponse(PLUS_FAIL, "Command failed. See error message.", "Invalid data collector.");
+    return PLUS_FAIL;
+  }
+
+  // Get device pointer
+  if (this->ChannelId.empty())
+  {
+    this->QueueCommandResponse(PLUS_FAIL, "Command failed. See error message.", "No ChannelId specified.");
+    return PLUS_FAIL;
+  }
+  vtkPlusChannel* channel = NULL;
+  if (dataCollector->GetChannel(channel, this->ChannelId) != PLUS_SUCCESS)
+  {
+    this->QueueCommandResponse(PLUS_FAIL, "Command failed. See error message.", std::string("Channel ")
+                               + (this->ChannelId.empty() ? "(undefined)" : this->ChannelId) + std::string(" is not found."));
+    return PLUS_FAIL;
+  }
+
+  // Get frame rate from corresponding video source
+  vtkPlusDataSource* dataSource = NULL;
+  channel->GetVideoSource(dataSource);
+  double stddev;
+  double framerate = dataSource->GetFrameRate(false, &stddev);
+
+  std::map < std::string, std::pair<IANA_ENCODING_TYPE, std::string> > metaData;
+
+  std::stringstream response;
+  std::string error = "";
+  response << "<CommandReply FrameRate=" << std::to_string(framerate) << " FrameRateStdDev=" << std::to_string(stddev) << " />";
+  metaData["FrameRate"] = std::make_pair(IANA_TYPE_US_ASCII, std::to_string(framerate));
+  metaData["FrameRateStdDev"] = std::make_pair(IANA_TYPE_US_ASCII, std::to_string(stddev));
+
+  vtkSmartPointer<vtkPlusCommandRTSCommandResponse> commandResponse = vtkSmartPointer<vtkPlusCommandRTSCommandResponse>::New();
+  commandResponse->UseDefaultFormatOff();
+  commandResponse->SetClientId(this->ClientId);
+  commandResponse->SetOriginalId(this->Id);
+  commandResponse->SetCommandName(this->GetName());
+  commandResponse->SetStatus(PLUS_SUCCESS);
+  commandResponse->SetRespondWithCommandMessage(this->RespondWithCommandMessage);
+  commandResponse->SetErrorString(error);
+  commandResponse->SetResultString(response.str());
+  commandResponse->SetParameters(metaData);
+  this->CommandResponseQueue.push_back(commandResponse);
+
+  return PLUS_SUCCESS;
+}

--- a/src/PlusServer/Commands/vtkPlusGetFrameRateCommand.h
+++ b/src/PlusServer/Commands/vtkPlusGetFrameRateCommand.h
@@ -1,0 +1,73 @@
+/*=Plus=header=begin======================================================
+  Program: Plus
+  Copyright (c) Laboratory for Percutaneous Surgery. All rights reserved.
+  See License.txt for details.
+=========================================================Plus=header=end*/
+
+#ifndef __vtkPlusGetFrameRateCommand_h
+#define __vtkPlusGetFrameRateCommand_h
+
+#include "vtkPlusServerExport.h"
+
+#include "vtkPlusCommand.h"
+
+class vtkMatrix4x4;
+
+/*!
+  \class vtkPlusGetFrameRateCommand
+  \brief This command returns the current frame rate from a vtkPlusChannel's DataSource.
+  \ingroup PlusLibPlusServer
+
+  This command is used for communicating with a vtkPlusChannel.
+ */
+class vtkPlusServerExport vtkPlusGetFrameRateCommand : public vtkPlusCommand
+{
+public:
+
+  static vtkPlusGetFrameRateCommand* New();
+  vtkTypeMacro(vtkPlusGetFrameRateCommand, vtkPlusCommand);
+  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual vtkPlusCommand* Clone() { return New(); }
+
+  /*! Executes the command  */
+  virtual PlusStatus Execute();
+
+  /*! Read command parameters from XML */
+  virtual PlusStatus ReadConfiguration(vtkXMLDataElement* aConfig);
+
+  /*! Write command parameters to XML */
+  virtual PlusStatus WriteConfiguration(vtkXMLDataElement* aConfig);
+
+  /*! Get all the command names that this class can execute */
+  virtual void GetCommandNames(std::list<std::string>& cmdNames);
+
+  /*! Gets the description for the specified command name. */
+  virtual std::string GetDescription(const std::string& commandName);
+
+  /*! Id of the channel to pull frame rate information from. */
+  virtual std::string GetChannelId() const;
+  virtual void SetChannelId(const std::string& channelId);
+
+  /*!
+    If true then the command waits for a response and returns with the received frame rate in the command response.
+  */
+  vtkSetMacro(ResponseExpected, bool);
+  vtkGetMacro(ResponseExpected, bool);
+  vtkBooleanMacro(ResponseExpected, bool);
+
+  void SetNameToGetFrameRate();
+
+protected:
+  vtkPlusGetFrameRateCommand();
+  virtual ~vtkPlusGetFrameRateCommand();
+
+private:
+  std::string ChannelId;
+  bool ResponseExpected;
+
+  vtkPlusGetFrameRateCommand(const vtkPlusGetFrameRateCommand&);
+  void operator=(const vtkPlusGetFrameRateCommand&);
+};
+
+
+#endif

--- a/src/PlusServer/vtkPlusCommandProcessor.cxx
+++ b/src/PlusServer/vtkPlusCommandProcessor.cxx
@@ -31,6 +31,7 @@ See License.txt for details.
 
 #include "vtkPlusAddRecordingDeviceCommand.h"
 #include "vtkPlusGenericSerialCommand.h"
+#include "vtkPlusGetFrameRateCommand.h"
 #include "vtkPlusGetPolydataCommand.h"
 #include "vtkPlusGetTransformCommand.h"
 #include "vtkPlusGetUsParameterCommand.h"
@@ -76,6 +77,7 @@ vtkPlusCommandProcessor::vtkPlusCommandProcessor()
   RegisterPlusCommand(vtkSmartPointer<vtkPlusGetUsParameterCommand>::New());
   RegisterPlusCommand(vtkSmartPointer<vtkPlusAddRecordingDeviceCommand>::New());
   RegisterPlusCommand(vtkSmartPointer<vtkPlusGenericSerialCommand>::New());
+  RegisterPlusCommand(vtkSmartPointer<vtkPlusGetFrameRateCommand>::New());
 #ifdef PLUS_USE_CAPISTRANO_VIDEO
   RegisterPlusCommand(vtkSmartPointer<vtkPlusCapistranoCommand>::New());
 #endif


### PR DESCRIPTION
This PR adds a vtkPlusCommand for retrieving the frame rate from a channel's data source.

The command input structure looks like
```
<Command Name="GetFrameRate" ChannelId="MyChannelId" />
```
The output structure looks like
```
<CommandReply FrameRate=123.456 FrameRateStdDev=0.123456 />
```

This is helpful for our group since we work with devices with varying frame rates based on changes to certain imaging parameters, and we'd like to monitor those frame rate changes through Slicer.

cc @jamesobutler who's reviewed these changes with hardware