### PR TITLE
Enhancements for WinProbe ARFI capture

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1978,6 +1978,10 @@ PlusStatus vtkPlusWinProbeVideoSource::SetARFIInterSetDelay(int32_t propertyValu
       LOG_ERROR("The maximum ARFI inter set delay is 250*250. Ignoring call to change to " << propertyValue);
       return PLUS_FAIL;
     }
+    else if (propertyValue == 0)
+    {
+      LOG_WARNING("ARFI inter set delay defaulting to clinical delay mode of approximately 1 second.");
+    }
     m_ARFIInterSetDelay = propertyValue;
     ::SetARFIInterSetDelay(propertyValue);  // API call includes SetPendingRecreateTables(true). Really just need SetPendingRestartSequencer(true);
     return PLUS_SUCCESS;

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -355,6 +355,8 @@ public:
   /*!
   Set the integer increment (1.05ms per increment) to delay after completion of the ARFIPushConfigurationString before it begins live streaming B-Mode frames again.
 
+  Setting to 0 will default to the clinical delay of approximately 1 second.
+
   The interset delay is a post ARFI configuration string delay.
   Example: "1,33,44;1,41,52;1,49,60;1,57,68;1,65,76;1,73,84;2,36,44;2,44,52;2,52,60;2,60,68;2,68,76;2,76,84(interset)"
   */
@@ -508,7 +510,7 @@ protected:
   uint16_t m_ARFILineTimer = 100;
   int32_t m_ARFIPrePushLineRepeatCount = 8;
   int32_t m_ARFIPostPushLineRepeatCount = 56;
-  int32_t m_ARFIInterSetDelay = 0;
+  int32_t m_ARFIInterSetDelay = 100;
   int32_t m_ARFIInterPushDelay = 100;
   std::string m_ARFIPushConfigurationString = "1,33,44;1,41,52;1,49,60;1,57,68;1,65,76;1,73,84";
   int m_ARFIPushConfigurationCount = 6;

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -327,7 +327,7 @@ public:
   void SetARFIEnabled(bool value);
   bool GetARFIEnabled();
   /*! If running in ARFI mode, does an ARFI push. Otherwise does nothing and returns failure status. */
-  PlusStatus ARFIPush();
+  PlusStatus ARFIPush(uint8_t maximumVoltage = 50);
   void SetARFIStartSample(int32_t value);
   int32_t GetARFIStartSample();
 


### PR DESCRIPTION
This PR adds various enhancements related to ARFI mode for the WinProbe device. 1) Documentation clarity on setting the inter set delay to 0, and 2) adding an upper bound to ARFI pushes to prevent potential probe burnout from high voltages.

cc @nhjohnston for an approving review with hardware