### PR TITLE
ENH: Expose Additional Getter/Setter Functions for Capistrano Device

### DIFF
--- a/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
+++ b/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.cxx
@@ -25,13 +25,25 @@ vtkStandardNewMacro(vtkPlusCapistranoVideoSource);
 const char* vtkPlusCapistranoVideoSource::CAPISTRANO_SET_WOBBLE_RATE = "SetWobbleRate";
 const char* vtkPlusCapistranoVideoSource::CAPISTRANO_GET_WOBBLE_RATE = "GetWobbleRate";
 const char* vtkPlusCapistranoVideoSource::CAPISTRANO_SET_BIDIRECTIONAL_MODE = "SetBidirectionalMode";
+const char* vtkPlusCapistranoVideoSource::CAPISTRANO_GET_BIDIRECTIONAL_MODE = "GetBidirectionalMode";
 const char* vtkPlusCapistranoVideoSource::CAPISTRANO_FREEZE_PROBE = "FreezeProbe";
 const char* vtkPlusCapistranoVideoSource::CAPISTRANO_IS_PROBE_FROZEN = "IsProbeFrozen";
 const char* vtkPlusCapistranoVideoSource::CAPISTRANO_SET_JITTER_COMPENSATION = "SetJitterCompensation";
 const char* vtkPlusCapistranoVideoSource::CAPISTRANO_GET_JITTER_COMPENSATION = "GetJitterCompensation";
 const char* vtkPlusCapistranoVideoSource::CAPISTRANO_SET_MIS_MODE = "SetMISMode";
+const char* vtkPlusCapistranoVideoSource::CAPISTRANO_GET_MIS_MODE = "GetMISMode";
 const char* vtkPlusCapistranoVideoSource::CAPISTRANO_SET_MIS_PULSE_PERIOD = "SetMISPulsePeriod";
 const char* vtkPlusCapistranoVideoSource::CAPISTRANO_GET_MIS_PULSE_PERIOD = "GetMISPulsePeriod";
+const char* vtkPlusCapistranoVideoSource::CAPISTRANO_SET_SWEEP_ANGLE = "SetSweepAngle";
+const char* vtkPlusCapistranoVideoSource::CAPISTRANO_GET_SWEEP_ANGLE = "GetSweepAngle";
+const char* vtkPlusCapistranoVideoSource::CAPISTRANO_SET_DERIVATIVE_COMPENSATION = "SetDerivativeCompensation";
+const char* vtkPlusCapistranoVideoSource::CAPISTRANO_GET_DERIVATIVE_COMPENSATION = "GetDerivativeCompensation";
+const char* vtkPlusCapistranoVideoSource::CAPISTRANO_SET_SAMPLE_FREQUENCY = "SetSampleFrequency";
+const char* vtkPlusCapistranoVideoSource::CAPISTRANO_GET_SAMPLE_FREQUENCY = "GetSampleFrequency";
+const char* vtkPlusCapistranoVideoSource::CAPISTRANO_SET_SERVO_GAIN = "SetServoGain";
+const char* vtkPlusCapistranoVideoSource::CAPISTRANO_GET_SERVO_GAIN = "GetServoGain";
+const char* vtkPlusCapistranoVideoSource::CAPISTRANO_SET_POSITION_SCALE = "SetPositionScale";
+const char* vtkPlusCapistranoVideoSource::CAPISTRANO_GET_POSITION_SCALE = "GetPositionScale";
 
 class vtkPlusCapistranoVideoSource::vtkInternal
 {

--- a/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.h
+++ b/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.h
@@ -30,13 +30,25 @@ public:
   static const char* CAPISTRANO_SET_WOBBLE_RATE;
   static const char* CAPISTRANO_GET_WOBBLE_RATE;
   static const char* CAPISTRANO_SET_BIDIRECTIONAL_MODE;
+  static const char* CAPISTRANO_GET_BIDIRECTIONAL_MODE;
   static const char* CAPISTRANO_FREEZE_PROBE;
   static const char* CAPISTRANO_IS_PROBE_FROZEN;
   static const char* CAPISTRANO_SET_JITTER_COMPENSATION;
   static const char* CAPISTRANO_GET_JITTER_COMPENSATION;
   static const char* CAPISTRANO_SET_MIS_MODE;
+  static const char* CAPISTRANO_GET_MIS_MODE;
   static const char* CAPISTRANO_SET_MIS_PULSE_PERIOD;
   static const char* CAPISTRANO_GET_MIS_PULSE_PERIOD;
+  static const char* CAPISTRANO_SET_SWEEP_ANGLE;
+  static const char* CAPISTRANO_GET_SWEEP_ANGLE;
+  static const char* CAPISTRANO_SET_DERIVATIVE_COMPENSATION;
+  static const char* CAPISTRANO_GET_DERIVATIVE_COMPENSATION;
+  static const char* CAPISTRANO_SET_SAMPLE_FREQUENCY;
+  static const char* CAPISTRANO_GET_SAMPLE_FREQUENCY;
+  static const char* CAPISTRANO_SET_SERVO_GAIN;
+  static const char* CAPISTRANO_GET_SERVO_GAIN;
+  static const char* CAPISTRANO_SET_POSITION_SCALE;
+  static const char* CAPISTRANO_GET_POSITION_SCALE;
 
   /*! Specify the device connected to this class */
   bool IsTracker() const override

--- a/src/PlusServer/Commands/vtkPlusCapistranoCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusCapistranoCommand.cxx
@@ -204,7 +204,7 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
           if (!valid)
           {
             error += "Failed to parse " + parameterName + ". ";
-            resultString += " Success=\"false\"/>";
+            resultString += " Success=\"false\"";
             metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "FAIL");
             status = PLUS_FAIL;
             continue;
@@ -222,7 +222,7 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
     else
     {
       error += "Invalid parameter " + parameterName + ". ";
-      resultString += " Success=\"false\"/>";
+      resultString += " Success=\"false\"";
       metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "FAIL");
       status = PLUS_FAIL;
       continue;
@@ -231,7 +231,7 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
     {
       int wobbleRate_int = std::stoi(value);
       status = device->SetWobbleRate((unsigned char)wobbleRate_int);
-      resultString += " Success=\"true\"/>";
+      resultString += " Success=\"true\"";
       metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "SUCCESS");
     }
     else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_WOBBLE_RATE)
