### PR TITLE
Enhancements to StartStopRecording command

### DIFF
--- a/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.cxx
@@ -65,7 +65,10 @@ std::string vtkPlusStartStopRecordingCommand::GetDescription(const std::string& 
   if (commandName.empty() || igsioCommon::IsEqualInsensitive(commandName, START_CMD))
   {
     desc += START_CMD;
-    desc += ": Start collecting data into file with a VirtualCapture device. Attributes: OutputFilename: name of the output file (optional if base file name is specified in config file). CaptureDeviceId: ID of the capture device, if not specified then the first VirtualCapture device will be started (optional)";
+    desc += ": Start collecting data into file with a VirtualCapture device.";
+    desc += " Attributes: OutputFilename: name of the output file (optional if base file name is specified in config file).";
+    desc += " CaptureDeviceId: ID of the capture device, if not specified then the first VirtualCapture device will be started (optional)";
+    desc += " PauseOnStart: Whether to enable capture when opening file. (optional)";
   }
   if (commandName.empty() || igsioCommon::IsEqualInsensitive(commandName, SUSPEND_CMD))
   {
@@ -127,6 +130,7 @@ PlusStatus vtkPlusStartStopRecordingCommand::ReadConfiguration(vtkXMLDataElement
   if (this->GetName() == START_CMD)
   {
     XML_READ_BOOL_ATTRIBUTE_OPTIONAL(EnableCompression, aConfig);
+    XML_READ_BOOL_ATTRIBUTE_OPTIONAL(PauseOnStart, aConfig);
     XML_READ_STRING_ATTRIBUTE_OPTIONAL(CodecFourCC, aConfig);
   }
   else if (this->GetName() == HEADER_CMD)
@@ -344,7 +348,7 @@ PlusStatus vtkPlusStartStopRecordingCommand::Execute()
       this->QueueCommandResponse(PLUS_FAIL, "Command failed. See error message.", responseMessageBase + std::string("Failed to open file ") + (!this->OutputFilename.empty() ? this->OutputFilename : "(undefined)") + std::string("."));
       return PLUS_FAIL;
     }
-    captureDevice->SetEnableCapturing(true);
+    captureDevice->SetEnableCapturing(!this->GetPauseOnStart());
     this->QueueCommandResponse(PLUS_SUCCESS, responseMessageBase + "successful.");
     return PLUS_SUCCESS;
   }

--- a/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.cxx
@@ -395,7 +395,7 @@ PlusStatus vtkPlusStartStopRecordingCommand::Execute()
 
     long numberOfFramesRecorded = captureDevice->GetTotalFramesRecorded();
     std::string actualOutputFilename;
-    if (captureDevice->CloseFile(this->OutputFilename.c_str(), &actualOutputFilename) != PLUS_SUCCESS)
+    if (captureDevice->CloseFile(resultFilename.c_str(), &actualOutputFilename) != PLUS_SUCCESS)
     {
       this->QueueCommandResponse(PLUS_FAIL, "Command failed. See error message.", responseMessageBase + "Failed to finalize file: " + resultFilename);
       return PLUS_FAIL;

--- a/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.cxx
@@ -372,10 +372,10 @@ PlusStatus vtkPlusStartStopRecordingCommand::Execute()
   }
   else if (igsioCommon::IsEqualInsensitive(this->Name, STOP_CMD))
   {
-    // it's stopped if: not in progress (it may be just suspended) and no frames have been recorded
-    if (!captureDevice->GetEnableCapturing() && captureDevice->GetTotalFramesRecorded() == 0)
+    // Don't bother closing the file if there aren't any frames
+    if (captureDevice->GetTotalFramesRecorded() == 0)
     {
-      this->QueueCommandResponse(PLUS_FAIL, "Command failed. See error message.", responseMessageBase + std::string("Recording to file is already stopped."));
+      this->QueueCommandResponse(PLUS_FAIL, "Command failed. See error message.", responseMessageBase + std::string("No frames to record."));
       return PLUS_FAIL;
     }
 

--- a/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.h
+++ b/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.h
@@ -55,6 +55,9 @@ public:
   vtkGetMacro(EnableCompression, bool);
   vtkSetMacro(EnableCompression, bool);
 
+  vtkGetMacro(PauseOnStart, bool);
+  vtkSetMacro(PauseOnStart, bool);
+
   vtkGetStdStringMacro(CodecFourCC);
   vtkSetStdStringMacro(CodecFourCC);
 
@@ -82,6 +85,7 @@ protected:
 
 private:
   bool        EnableCompression;
+  bool        PauseOnStart;
   std::string CodecFourCC;
   std::string OutputFilename;
   std::string CaptureDeviceId;

--- a/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.h
+++ b/src/PlusServer/Commands/vtkPlusStartStopRecordingCommand.h
@@ -62,6 +62,7 @@ public:
   void SetNameToSuspend();
   void SetNameToResume();
   void SetNameToStop();
+  void SetNameToHeader();
 
   /*!
     Helper function to get pointer to the capture device
@@ -85,6 +86,8 @@ private:
   std::string OutputFilename;
   std::string CaptureDeviceId;
   std::string ChannelId;
+
+  std::map<std::string, std::string> RequestedCustomHeaders;
 
   vtkPlusStartStopRecordingCommand(const vtkPlusStartStopRecordingCommand&);
   void operator=(const vtkPlusStartStopRecordingCommand&);


### PR DESCRIPTION
This PR adds some features to the StartStopRecording command which give some more control over when frames are recorded as well as enabling custom header setting through the VirtualCapture device.

cc @jamesobutler who has reviewed these changes on our end