### PR TITLE
ENH: Speed up PlusVersion check that includes WinProbe device

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -774,7 +774,6 @@ vtkPlusWinProbeVideoSource::vtkPlusWinProbeVideoSource()
   Callback funcPtr = &frameCallback;
   thisPtr = this;
   WPSetCallback(funcPtr);
-  WPInitialize();
 
   if (m_UseDeviceFrameReconstruction)
   {
@@ -790,13 +789,12 @@ vtkPlusWinProbeVideoSource::~vtkPlusWinProbeVideoSource()
   {
     this->Disconnect();
   }
-  WPDXDispose();
-  WPDispose();
 }
 
 // ----------------------------------------------------------------------------
 PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
 {
+  WPInitialize();
   this->GetVideoSourcesByPortName(vtkPlusDevice::RFMODE_PORT_NAME, m_ExtraSources);
   this->GetVideoSourcesByPortName(vtkPlusDevice::BMODE_PORT_NAME, m_PrimarySources);
   if(m_ExtraSources.empty() && m_PrimarySources.empty())
@@ -996,6 +994,8 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalDisconnect()
   }
   WPDisconnect();
   LOG_DEBUG("Disconnect from WinProbe finished");
+  WPDXDispose();
+  WPDispose();
   return PLUS_SUCCESS;
 }
 


### PR DESCRIPTION
This moves some initialization and destruction of resources to the internal connect/disconnect calls instead of the device constructor and destructor. This is based on recommendations per https://plustoolkit.github.io/devicecode

"Initialization and destruction of resources is performed during YourDevice::InternalConnect and YourDevice::InternalDisconnect respectively."

cc: @matt-harmody-pki