### PR TITLE
ENH: Expose ARFI InterSet and InterPush delays

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1902,6 +1902,11 @@ PlusStatus vtkPlusWinProbeVideoSource::SetARFILineTimer(uint16_t propertyValue)
 
   if(Connected)
   {
+    if(propertyValue > 2000)
+    {
+      LOG_ERROR("The maximum ARFI line timer is 2000. Ignoring call to change to " << propertyValue);
+      return PLUS_FAIL;
+    }
     m_ARFILineTimer = propertyValue;
     ::SetARFILineTimer(propertyValue);
     SetPendingRecreateTables(true);

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -75,6 +75,10 @@ const char* vtkPlusWinProbeVideoSource::SET_ARFI_PRE_PUSH_LINE_REPEAT_COUNT  = "
 const char* vtkPlusWinProbeVideoSource::GET_ARFI_PRE_PUSH_LINE_REPEAT_COUNT  = "GetARFIPrePushLineRepeatCount";
 const char* vtkPlusWinProbeVideoSource::SET_ARFI_POST_PUSH_LINE_REPEAT_COUNT = "SetARFIPostPushLineRepeatCount";
 const char* vtkPlusWinProbeVideoSource::GET_ARFI_POST_PUSH_LINE_REPEAT_COUNT = "GetARFIPostPushLineRepeatCount";
+const char* vtkPlusWinProbeVideoSource::GET_ARFI_INTER_SET_DELAY     = "GetARFIInterSetDelay";
+const char* vtkPlusWinProbeVideoSource::SET_ARFI_INTER_SET_DELAY     = "SetARFIInterSetDelay";
+const char* vtkPlusWinProbeVideoSource::GET_ARFI_INTER_PUSH_DELAY    = "GetARFIInterPushDelay";
+const char* vtkPlusWinProbeVideoSource::SET_ARFI_INTER_PUSH_DELAY    = "SetARFIInterPushDelay";
 const char* vtkPlusWinProbeVideoSource::SET_ARFI_LINE_TIMER          = "SetARFILineTimer";
 const char* vtkPlusWinProbeVideoSource::GET_ARFI_LINE_TIMER          = "GetARFILineTimer";
 const char* vtkPlusWinProbeVideoSource::SET_ARFI_TX_CYCLE_COUNT      = "SetARFITxCycleCount";
@@ -926,6 +930,8 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
     SetARFITxTxCycleWidth(m_ARFITxTxCycleWidth);
     SetARFITxCycleCount(m_ARFITxCycleCount);
     SetARFITxCycleWidth(m_ARFITxCycleWidth);
+    SetARFIInterSetDelay(m_ARFIInterSetDelay);
+    SetARFIInterPushDelay(m_ARFIInterPushDelay);
     SetARFILineTimer(m_ARFILineTimer);
     SetARFIStartSample(m_ARFIStartSample);
     SetARFIStopSample(m_ARFIStopSample);
@@ -1955,6 +1961,58 @@ int32_t vtkPlusWinProbeVideoSource::GetARFIPostPushLineRepeatCount()
     m_ARFIPostPushLineRepeatCount = ::GetARFIPostPushLineRepeatCount();
   }
   return m_ARFIPostPushLineRepeatCount;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusWinProbeVideoSource::SetARFIInterSetDelay(int32_t propertyValue)