@@ -248,7 +248,7 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
     {
       bool bidi = std::stoi(value);
       device->SetBidirectionalMode(bidi);
-      resultString += " Success=\"true\"/>";
+      resultString += " Success=\"true\"";
       metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "SUCCESS");
     }
     else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_FREEZE_PROBE)
@@ -256,13 +256,13 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
       bool freezeProbe_bool = std::stoi(value);
       if (device->FreezeDevice(freezeProbe_bool) == PLUS_SUCCESS)
       {
-        resultString += " Success=\"true\"/>";
+        resultString += " Success=\"true\"";
         metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "SUCCESS");
       }
       else
       {
         LOG_ERROR("Failed to freeze probe"); 
-        resultString += " Success=\"false\"/>";
+        resultString += " Success=\"false\"";
         metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "FAIL");
       }
     }
@@ -280,7 +280,7 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
     {
       int jitterCompensation_int = std::stoi(value);
       status = device->SetJitterCompensation((unsigned char)jitterCompensation_int);
-      resultString += " Success=\"true\"/>";
+      resultString += " Success=\"true\"";
       metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "SUCCESS");
     }
     else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_JITTER_COMPENSATION)
@@ -298,13 +298,13 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
       bool MISMode_bool = std::stoi(value);
       if (device->SetMISMode(MISMode_bool) == PLUS_SUCCESS)
       {
-        resultString += " Success=\"true\"/>";
+        resultString += " Success=\"true\"";
         metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "SUCCESS");
       }
       else
       {
         LOG_ERROR("Failed to set MIS mode"); 
-        resultString += " Success=\"false\"/>";
+        resultString += " Success=\"false\"";
         metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "FAIL");
       }
     }
@@ -313,24 +313,25 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
       int misPulse_int = std::stoi(value);
       if (device->SetMISPulsePeriod((unsigned char)misPulse_int) == PLUS_SUCCESS)
       {
-        resultString += " Success=\"true\"/>";
+        resultString += " Success=\"true\"";
         metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "SUCCESS");
       }
       else
       {
         LOG_ERROR("Failed to set MIS pulse period"); 
-        resultString += " Success=\"false\"/>";
+        resultString += " Success=\"false\"";
         metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "FAIL");
       }
     }
     if (status != PLUS_SUCCESS)
     {
       error += "Failed to set " + parameterName + ". ";
-      resultString += " Success=\"false\"/>";
+      resultString += " Success=\"false\"";
       metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "FAIL");
       status = PLUS_FAIL;
       continue;
     }
+    resultString += "/>";
   } // For each parameter
   resultString += "</CommandReply>";
 

--- a/src/PlusServer/Commands/vtkPlusCapistranoCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusCapistranoCommand.cxx
@@ -185,6 +185,7 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
   std::string error = "";
   std::map < std::string, std::pair<IANA_ENCODING_TYPE, std::string> > metaData;
   PlusStatus status = PLUS_SUCCESS;
+  bool hasFailure = false;
 
   std::list<std::pair<std::string, std::string>>::iterator paramIt;
   for (paramIt = this->RequestedParameterChanges.begin(); paramIt != this->RequestedParameterChanges.end(); ++paramIt)
