### PR TITLE
ENH get loaded marker geometries through Atracsys wrapper

### DIFF
--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
@@ -127,7 +127,7 @@ public:
   // helper function to load ftkGeometry from string
   ATRACSYS_RESULT LoadFtkGeometryFromString(const std::string& geomString, ftkGeometry& geom);
 
-  std::map<int, std::vector<std::array<float, 3>>> geometries;
+  std::map<int, std::vector<std::array<float, 3>>> Geometries;
 
   // correspondence between atracsys option name and its actual id in the sdk
   // this map is filled automatically by the sdk, DO NOT hardcode/change any id

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
@@ -127,6 +127,8 @@ public:
   // helper function to load ftkGeometry from string
   ATRACSYS_RESULT LoadFtkGeometryFromString(const std::string& geomString, ftkGeometry& geom);
 
+  std::map<int, std::vector<std::array<float, 3>>> geometries;
+
   // correspondence between atracsys option name and its actual id in the sdk
   // this map is filled automatically by the sdk, DO NOT hardcode/change any id
   std::map<std::string, ftkOptionsInfo> DeviceOptionMap{};
@@ -476,9 +478,16 @@ public:
       }
     }
 
+    std::vector<std::array<float, 3>> pts;
+    for (uint32 i(0u); i < geometry.pointsCount; ++i)
+    {
+      std::array<float, 3> pt = { geometry.positions[i].x, geometry.positions[i].y, geometry.positions[i].z };
+      pts.push_back(pt);
+    }
+    geometries[geometry.geometryId] = pts;
+
     return true;
   }
-
 };
 
 //----------------------------------------------------------------------------
@@ -854,6 +863,13 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetMarkerInfo(std::string& mar
     return ERROR_CANNOT_GET_MARKER_INFO;
   }
   markerInfo = std::string(buffer.data, buffer.data + buffer.size);
+  return SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetLoadedGeometries(std::map<int, std::vector<std::array<float, 3>>>& geometries)
+{
+  geometries = this->Internal->geometries;
   return SUCCESS;
 }
 

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.h
@@ -171,6 +171,9 @@ public:
   ATRACSYS_RESULT GetMarkerInfo(std::string& markerInfo);
 
   /*! */
+  ATRACSYS_RESULT GetLoadedGeometries(std::map<int, std::vector<std::array<float,3>>>& geometries);
+
+  /*! */
   std::string ResultToString(ATRACSYS_RESULT result);
 
   /*! */

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
@@ -164,6 +164,22 @@ PlusStatus vtkPlusAtracsysTracker::GetCamerasCalibration(
 }
 
 //----------------------------------------------------------------------------
+PlusStatus vtkPlusAtracsysTracker::GetLoadedGeometries(std::map<int, std::vector<std::array<float, 3>>>& geometries)
+{
+  if (this->Internal->Tracker.GetLoadedGeometries(geometries) != ATRACSYS_RESULT::SUCCESS)
+  {
+    LOG_ERROR("Could not get loaded geometries");
+    return PLUS_FAIL;
+  }
+  if (geometries.size() == 0)
+  {
+    LOG_ERROR("No loaded geometries");
+    return PLUS_FAIL;
+  }
+  return PLUS_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
 PlusStatus vtkPlusAtracsysTracker::ReadConfiguration(vtkXMLDataElement* rootConfigElement)
 {
   // Read and store all device options read in the xml config file

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.h
@@ -33,14 +33,16 @@ public:
   std::string GetDeviceType();
 
   /*! Retrieves the cameras parameters :
-* leftIntrinsic = left camera focal length [0-1], optical center [2-3], lens distorsion [4-8] and skew [9]
-* rightIntrinsic = left camera focal length [0-1], optical center [2-3], lens distorsion [4-8] and skew [9]
-* rightPosition = position of the right camera in the coordinate system of the left camera
-* rightOrientation = orientation of the right camera in the coordinate system of the left camera
-*/
+  * leftIntrinsic = left camera focal length [0-1], optical center [2-3], lens distorsion [4-8] and skew [9]
+  * rightIntrinsic = left camera focal length [0-1], optical center [2-3], lens distorsion [4-8] and skew [9]
+  * rightPosition = position of the right camera in the coordinate system of the left camera
+  * rightOrientation = orientation of the right camera in the coordinate system of the left camera
+  */
   PlusStatus GetCamerasCalibration(
     std::array<float, 10>& leftIntrinsic, std::array<float, 10>& rightIntrinsic,
     std::array<float, 3>& rightPosition, std::array<float, 3>& rightOrientation);
+
+  PlusStatus GetLoadedGeometries(std::map<int, std::vector<std::array<float, 3>>>& geometries);
 
   /* Device is a hardware tracker. */
   virtual bool IsTracker() const { return true; }

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.h
@@ -42,6 +42,10 @@ public:
     std::array<float, 10>& leftIntrinsic, std::array<float, 10>& rightIntrinsic,
     std::array<float, 3>& rightPosition, std::array<float, 3>& rightOrientation);
 
+  /*! Retrieves the loaded marker geometries :
+  * geometries maps a marker (described by its id) to the vector of x,y,z coordinates of each fiducial
+  * that composes the marker
+  */
   PlusStatus GetLoadedGeometries(std::map<int, std::vector<std::array<float, 3>>>& geometries);
 
   /* Device is a hardware tracker. */


### PR DESCRIPTION
The geometry that describes the tracked markers can be retrieved as a vector of coords x,y,z (float) for each fiducial that composes the marker.