### PR TITLE
ENH changes to Atracsys wrapper

### DIFF
--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
@@ -997,13 +997,6 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetMarkersInFrame(std::vector<
       ss << ptr->SensorId << " " << ptr->SensorValue;
       events.emplace("tempv4", ss.str());
     }
-    else if (event.Type == FtkEventType::fetSyntheticTemperaturesV1)
-    {
-      std::stringstream ss;
-      const EvtSyntheticTemperaturesV1Payload* ptr = reinterpret_cast<EvtSyntheticTemperaturesV1Payload*>(event.Data);
-      ss << ptr->CurrentValue << " " << ptr->ReferenceValue;
-      events.emplace("synthTempv1", ss.str());
-    }
   }
 
   return SUCCESS;

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
@@ -717,7 +717,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::Connect()
     return ERROR_CANNOT_CREATE_FRAME_INSTANCE;
   }
 
-  if (ftkSetFrameOptions(false, this->MaxEventsNumber,
+  if (ftkSetFrameOptions(false, this->MaxAdditionalEventsNumber,
     this->Max2dFiducialsNumber, this->Max2dFiducialsNumber,
     this->Max3dFiducialsNumber, this->MaxMarkersNumber,
     this->Internal->Frame) != ftkError::FTK_OK)
@@ -1137,12 +1137,12 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerBatteryStr
 }
 
 //----------------------------------------------------------------------------
-AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMaxEventsNumber(int n)
+AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMaxAdditionalEventsNumber(int n)
 {
   if (n < 0) {
     return ERROR_SET_OPTION;
   }
-  this->MaxEventsNumber = n;
+  this->MaxAdditionalEventsNumber = n;
   return SUCCESS;
 }
 

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.h
@@ -200,9 +200,10 @@ public:
   // ------------------------------------------
   // frame options
   // ------------------------------------------
-  /*! Set/get the maximum number of events per frame included in the device's output */
-  ATRACSYS_RESULT SetMaxEventsNumber(int n);
-  int GetMaxEventsNumber() { return MaxEventsNumber; }
+  /*! Set/get the maximum number of additional events per frame included in the device's output.
+  This extends the default allocation of 20, for a total of 20 + n events allowed per frame. */
+  ATRACSYS_RESULT SetMaxAdditionalEventsNumber(int n);
+  int GetMaxAdditionalEventsNumber() { return MaxAdditionalEventsNumber; }
 
   /*! Set/get the maximum number of 2D fiducials (in either left or right frame) included in the device's output */
   ATRACSYS_RESULT SetMax2dFiducialsNumber(int n);
@@ -247,7 +248,7 @@ protected:
 private:
   DEVICE_TYPE DeviceType = UNKNOWN_DEVICE;
 
-  int MaxEventsNumber = 0;
+  int MaxAdditionalEventsNumber = 0; // beyond the default allocation of 20 events
   int Max2dFiducialsNumber = 256;
   int Max3dFiducialsNumber = 256;
   int MaxMarkersNumber = 16;

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
@@ -636,7 +636,8 @@ PlusStatus vtkPlusAtracsysTracker::InternalUpdate()
       mos.precision(3);
       mos << std::fixed << mit->GetMarkerStatus() << " " << mit->GetTrackingID() << " ";
       mos << mit->GetGeometryID() << " " << mit->GetGeometryPresenceMask() << " ";
-      mos << mit->GetFiducialRegistrationErrorMm();
+      mos << mit->GetFiducialRegistrationErrorMm() << " ";
+      mos << mit->GetFiducials().size(); // add number of fiducials
       customFields[it->second + "_info"].first = FRAMEFIELD_NONE;
       customFields[it->second + "_info"].second = mos.str();
 

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
@@ -380,17 +380,17 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
 
   // set frame options (internally passed to sdk during connection)
   // ------- maximum number of events per frame included in the device's output
-  itd = this->Internal->DeviceOptions.find("MaxEventsNumber");
+  itd = this->Internal->DeviceOptions.find("MaxAdditionalEventsNumber");
   if (itd != this->Internal->DeviceOptions.cend())
   {
     int value = -1;
     strToInt32(itd->second, value);
     if (value < 0) {
       LOG_WARNING("Invalid value for max events number per frame in output: " << itd->second
-        << ". Default value used (" << this->Internal->Tracker.GetMaxEventsNumber() << ")");
+        << ". Default value used (" << this->Internal->Tracker.GetMaxAdditionalEventsNumber() << ")");
     }
     else {
-      this->Internal->Tracker.SetMaxEventsNumber(value);
+      this->Internal->Tracker.SetMaxAdditionalEventsNumber(value);
     }
   }
   // ------- maximum number of 2D fiducials (in either left or right frame) included in the device's output

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
@@ -469,6 +469,13 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
         this->Internal->Tracker.SetOption("Embedded " + translatedOptionName, i.second);
       }
     }
+    else if (i.first.find('_') != std::string::npos) // just try to infer the option name by replacing _ by spaces
+    {
+      std::string optionName = i.first;
+      std::replace(optionName.begin(), optionName.end(), '_', ' ');
+      if (this->Internal->Tracker.SetOption(optionName, i.second) == ATRACSYS_RESULT::SUCCESS)
+        LOG_WARNING("Inferred option \"" << optionName << "\" successfully set to " << i.second);
+    }
   }
 
   // if spryTrack, setup for onboard processing


### PR DESCRIPTION
- Clarification that the maximum number of events is actually the maximum number of **additional** events on top of the default allocation of 20.

- Removed the event `synthTempv1` which is obsolete

- The number of fiducials is now indicated in the "Marker_Info" framefield

- Option names that are not included in the dictionary can now be parsed and applied. Simply replace the spaces by underscores to set any option compatible with the SDK/device.
For example, setting Matching Tolerance and Epipolar Maximum Distance:
```
<Device
  Id="TrackerDevice"
  Type="AtracsysTracker"
  MaxMissingFiducials="0"
  MaxMeanRegistrationErrorMm="1.0"
  Matching_Tolerance="0.5"
  Epipolar_Maximum_Distance="5.0"
  ToolReferenceFrame="Tracker"
>
```