@@ -197,7 +198,12 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
         || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_MIS_PULSE_PERIOD
         || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_JITTER_COMPENSATION
         || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_FREEZE_PROBE
-        || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_BIDIRECTIONAL_MODE)
+        || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_BIDIRECTIONAL_MODE
+        || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_SWEEP_ANGLE
+        || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_DERIVATIVE_COMPENSATION
+        || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_SAMPLE_FREQUENCY
+        || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_SERVO_GAIN
+        || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_POSITION_SCALE)
         {
           bool valid = false;
           double parameterValue = vtkVariant(value).ToDouble(&valid);
@@ -212,7 +218,15 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
         }
     else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_WOBBLE_RATE
              || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_JITTER_COMPENSATION
-             || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_IS_PROBE_FROZEN)
+             || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_IS_PROBE_FROZEN
+             || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_MIS_PULSE_PERIOD
+             || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_MIS_MODE
+             || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_BIDIRECTIONAL_MODE
+             || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_SWEEP_ANGLE
+             || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_DERIVATIVE_COMPENSATION
+             || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_SAMPLE_FREQUENCY
+             || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_SERVO_GAIN
+             || parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_POSITION_SCALE)
         {
           if (value != "None")
           {
@@ -226,7 +240,7 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
       metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "FAIL");
       status = PLUS_FAIL;
       continue;
-    } 
+    }
     if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_WOBBLE_RATE)
     {
       int wobbleRate_int = std::stoi(value);
@@ -237,11 +251,9 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
     else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_WOBBLE_RATE)
     {
       value = std::to_string(device->GetWobbleRate());
-      std::stringstream ss;
-      ss << value;
       resultString += " Success=\"true\"";
-      resultString += " Value=\"" + ss.str() + "\"";
-      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, ss.str());
+      resultString += " Value=\"" + value + "\"";
+      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, value);
       status = PLUS_SUCCESS;
     }
     else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_BIDIRECTIONAL_MODE)
@@ -250,6 +262,13 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
       device->SetBidirectionalMode(bidi);
       resultString += " Success=\"true\"";
       metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "SUCCESS");
+    }
+    else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_BIDIRECTIONAL_MODE)
+    {
+      value = std::to_string(device->GetBidirectionalMode());
+      resultString += " Success=\"true\"";
+      resultString += " Value=\"" + value + "\"";
+      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, value);
     }
     else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_FREEZE_PROBE)
     {
@@ -261,7 +280,7 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
       }
       else
       {
-        LOG_ERROR("Failed to freeze probe"); 
+        LOG_ERROR("Failed to freeze probe");
         resultString += " Success=\"false\"";
         metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "FAIL");
       }
@@ -269,11 +288,9 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
     else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_IS_PROBE_FROZEN)
     {
       value = device->IsFrozen() ? "1" : "0";
-      std::stringstream ss;
-      ss << value;
       resultString += " Success=\"true\"";
-      resultString += " Value=\"" + ss.str() + "\"";
-      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, ss.str());
+      resultString += " Value=\"" + value + "\"";
+      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, value);
       status = PLUS_SUCCESS;
     }
     else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_JITTER_COMPENSATION)
@@ -286,11 +303,9 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
     else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_JITTER_COMPENSATION)
     {
       value = std::to_string(device->GetJitterCompensation());
-      std::stringstream ss;
-      ss << value;
       resultString += " Success=\"true\"";
-      resultString += " Value=\"" + ss.str() + "\"";
-      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, ss.str());
+      resultString += " Value=\"" + value + "\"";
+      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, value);
       status = PLUS_SUCCESS;
     }
     else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_MIS_MODE)
@@ -303,7 +318,24 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
       }
       else
       {
-        LOG_ERROR("Failed to set MIS mode"); 
+        LOG_ERROR("Failed to set MIS mode");
+        resultString += " Success=\"false\"";
+        metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "FAIL");
+      }
+    }
+    else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_MIS_MODE)
+    {
+      bool MISMode;
+      if (device->GetMISMode(MISMode) == PLUS_SUCCESS)
+      {
+        value = std::to_string(MISMode);
+        resultString += " Success=\"true\"";
+        resultString += " Value=\"" + value + "\"";
+        metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, value);
+      }
+      else
+      {
+        LOG_ERROR("Failed to get MIS mode");
         resultString += " Success=\"false\"";
         metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "FAIL");
       }
@@ -318,28 +350,109 @@ PlusStatus vtkPlusCapistranoCommand::Execute()
       }
       else
       {
-        LOG_ERROR("Failed to set MIS pulse period"); 
+        LOG_ERROR("Failed to set MIS pulse period");
         resultString += " Success=\"false\"";
         metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "FAIL");
       }
     }
