### PR TITLE
ENH: Added option to change the tracking frequency in NDICAPI

### DIFF
--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
@@ -127,6 +127,8 @@ public:
   // helper function to load ftkGeometry from string
   ATRACSYS_RESULT LoadFtkGeometryFromString(const std::string& geomString, ftkGeometry& geom);
 
+  std::map<int, std::vector<std::array<float, 3>>> geometries;
+
   // correspondence between atracsys option name and its actual id in the sdk
   // this map is filled automatically by the sdk, DO NOT hardcode/change any id
   std::map<std::string, ftkOptionsInfo> DeviceOptionMap{};
@@ -476,9 +478,16 @@ public:
       }
     }
 
+    std::vector<std::array<float, 3>> pts;
+    for (uint32 i(0u); i < geometry.pointsCount; ++i)
+    {
+      std::array<float, 3> pt = { geometry.positions[i].x, geometry.positions[i].y, geometry.positions[i].z };
+      pts.push_back(pt);
+    }
+    geometries[geometry.geometryId] = pts;
+
     return true;
   }
-
 };
 
 //----------------------------------------------------------------------------
@@ -854,6 +863,13 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetMarkerInfo(std::string& mar
     return ERROR_CANNOT_GET_MARKER_INFO;
   }
   markerInfo = std::string(buffer.data, buffer.data + buffer.size);
+  return SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetLoadedGeometries(std::map<int, std::vector<std::array<float, 3>>>& geometries)
+{
+  geometries = this->Internal->geometries;
   return SUCCESS;
 }
 

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.h
@@ -171,6 +171,9 @@ public:
   ATRACSYS_RESULT GetMarkerInfo(std::string& markerInfo);
 
   /*! */
+  ATRACSYS_RESULT GetLoadedGeometries(std::map<int, std::vector<std::array<float,3>>>& geometries);
+
+  /*! */
   std::string ResultToString(ATRACSYS_RESULT result);
 
   /*! */

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
@@ -164,6 +164,22 @@ PlusStatus vtkPlusAtracsysTracker::GetCamerasCalibration(
 }
 
 //----------------------------------------------------------------------------
+PlusStatus vtkPlusAtracsysTracker::GetLoadedGeometries(std::map<int, std::vector<std::array<float, 3>>>& geometries)
+{
+  if (this->Internal->Tracker.GetLoadedGeometries(geometries) != ATRACSYS_RESULT::SUCCESS)
+  {
+    LOG_ERROR("Could not get loaded geometries");
+    return PLUS_FAIL;
+  }
+  if (geometries.size() == 0)
+  {
+    LOG_ERROR("No loaded geometries");
+    return PLUS_FAIL;
+  }
+  return PLUS_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
 PlusStatus vtkPlusAtracsysTracker::ReadConfiguration(vtkXMLDataElement* rootConfigElement)
 {
   // Read and store all device options read in the xml config file

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.h
@@ -33,14 +33,16 @@ public:
   std::string GetDeviceType();
 
   /*! Retrieves the cameras parameters :
-* leftIntrinsic = left camera focal length [0-1], optical center [2-3], lens distorsion [4-8] and skew [9]
-* rightIntrinsic = left camera focal length [0-1], optical center [2-3], lens distorsion [4-8] and skew [9]
-* rightPosition = position of the right camera in the coordinate system of the left camera
-* rightOrientation = orientation of the right camera in the coordinate system of the left camera
-*/
+  * leftIntrinsic = left camera focal length [0-1], optical center [2-3], lens distorsion [4-8] and skew [9]
+  * rightIntrinsic = left camera focal length [0-1], optical center [2-3], lens distorsion [4-8] and skew [9]
+  * rightPosition = position of the right camera in the coordinate system of the left camera
+  * rightOrientation = orientation of the right camera in the coordinate system of the left camera
+  */
   PlusStatus GetCamerasCalibration(
     std::array<float, 10>& leftIntrinsic, std::array<float, 10>& rightIntrinsic,
     std::array<float, 3>& rightPosition, std::array<float, 3>& rightOrientation);
+
+  PlusStatus GetLoadedGeometries(std::map<int, std::vector<std::array<float, 3>>>& geometries);
 
   /* Device is a hardware tracker. */
   virtual bool IsTracker() const { return true; }


### PR DESCRIPTION
Tracking frequency could now be changed similarly to the measurement volume i.e. by specifying the setting in the configuration file.
Example:
```
<Device
Id="TrackerDevice"
Type="PolarisTracker"
NetworkHostname="169.254.x.x"
NetworkPort="8765"
MeasurementVolumeNumber="1"
TrackingFrequencyNumber="2"
ToolReferenceFrame="Tracker" >
```

This sets the Extended Volume (MeasurementVolumeNumber=1) and a tracking frequency of 60Hz (TrackingFrequencyNumber=2) for a Vega Polaris tracker.
For TrackingFrequencyNumber,
0 = 1/3 of frame frequency =>20Hz
1 = 1/2 of frame frequency =>30Hz
2 = 1/1 of frame frequency =>60Hz