+{
+  if(Connected)
+  {
+    if(propertyValue > 250 * 250)
+    {
+      LOG_ERROR("The maximum ARFI inter set delay is 250*250. Ignoring call to change to " << propertyValue);
+      return PLUS_FAIL;
+    }
+    m_ARFIInterSetDelay = propertyValue;
+    ::SetARFIInterSetDelay(propertyValue);  // API call includes SetPendingRecreateTables(true). Really just need SetPendingRestartSequencer(true);
+    return PLUS_SUCCESS;
+  }
+  return PLUS_FAIL;
+}
+
+int32_t vtkPlusWinProbeVideoSource::GetARFIInterSetDelay()
+{
+  if(Connected)
+  {
+    m_ARFIInterSetDelay = ::GetARFIInterSetDelay();
+  }
+  return m_ARFIInterSetDelay;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusWinProbeVideoSource::SetARFIInterPushDelay(int32_t propertyValue)
+{
+  if(Connected)
+  {
+    if(propertyValue > 250)
+    {
+      LOG_ERROR("The maximum ARFI inter push delay is 250. Ignoring call to change to " << propertyValue);
+      return PLUS_FAIL;
+    }
+    m_ARFIInterPushDelay = propertyValue;
+    ::SetARFIInterPushDelay(propertyValue);  // API call includes SetPendingRecreateTables(true). Really just need SetPendingRestartSequencer(true);
+    return PLUS_SUCCESS;
+  }
+  return PLUS_FAIL;
+}
+
+int32_t vtkPlusWinProbeVideoSource::GetARFIInterPushDelay()
+{
+  if(Connected)
+  {
+    m_ARFIInterPushDelay = ::GetARFIInterPushDelay();
+  }
+  return m_ARFIInterPushDelay;
 }
 
 //----------------------------------------------------------------------------

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1977,7 +1977,10 @@ std::string vtkPlusWinProbeVideoSource::GetARFIPushConfigurationString()
 {
   if(Connected)
   {
-    m_ARFIPushConfigurationString = WPGetARFIPushConfigurationString();
+    char* temp = new char[50];
+    WPGetARFIPushConfigurationString(temp);
+    m_ARFIPushConfigurationString.assign(temp);
+    delete[] temp;
   }
   return m_ARFIPushConfigurationString;
 }
@@ -1985,7 +1988,10 @@ std::string vtkPlusWinProbeVideoSource::GetARFIPushConfigurationString()
 //----------------------------------------------------------------------------
 std::string vtkPlusWinProbeVideoSource::GetFPGARevDateString()
 {
-  m_FPGAVersion = WPGetFPGARevDateString();
+  char* temp = new char[20];
+  WPGetFPGARevDateString(temp);
+  m_FPGAVersion.assign(temp);
+  delete[] temp;
   return m_FPGAVersion;
 }
 

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -83,6 +83,10 @@ public:
   static const char* GET_ARFI_PRE_PUSH_LINE_REPEAT_COUNT;
   static const char* SET_ARFI_POST_PUSH_LINE_REPEAT_COUNT;
   static const char* GET_ARFI_POST_PUSH_LINE_REPEAT_COUNT;
+  static const char* SET_ARFI_INTER_SET_DELAY;
+  static const char* GET_ARFI_INTER_SET_DELAY;
+  static const char* SET_ARFI_INTER_PUSH_DELAY;
+  static const char* GET_ARFI_INTER_PUSH_DELAY;
   static const char* SET_ARFI_LINE_TIMER;
   static const char* GET_ARFI_LINE_TIMER;
   static const char* SET_ARFI_TX_CYCLE_COUNT;
@@ -348,6 +352,27 @@ public:
   /* Get the number of repeats for the tracking lines after the push. */
   int32_t GetARFIPostPushLineRepeatCount();
 
+  /*!
+  Set the integer increment (1.05ms per increment) to delay after completion of the ARFIPushConfigurationString before it begins live streaming B-Mode frames again.
+
+  The interset delay is a post ARFI configuration string delay.
+  Example: "1,33,44;1,41,52;1,49,60;1,57,68;1,65,76;1,73,84;2,36,44;2,44,52;2,52,60;2,60,68;2,68,76;2,76,84(interset)"
+  */
+  PlusStatus SetARFIInterSetDelay(int32_t propertyValue);
+
+   /* Get the integer increment (1.05ms per increment) to delay after completion of the ARFIPushConfigurationString before it begins live streaming B-Mode frames again. */
+  int32_t GetARFIInterSetDelay();
+
+  /*!
+  Set the integer increment (1.05ms per increment) to delay after each push of the ARFIPushConfigurationString.
+
+  Example: "1,33,44;(interpush)1,41,52;(interpush)1,49,60;(interpush)1,57,68;(interpush)1,65,76;(interpush)1,73,84;(interpush)(interset)"
+  */
+  PlusStatus SetARFIInterPushDelay(int32_t propertyValue);
+
+  /* Get the integer increment (1.05ms per increment) to delay after each push of the ARFIPushConfigurationString. */
+  int32_t GetARFIInterPushDelay();
+
   int GetTransducerInternalID();
 
   /*!
@@ -483,6 +508,8 @@ protected:
   uint16_t m_ARFILineTimer = 100;
   int32_t m_ARFIPrePushLineRepeatCount = 8;
   int32_t m_ARFIPostPushLineRepeatCount = 56;
+  int32_t m_ARFIInterSetDelay = 0;
+  int32_t m_ARFIInterPushDelay = 100;
   std::string m_ARFIPushConfigurationString = "1,33,44;1,41,52;1,49,60;1,57,68;1,65,76;1,73,84";
   int m_ARFIPushConfigurationCount = 6;
   int32_t m_MPRF = 100;

--- a/src/PlusServer/Commands/vtkPlusWinProbeCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusWinProbeCommand.cxx
@@ -281,6 +281,8 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_STOP_SAMPLE)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_PRE_PUSH_LINE_REPEAT_COUNT)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_POST_PUSH_LINE_REPEAT_COUNT)
+        || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_INTER_SET_DELAY)
+        || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_INTER_PUSH_DELAY)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_LINE_TIMER)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_TX_CYCLE_COUNT)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_TX_CYCLE_WIDTH)
@@ -344,6 +346,10 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
           res = std::to_string(device->GetARFIPrePushLineRepeatCount());
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_POST_PUSH_LINE_REPEAT_COUNT))
           res = std::to_string(device->GetARFIPostPushLineRepeatCount());
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_INTER_SET_DELAY))
+          res = std::to_string(device->GetARFIInterSetDelay());
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_INTER_PUSH_DELAY))
+          res = std::to_string(device->GetARFIInterPushDelay());
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_LINE_TIMER))
           res = std::to_string(device->GetARFILineTimer());
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_TX_CYCLE_COUNT))
@@ -402,6 +408,8 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_STOP_SAMPLE)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_PRE_PUSH_LINE_REPEAT_COUNT)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_POST_PUSH_LINE_REPEAT_COUNT)
+             || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_INTER_SET_DELAY)
+             || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_INTER_PUSH_DELAY)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_LINE_TIMER)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_TX_CYCLE_COUNT)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_TX_CYCLE_WIDTH)
@@ -554,6 +562,16 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
       {
         int32_t val = stoi(value);
         status = device->SetARFIPostPushLineRepeatCount(val);
+      }
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_INTER_SET_DELAY))
+      {
+        int32_t val = stoi(value);
+        status = device->SetARFIInterSetDelay(val);
+      }
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_INTER_PUSH_DELAY))
+      {
+        int32_t val = stoi(value);
+        status = device->SetARFIInterPushDelay(val);
       }
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_LINE_TIMER))
       {


### PR DESCRIPTION
This exposes a couple new parameters (InterSet and InterPush delays) for the WinProbe device.

cc: @hannah-morilak for an approving review based on hardware testing

`BUG: Fix Winprobe ARFI cmds failing in debug builds` is for compatibility with the latest WinProbe API which has the InterSet and InterPush parameters.