-    if (status != PLUS_SUCCESS)
+    else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_MIS_PULSE_PERIOD)
     {
+      unsigned int PulsePeriod;
+      if (device->GetMISPulsePeriod(PulsePeriod) == PLUS_SUCCESS)
+      {
+        value = std::to_string(PulsePeriod);
+        resultString += " Success=\"true\"";
+        resultString += " Value=\"" + value + "\"";
+        metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, value);
+      }
+      else
+      {
+        LOG_ERROR("Failed to get MIS pulse period");
+        resultString += " Success=\"false\"";
+        metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "FAIL");
+      }
+    }
+    else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_SWEEP_ANGLE)
+    {
+      float sweepAngle = std::stof(value);
+      status = device->SetSweepAngle(sweepAngle);
+      resultString += " Success=\"true\"";
+      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "SUCCESS");
+    }
+    else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_SWEEP_ANGLE)
+    {
+      value = std::to_string(device->GetSweepAngle());
+      resultString += " Success=\"true\"";
+      resultString += " Value=\"" + value + "\"";
+      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, value);
+      status = PLUS_SUCCESS;
+    }
+    else if  (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_DERIVATIVE_COMPENSATION)
+    {
+      int derComp = std::stoi(value);
+      status = device->SetDerivativeCompensation((unsigned char)derComp);
+      resultString += " Success=\"true\"";
+      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "SUCCESS");
+    }
+    else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_DERIVATIVE_COMPENSATION)
+    {
+      value = std::to_string(device->GetDerivativeCompensation());
+      resultString += " Success=\"true\"";
+      resultString += " Value=\"" + value + "\"";
+      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, value);
+      status = PLUS_SUCCESS;
+    }
+    else if  (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_SERVO_GAIN)
+    {
+      int servoGain = std::stoi(value);
+      status = device->SetServoGain((unsigned char)servoGain);
+      resultString += " Success=\"true\"";
+      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "SUCCESS");
+    }
+    else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_SERVO_GAIN)
+    {
+      value = std::to_string(device->GetServoGain());
+      resultString += " Success=\"true\"";
+      resultString += " Value=\"" + value + "\"";
+      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, value);
+      status = PLUS_SUCCESS;
+    }
+    else if  (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_SET_POSITION_SCALE)
+    {
+      int positionScale = std::stoi(value);
+      status = device->SetPositionScale((unsigned char)positionScale);
+      resultString += " Success=\"true\"";
+      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "SUCCESS");
+    }
+    else if (parameterName == vtkPlusCapistranoVideoSource::CAPISTRANO_GET_POSITION_SCALE)
+    {
+      value = std::to_string(device->GetPositionScale());
+      resultString += " Success=\"true\"";
+      resultString += " Value=\"" + value + "\"";
+      metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, value);
+      status = PLUS_SUCCESS;
+    }
+    else
+    {
+      status = PLUS_FAIL;
       error += "Failed to set " + parameterName + ". ";
       resultString += " Success=\"false\"";
       metaData[parameterName] = std::make_pair(IANA_TYPE_US_ASCII, "FAIL");
       status = PLUS_FAIL;
-      continue;
+    }
+    if (status != PLUS_SUCCESS)
+    {
+      hasFailure = true;
     }
     resultString += "/>";
   } // For each parameter
   resultString += "</CommandReply>";
-
-  if (status != PLUS_SUCCESS)
+  if (hasFailure)
   {
-    LOG_WARNING("Failed to set US parameter, result string was: " << resultString);
+    status = PLUS_FAIL;
+    LOG_WARNING("Failed to set some requested parameter(s), result string was: " << resultString);
   }
-  
+
   vtkSmartPointer<vtkPlusCommandRTSCommandResponse> commandResponse = vtkSmartPointer<vtkPlusCommandRTSCommandResponse>::New();
   commandResponse->UseDefaultFormatOff();
   commandResponse->SetClientId(this->ClientId);


### PR DESCRIPTION
This PR extends vtkPlusCommand functionality for Capistrano device commands: 

**GetMISMode, GetMISPulsePeriod, GetBidirectionalMode 
SetSweepAngle, GetSweepAngle 
SetDerivativeCompensation, GetDerivativeCompensation 
 
SetServoGain, GetServoGain 
SetPositionScale, GetPositionScale** 

 
Example Usage: 
**Command** 
`<Command Name="CapistranoCommand" UsDeviceId="Wobbler"><Parameter Name="GetDerivativeCompensation"/></Command>`
**Reply** 
`<CommandReply><Parameter Name="GetDerivativeCompensation" Success="true" Value="120"/></CommandReply>`

 
cc [@jamesobutler](https://github.com/jamesobutler) who has tested with hardware