### PR TITLE
SEI disconnection and retry connections

### DIFF
--- a/src/SEIDrv/SEIDrv.cpp
+++ b/src/SEIDrv/SEIDrv.cpp
@@ -7,6 +7,7 @@ ref struct Globals
     static System::Collections::Generic::List<USDigital::A2^> encoders;
     static System::Collections::Generic::Dictionary<unsigned char, USDigital::A2^> addresses;
     static unsigned initialized = 0; // how many times initialization was called
+    static long activeCOM = 0;
 };
 
 void enumerateEncoders(long comPort, long mode, int devicesExpected)
@@ -24,6 +25,7 @@ void enumerateEncoders(long comPort, long mode, int devicesExpected)
         Globals::encoders.Add(a2Dev);
         Globals::addresses.Add(a2Dev->Address, a2Dev);
     }
+    Globals::activeCOM = comPort;
 }
 
 void enumerateEncodersAll(long mode, int devicesExpected)
@@ -127,6 +129,12 @@ void CloseSEI()
         Globals::encoders.Clear();
         Globals::addresses.Clear();
     }
+
+    System::String^ comPortString = "COM" + System::Convert::ToString(Globals::activeCOM);
+    USDigital::SEIBusManager mgr;
+    USDigital::SEIBus^ mSEIBus = mgr.GetBus(comPortString);
+    mSEIBus->Close();
+    Globals::activeCOM = 0;
 }
 
 

--- a/src/SEIDrv/SEIDrv.cpp
+++ b/src/SEIDrv/SEIDrv.cpp
@@ -1,6 +1,7 @@
 #include "SEIDrv.h"
 #include <string>
 #include <Windows.h> // for QueryDosDevice
+#include <chrono>
 
 ref struct Globals
 {
@@ -73,13 +74,29 @@ long InitializeSEI(long comm, long mode, int devicesExpected)
 
     try
     {
-        if (comm == 0)
+        int mRetryLimit = 5;
+        int retryCount = 0;
+        for (int retryCount = 0; retryCount < mRetryLimit; retryCount++)
         {
-            enumerateEncodersAll(mode, devicesExpected);
-        }
-        else
-        {
-            enumerateEncoders(comm, mode, devicesExpected);
+            if (comm == 0)
+            {
+                enumerateEncodersAll(mode, devicesExpected);
+            }
+            else
+            {
+                enumerateEncoders(comm, mode, devicesExpected);
+            }
+            if(GetNumberOfDevices() != devicesExpected && retryCount < mRetryLimit)
+            {
+                System::Console::WriteLine("SEI Retrying...Current number of devices: {0}", GetNumberOfDevices());
+                Globals::encoders.Clear();
+                Globals::addresses.Clear();
+                Sleep(30);
+            }
+            else
+            {
+                break;
+            }
         }
         Globals::initialized = 1;
         return 0;


### PR DESCRIPTION
This adds some changes to the SEIDrv to explicitly close the SEI bus at time of close. It also adds retry connection attempts based on a USDigital example to address certain issues of failed connections where the connection started soon after another connection ended.

cc: @adamaji 