### PR TITLE
ENH Atracsys: calibration date and better option management

### DIFF
--- a/src/PlusDataCollection/Atracsys/AtracsysMarkerCreator.cxx
+++ b/src/PlusDataCollection/Atracsys/AtracsysMarkerCreator.cxx
@@ -212,7 +212,8 @@ PlusStatus CollectFiducials(fidsFrameList& fidFrameList, int numFrames)
   {
     // ensure vector is empty
     markerFrame.clear();
-    ATRACSYS_RESULT result = Tracker.GetMarkersInFrame(markerFrame, events);
+    uint64_t ts = 0;
+    ATRACSYS_RESULT result = Tracker.GetMarkersInFrame(markerFrame, events, ts);
     if (result == ATR_SUCCESS)
     {
       m++;

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
@@ -586,7 +586,9 @@ bool AtracsysTracker::GetOptionInfo(const std::string& optionName, const ftkOpti
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetOption(const std::string& optionName, const std::string& attributeValue)
 {
   if (this->Internal->isVirtual)
+  {
     return SUCCESS;
+  }
 
   std::string optionStr{ optionName };
   // if Embedded processing is on and the option has an Embedded variant, add the prefix
@@ -785,6 +787,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::Connect()
 
   // Check whether onboard processing is off or on (spryTrack only)
   if (this->DeviceType == SPRYTRACK_180 || this->DeviceType == SPRYTRACK_300)
+  {
     if (!this->GetOptionInfo("Enable embedded processing", info))
     {
       LOG_WARNING(std::string("Embedded processing not part of the option list."));
@@ -797,6 +800,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::Connect()
       isOnboardProcessing = (val == 1) ? true : false;
       LOG_INFO("Embedded processing is initially " << (isOnboardProcessing ? "enabled" : "disabled"));
     }
+  }
 
   return SUCCESS;
 }
@@ -805,7 +809,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::Connect()
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::Disconnect()
 {
   if (this->Internal->isVirtual)
+  {
     return SUCCESS;
+  }
 
   if (this->Internal->FtkLib == nullptr && this->Internal->TrackerSN == 0)
   {
@@ -927,7 +933,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::LoadMarkerGeometryFromString(s
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetMarkerInfo(std::string& markerInfo)
 {
   if (this->Internal->isVirtual)
+  {
     return ERROR_CANNOT_GET_MARKER_INFO;
+  }
 
   // get correct device option number
   const ftkOptionsInfo* info;
@@ -1089,7 +1097,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetMarkersInFrame(std::vector<
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetUserLEDState(int red, int green, int blue, int frequency, bool enabled /* = true */)
 {
   if (this->Internal->isVirtual)
+  {
     return SUCCESS;
+  }
 
   // get correct device option number
   const ftkOptionsInfo* info;
@@ -1133,7 +1143,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetUserLEDState(int red, int g
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableUserLED(bool enabled)
 {
   if (this->Internal->isVirtual)
+  {
     return SUCCESS;
+  }
 
   // get correct device option number
   const ftkOptionsInfo* info;
@@ -1152,7 +1164,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableUserLED(bool enabled)
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetLaserEnabled(bool enabled)
 {
   if (this->Internal->isVirtual)
+  {
     return SUCCESS;
+  }
 
   // get correct device option number
   const ftkOptionsInfo* info;
@@ -1174,7 +1188,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetLaserEnabled(bool enabled)
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerPairing(bool enabled)
 {
   if (this->Internal->isVirtual)
+  {
     return SUCCESS;
+  }
 
   // get correct device option number
   const ftkOptionsInfo* info;
@@ -1194,7 +1210,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerPairing(bo
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerStatusStreaming(bool enabled)
 {
   if (this->Internal->isVirtual)
+  {
     return SUCCESS;
+  }
 
   // get correct device option number
   const ftkOptionsInfo* info;
@@ -1214,7 +1232,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerStatusStre
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerBatteryStreaming(bool enabled)
 {
   if (this->Internal->isVirtual)
+  {
     return SUCCESS;
+  }
 
   // get correct device option number
   const ftkOptionsInfo* info;
@@ -1233,7 +1253,8 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerBatteryStr
 //----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMaxAdditionalEventsNumber(int n)
 {
-  if (n < 0) {
+  if (n < 0)
+  {
     return ERROR_SET_OPTION;
   }
   this->MaxAdditionalEventsNumber = n;
@@ -1243,7 +1264,8 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMaxAdditionalEventsNumber(i
 //----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMax2dFiducialsNumber(int n)
 {
-  if (n < 0) {
+  if (n < 0)
+  {
     return ERROR_SET_OPTION;
   }
   this->Max2dFiducialsNumber = n;
@@ -1253,7 +1275,8 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMax2dFiducialsNumber(int n)
 //----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMax3dFiducialsNumber(int n)
 {
-  if (n < 0) {
+  if (n < 0)
+  {
     return ERROR_SET_OPTION;
   }
   this->Max3dFiducialsNumber = n;
@@ -1263,7 +1286,8 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMax3dFiducialsNumber(int n)
 //----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMaxMarkersNumber(int n)
 {
-  if (n < 0) {
+  if (n < 0)
+  {
     return ERROR_SET_OPTION;
   }
   this->MaxMarkersNumber = n;
@@ -1277,7 +1301,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMaxMarkersNumber(int n)
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableOnboardProcessing(bool enabled)
 {
   if (this->Internal->isVirtual)
+  {
     return SUCCESS;
+  }
 
   // get correct device option number
   const ftkOptionsInfo* info;
@@ -1298,7 +1324,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableOnboardProcessing(bool e
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableImageStreaming(bool enabled)
 {
   if (this->Internal->isVirtual)
+  {
     return SUCCESS;
+  }
 
   // get correct device option number
   const ftkOptionsInfo* info;
@@ -1382,7 +1410,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetDroppedFrameCount(int& drop
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::ResetLostFrameCount()
 {
   if (this->Internal->isVirtual)
+  {
     return SUCCESS;
+  }
 
   if (this->DeviceType == FUSIONTRACK_250 || this->DeviceType == FUSIONTRACK_500)
   {
@@ -1462,5 +1492,7 @@ bool AtracsysTracker::Marker::AddFiducial(AtracsysTracker::Fiducial fid)
     return true;
   }
   else
+  {
     return false;
+  }
 }

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
@@ -104,14 +104,24 @@ public:
   {
     FtkLib = nullptr;
     LibVersion = "";
+    CalibrationDate = "";
     TrackerSN = 0;
   }
+
+  // is virtual device or not
+  bool isVirtual = false;
+
+  // is paused or not
+  bool isPaused = true;
 
   // handle to FtkLib library
   ftkLibrary FtkLib = nullptr;
 
   // library version 
   std::string LibVersion;
+
+  // calibration date
+  std::string CalibrationDate;
 
   // serial number of tracker
   uint64 TrackerSN = 0;
@@ -575,13 +585,21 @@ bool AtracsysTracker::GetOptionInfo(const std::string& optionName, const ftkOpti
 // this method sets a value to an option in the device. The option name follows Atracsys' nomenclature.
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetOption(const std::string& optionName, const std::string& attributeValue)
 {
-  LOG_INFO(std::string("Setting option \"") + optionName + std::string("\" at value ") + attributeValue);
+  if (this->Internal->isVirtual)
+    return SUCCESS;
+
+  std::string optionStr{ optionName };
+  // if Embedded processing is on and the option has an Embedded variant, add the prefix
+  if (isOnboardProcessing && this->Internal->DeviceOptionMap.find("Embedded " + optionName) != this->Internal->DeviceOptionMap.end())
+  {
+    optionStr = "Embedded " + optionStr;
+  }
 
   const ftkOptionsInfo* info;
 
-  if (!this->GetOptionInfo(optionName, info))
+  if (!this->GetOptionInfo(optionStr, info))
   {
-    LOG_WARNING(std::string("Info for option \"") + optionName + std::string("\" not found."));
+    LOG_WARNING(std::string("Info for option \"") + optionStr + std::string("\" not found."));
     return ERROR_OPTION_NOT_FOUND;
   }
 
@@ -602,7 +620,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetOption(const std::string& o
       }
       else
       {
-        LOG_WARNING(std::string("Unknown error setting option ") + optionName);
+        LOG_WARNING(std::string("Unknown error setting option ") + optionStr);
       }
     }
   }
@@ -623,7 +641,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetOption(const std::string& o
       }
       else
       {
-        LOG_WARNING(std::string("Unknown error setting option ") + optionName);
+        LOG_WARNING(std::string("Unknown error setting option ") + optionStr);
       }
     }
   }
@@ -631,6 +649,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetOption(const std::string& o
   {
     LOG_WARNING(std::string("Option of type \"data\" not supported yet"));
   }
+  LOG_INFO(std::string("Option \"") + optionStr + std::string("\" successfully set at value ") + attributeValue);
 
   return SUCCESS;
 }
@@ -646,6 +665,24 @@ AtracsysTracker::~AtracsysTracker()
 {
   delete Internal;
   Internal = nullptr;
+}
+
+//----------------------------------------------------------------------------
+void AtracsysTracker::Pause(bool tof)
+{
+  this->Internal->isPaused = tof;
+}
+
+//----------------------------------------------------------------------------
+bool AtracsysTracker::IsOnboardProcessing()
+{
+  return isOnboardProcessing;
+}
+
+//----------------------------------------------------------------------------
+bool AtracsysTracker::IsVirtual()
+{
+  return this->Internal->isVirtual;
 }
 
 //----------------------------------------------------------------------------
@@ -735,12 +772,41 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::Connect()
     return ERROR_OPTION_NOT_FOUND;
   }
 
+  // Needs to be after the device option enumeration
+  const ftkOptionsInfo* info;
+  if (!this->GetOptionInfo("Calibration processing datetime", info))
+  {
+    LOG_ERROR("Option unknown: \"Calibration processing datetime\"");
+    return ERROR_OPTION_NOT_FOUND;
+  }
+  ftkBuffer buff;
+  ftkGetData(this->Internal->FtkLib, this->Internal->TrackerSN, info->id, &buff);
+  this->Internal->CalibrationDate = std::string(buff.data);
+
+  // Check whether onboard processing is off or on (spryTrack only)
+  if (this->DeviceType == SPRYTRACK_180 || this->DeviceType == SPRYTRACK_300)
+    if (!this->GetOptionInfo("Enable embedded processing", info))
+    {
+      LOG_WARNING(std::string("Embedded processing not part of the option list."));
+      return ERROR_OPTION_NOT_FOUND;
+    }
+    else
+    {
+      int32 val;
+      ftkGetInt32(this->Internal->FtkLib, this->Internal->TrackerSN, info->id, &val, ftkOptionGetter::FTK_VALUE);
+      isOnboardProcessing = (val == 1) ? true : false;
+      LOG_INFO("Embedded processing is initially " << (isOnboardProcessing ? "enabled" : "disabled"));
+    }
+
   return SUCCESS;
 }
 
 //----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::Disconnect()
 {
+  if (this->Internal->isVirtual)
+    return SUCCESS;
+
   if (this->Internal->FtkLib == nullptr && this->Internal->TrackerSN == 0)
   {
     return ERROR_DISCONNECT_ATTEMPT_WHEN_NOT_CONNECTED;
@@ -766,6 +832,13 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetSDKversion(std::string& ver
 }
 
 //----------------------------------------------------------------------------
+AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetCalibrationDate(std::string& date)
+{
+  date = this->Internal->CalibrationDate;
+  return SUCCESS;
+}
+
+//----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetDeviceType(DEVICE_TYPE& deviceType)
 {
   deviceType = this->DeviceType;
@@ -777,7 +850,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetCamerasCalibration(
   std::array<float, 10>& leftIntrinsic, std::array<float, 10>& rightIntrinsic,
   std::array<float, 3>& rightPosition, std::array<float, 3>& rightOrientation)
 {
-  if (this->SetOption("Calibration export", "1") != SUCCESS)
+  if (!this->Internal->isVirtual || this->SetOption("Calibration export", "1") != SUCCESS)
   {
     LOG_ERROR("Could not export calibration.");
     return ERROR_FAILED_TO_EXPORT_CALIB;
@@ -827,7 +900,8 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::LoadMarkerGeometryFromFile(std
 {
   ftkGeometry geom;
   this->Internal->LoadFtkGeometryFromFile(filePath, geom);
-  if (ftkSetGeometry(this->Internal->FtkLib, this->Internal->TrackerSN, &geom) != ftkError::FTK_OK)
+  if (!this->Internal->isVirtual &&
+    ftkSetGeometry(this->Internal->FtkLib, this->Internal->TrackerSN, &geom) != ftkError::FTK_OK)
   {
     return ERROR_UNABLE_TO_LOAD_MARKER;
   }
@@ -840,7 +914,8 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::LoadMarkerGeometryFromString(s
 {
   ftkGeometry geom;
   this->Internal->LoadFtkGeometryFromString(geomString, geom);
-  if (ftkSetGeometry(this->Internal->FtkLib, this->Internal->TrackerSN, &geom) != ftkError::FTK_OK)
+  if (!this->Internal->isVirtual &&
+    ftkSetGeometry(this->Internal->FtkLib, this->Internal->TrackerSN, &geom) != ftkError::FTK_OK)
   {
     return ERROR_UNABLE_TO_LOAD_MARKER;
   }
@@ -851,6 +926,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::LoadMarkerGeometryFromString(s
 //----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetMarkerInfo(std::string& markerInfo)
 {
+  if (this->Internal->isVirtual)
+    return ERROR_CANNOT_GET_MARKER_INFO;
+
   // get correct device option number
   const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Active Wireless Markers info", info))
@@ -887,7 +965,8 @@ std::string AtracsysTracker::ResultToString(AtracsysTracker::ATRACSYS_RESULT res
 }
 
 //----------------------------------------------------------------------------
-AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetMarkersInFrame(std::vector<Marker>& markers, std::map<std::string, std::string>& events)
+AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetMarkersInFrame(std::vector<Marker>& markers,
+  std::map<std::string, std::string>& events, uint64_t& sdkTimestamp)
 {
   ftkError err = ftkGetLastFrame(this->Internal->FtkLib, this->Internal->TrackerSN, this->Internal->Frame, 20);
   if (err != ftkError::FTK_OK)
@@ -1000,12 +1079,18 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetMarkersInFrame(std::vector<
     }
   }
 
+  // Save sdk timestamp
+  sdkTimestamp = this->Internal->Frame->imageHeader->timestampUS;
+
   return SUCCESS;
 }
 
 //----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetUserLEDState(int red, int green, int blue, int frequency, bool enabled /* = true */)
 {
+  if (this->Internal->isVirtual)
+    return SUCCESS;
+
   // get correct device option number
   const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("User-LED frequency", info))
@@ -1047,6 +1132,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetUserLEDState(int red, int g
 //----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableUserLED(bool enabled)
 {
+  if (this->Internal->isVirtual)
+    return SUCCESS;
+
   // get correct device option number
   const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Enables the user-LED", info))
@@ -1063,6 +1151,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableUserLED(bool enabled)
 //----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetLaserEnabled(bool enabled)
 {
+  if (this->Internal->isVirtual)
+    return SUCCESS;
+
   // get correct device option number
   const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Enables lasers", info))
@@ -1082,6 +1173,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetLaserEnabled(bool enabled)
 //----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerPairing(bool enabled)
 {
+  if (this->Internal->isVirtual)
+    return SUCCESS;
+
   // get correct device option number
   const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Active Wireless Pairing Enable", info))
@@ -1099,6 +1193,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerPairing(bo
 //----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerStatusStreaming(bool enabled)
 {
+  if (this->Internal->isVirtual)
+    return SUCCESS;
+
   // get correct device option number
   const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Active Wireless button statuses streaming", info))
@@ -1116,6 +1213,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerStatusStre
 //----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableWirelessMarkerBatteryStreaming(bool enabled)
 {
+  if (this->Internal->isVirtual)
+    return SUCCESS;
+
   // get correct device option number
   const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Active Wireless battery state streaming", info))
@@ -1176,6 +1276,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetMaxMarkersNumber(int n)
 
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableOnboardProcessing(bool enabled)
 {
+  if (this->Internal->isVirtual)
+    return SUCCESS;
+
   // get correct device option number
   const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Enable embedded processing", info))
@@ -1187,12 +1290,16 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableOnboardProcessing(bool e
   {
     return ERROR_ENABLE_ONBOARD_PROCESSING;
   }
+  LOG_INFO("Embedded processing successfully " << (enabled ? "enabled" : "disabled"));
   return SUCCESS;
 }
 
 //----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableImageStreaming(bool enabled)
 {
+  if (this->Internal->isVirtual)
+    return SUCCESS;
+
   // get correct device option number
   const ftkOptionsInfo* info;
   if (!this->GetOptionInfo("Enable images sending", info))
@@ -1204,6 +1311,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::EnableImageStreaming(bool enab
   {
     return ERROR_ENABLE_IMAGE_STREAMING;
   }
+  LOG_INFO("Image streaming successfully " << (enabled ? "enabled" : "disabled"));
   return SUCCESS;
 }
 
@@ -1212,6 +1320,7 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetSpryTrackProcessingType(Atr
 {
   if (this->DeviceType != SPRYTRACK_180 && this->DeviceType != SPRYTRACK_300)
   {
+    LOG_WARNING("Embedded processing is available only on spryTracks.");
     return ERROR_OPTION_AVAILABLE_ONLY_ON_STK;
   }
   bool succeeded = true;
@@ -1219,11 +1328,13 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetSpryTrackProcessingType(Atr
   {
     succeeded = succeeded && (this->EnableOnboardProcessing(true) == SUCCESS);
     succeeded = succeeded && (this->EnableImageStreaming(false) == SUCCESS);
+    isOnboardProcessing = true;
   }
   else if (processingType == PROCESSING_ON_PC)
   {
     succeeded = succeeded && (this->EnableOnboardProcessing(false) == SUCCESS);
     succeeded = succeeded && (this->EnableImageStreaming(true) == SUCCESS);
+    isOnboardProcessing = false;
   }
 
   if (!succeeded)
@@ -1239,6 +1350,12 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::SetSpryTrackProcessingType(Atr
 
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetDroppedFrameCount(int& droppedFrameCount)
 {
+  if (this->Internal->isVirtual)
+  {
+    droppedFrameCount = 0;
+    return SUCCESS;
+  }
+
   if (this->DeviceType == FUSIONTRACK_250 || this->DeviceType == FUSIONTRACK_500)
   {
     int32 lost = 0, corrupted = 0;
@@ -1264,6 +1381,9 @@ AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::GetDroppedFrameCount(int& drop
 //----------------------------------------------------------------------------
 AtracsysTracker::ATRACSYS_RESULT AtracsysTracker::ResetLostFrameCount()
 {
+  if (this->Internal->isVirtual)
+    return SUCCESS;
+
   if (this->DeviceType == FUSIONTRACK_250 || this->DeviceType == FUSIONTRACK_500)
   {
     // get correct device option number

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.h
@@ -84,6 +84,7 @@ public:
     // override equality operator to make fids less than EQUALITY_DISTANCE_MM considered equal
     bool operator==(const Fiducial& f);
     bool operator<(const Fiducial& f) const;
+    uint32_t id = 0;
     // 3D
     uint32_t Fid3dStatus = 0;
     float xMm = 0;
@@ -138,13 +139,26 @@ public:
     Fiducials fiducials; // fiducial coordinates
   };
 
+  /* Is onboard/embedded processing on ?*/
+  bool IsOnboardProcessing();
+
+  /*! Is virtual ? */
+  bool IsVirtual();
+
+  /*! If virtual device, pause/unpause */
+  void Pause(bool tof);
+
   /*! Connect to Atracsys tracker, must be called before any other function in this wrapper API. */
   ATRACSYS_RESULT Connect();
+
   /*! Closes connections to Atracsys tracker, must be called at end of application. */
   ATRACSYS_RESULT Disconnect();
 
   /*! */
   ATRACSYS_RESULT GetSDKversion(std::string& version);
+
+  /*! */
+  ATRACSYS_RESULT GetCalibrationDate(std::string& date);
 
   /*! */
   ATRACSYS_RESULT GetDeviceType(DEVICE_TYPE& deviceType);
@@ -177,7 +191,8 @@ public:
   std::string ResultToString(ATRACSYS_RESULT result);
 
   /*! */
-  ATRACSYS_RESULT GetMarkersInFrame(std::vector<Marker>& markers, std::map<std::string, std::string>& events);
+  ATRACSYS_RESULT GetMarkersInFrame(std::vector<Marker>& markers,
+    std::map<std::string, std::string>& events, uint64_t& sdkTimestamp);
 
   /*! */
   ATRACSYS_RESULT SetUserLEDState(int red, int green, int blue, int frequency, bool enabled = true);
@@ -252,6 +267,8 @@ private:
   int Max2dFiducialsNumber = 256;
   int Max3dFiducialsNumber = 256;
   int MaxMarkersNumber = 16;
+
+  bool isOnboardProcessing = false;
 
   class AtracsysInternal;
   AtracsysInternal* Internal;

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
@@ -409,7 +409,8 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
       LOG_WARNING("Invalid value for max events number per frame in output: " << itd->second
         << ". Default value used (" << this->Internal->Tracker.GetMaxAdditionalEventsNumber() << ")");
     }
-    else {
+    else
+    {
       this->Internal->Tracker.SetMaxAdditionalEventsNumber(value);
     }
   }
@@ -419,11 +420,13 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
   {
     int value = -1;
     strToInt32(itd->second, value);
-    if (value < 0) {
+    if (value < 0)
+    {
       LOG_WARNING("Invalid value for max 2D fiducials number in output: " << itd->second
         << ". Default value used (" << this->Internal->Tracker.GetMax2dFiducialsNumber() << ")");
     }
-    else {
+    else
+    {
       this->Internal->Tracker.SetMax2dFiducialsNumber(value);
     }
   }
@@ -433,11 +436,13 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
   {
     int value = -1;
     strToInt32(itd->second, value);
-    if (value < 0) {
+    if (value < 0)
+    {
       LOG_WARNING("Invalid value for max 3D fiducials number in output: " << itd->second
         << ". Default value used (" << this->Internal->Tracker.GetMax3dFiducialsNumber() << ")");
     }
-    else {
+    else
+    {
       this->Internal->Tracker.SetMax3dFiducialsNumber(value);
     }
   }
@@ -447,11 +452,13 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
   {
     int value = -1;
     strToInt32(itd->second, value);
-    if (value < 0) {
+    if (value < 0)
+    {
       LOG_WARNING("Invalid value for max markers number in output: " << itd->second
         << ". Default value used (" << this->Internal->Tracker.GetMaxMarkersNumber() << ")");
     }
-    else {
+    else
+    {
       this->Internal->Tracker.SetMaxMarkersNumber(value);
     }
   }

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
@@ -131,6 +131,14 @@ std::string vtkPlusAtracsysTracker::GetSdkVersion()
 }
 
 //----------------------------------------------------------------------------
+std::string vtkPlusAtracsysTracker::GetCalibrationDate()
+{
+  std::string d;
+  this->Internal->Tracker.GetCalibrationDate(d);
+  return d;
+}
+
+//----------------------------------------------------------------------------
 std::string vtkPlusAtracsysTracker::GetDeviceType()
 {
   switch (this->Internal->DeviceType)
@@ -154,8 +162,8 @@ PlusStatus vtkPlusAtracsysTracker::GetCamerasCalibration(
   std::array<float, 3>& rightPosition, std::array<float, 3>& rightOrientation)
 {
   ATRACSYS_RESULT result = this->Internal->Tracker.GetCamerasCalibration(
-  leftIntrinsic, rightIntrinsic, rightPosition, rightOrientation);
-  if (result != ATRACSYS_RESULT::SUCCESS)
+    leftIntrinsic, rightIntrinsic, rightPosition, rightOrientation);
+  if (result != ATR_SUCCESS)
   {
     LOG_ERROR(this->Internal->Tracker.ResultToString(result));
     return PLUS_FAIL;
@@ -166,7 +174,7 @@ PlusStatus vtkPlusAtracsysTracker::GetCamerasCalibration(
 //----------------------------------------------------------------------------
 PlusStatus vtkPlusAtracsysTracker::GetLoadedGeometries(std::map<int, std::vector<std::array<float, 3>>>& geometries)
 {
-  if (this->Internal->Tracker.GetLoadedGeometries(geometries) != ATRACSYS_RESULT::SUCCESS)
+  if (this->Internal->Tracker.GetLoadedGeometries(geometries) != ATR_SUCCESS)
   {
     LOG_ERROR("Could not get loaded geometries");
     return PLUS_FAIL;
@@ -177,6 +185,12 @@ PlusStatus vtkPlusAtracsysTracker::GetLoadedGeometries(std::map<int, std::vector
     return PLUS_FAIL;
   }
   return PLUS_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+bool vtkPlusAtracsysTracker::IsVirtual() const
+{
+  return this->Internal->Tracker.IsVirtual();
 }
 
 //----------------------------------------------------------------------------
@@ -274,7 +288,13 @@ PlusStatus vtkPlusAtracsysTracker::Probe()
 }
 
 //----------------------------------------------------------------------------
-PlusStatus vtkPlusAtracsysTracker::GetOptionValue(const std::string &optionName, std::string &optionValue)
+const std::map<std::string, std::string>& vtkPlusAtracsysTracker::GetDeviceOptions() const
+{
+  return this->Internal->DeviceOptions;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusAtracsysTracker::GetOptionValue(const std::string& optionName, std::string& optionValue)
 {
   std::map<std::string, std::string>::const_iterator itd = this->Internal->DeviceOptions.find(optionName);
   if (itd != this->Internal->DeviceOptions.cend())
@@ -306,7 +326,7 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
 {
   LOG_TRACE("vtkPlusAtracsysTracker::InternalConnect");
 
-  // Connect to tracker
+  // Connect to device
   AtracsysTracker::ATRACSYS_RESULT result = this->Internal->Tracker.Connect();
   if (result != ATR_SUCCESS && result != AtracsysTracker::ATRACSYS_RESULT::WARNING_CONNECTED_IN_USB2)
   {
@@ -436,52 +456,90 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
     }
   }
 
-  // set actual device options
-  for (const auto& i : this->Internal->DeviceOptions)
+  // Set actual device options and remove those unsuccessfully set
+  // SpryTrack's Embedded processing option needs to be considered first.
+  // By default, the spryTrack is in Embedded processing mode.
+  // In Embedded processing mode, some other options will require the "Embedded " prefix.
+  std::map<std::string, std::string>::iterator itr = this->Internal->DeviceOptions.find("Enable_embedded_processing");
+  if (itr != this->Internal->DeviceOptions.end())
+  {
+    if (this->Internal->DeviceOptions.at("Enable_embedded_processing") == "0")
+    {
+      if (this->Internal->Tracker.SetSpryTrackProcessingType(AtracsysTracker::PROCESSING_ON_PC) != ATR_SUCCESS)
+      {
+        LOG_WARNING("Embedded processing could not be disabled.");
+        this->Internal->DeviceOptions.erase(itr);
+      }
+    }
+    else if (this->Internal->DeviceOptions.at("Enable_embedded_processing") == "1")
+    {
+      if (this->Internal->Tracker.SetSpryTrackProcessingType(AtracsysTracker::PROCESSING_ONBOARD) != ATR_SUCCESS)
+      {
+        this->Internal->DeviceOptions.erase(itr);
+        LOG_WARNING("Embedded processing could not be enabled.");
+      }
+    }
+    else
+    {
+      LOG_WARNING(this->Internal->DeviceOptions.at("Enable_embedded_processing") << " is not a correct value for Embedded processing.\nAccepted values are 0 (false) and 1 (true).");
+      this->Internal->DeviceOptions.erase(itr);
+    }
+  }
+
+  itr = this->Internal->DeviceOptions.begin();
+  while (itr != this->Internal->DeviceOptions.end())
   {
     std::string translatedOptionName;
 
     /* Dirty hack circumventing a nomenclature discrepancy between ftk and stk API's, this may be fixed in a future API release */
-    if (i.first == "EnableIRstrobe" && (this->Internal->DeviceType == AtracsysTracker::DEVICE_TYPE::FUSIONTRACK_500
+    if (itr->first == "EnableIRstrobe" && (this->Internal->DeviceType == AtracsysTracker::DEVICE_TYPE::FUSIONTRACK_500
       || this->Internal->DeviceType == AtracsysTracker::DEVICE_TYPE::FUSIONTRACK_250))
     {
-      // for fusiontracks, strobe on is 0 and strobe off is 1 (the opposite of sprytracks)
-      if (i.second == "0") {
-        this->Internal->Tracker.SetOption("Strobe mode", "1");
-      }
-      else if (i.second == "1") {
-        this->Internal->Tracker.SetOption("Strobe mode", "0");
-      }
-      // fusiontracks also supports a mode where the strobe turns on every other frame (unsupported by sprytracks at the moment)
-      else if (i.second == "2") {
-        this->Internal->Tracker.SetOption("Strobe mode", "2");
-      }
-      else {
-        LOG_WARNING("Wrong strobe mode value " << i.second);
-      }
-    }
-    else/* end of hack*/ if (this->TranslateOptionName(i.first, translatedOptionName))
-    {
-      this->Internal->Tracker.SetOption(translatedOptionName, i.second);
-      // if spryTrack, also set the same options but for onboard processing
-      if (this->Internal->DeviceType == AtracsysTracker::DEVICE_TYPE::SPRYTRACK_180 || this->Internal->DeviceType == AtracsysTracker::DEVICE_TYPE::SPRYTRACK_300)
+      // For fusiontracks, strobe on is 0 and strobe off is 1 (the opposite of sprytracks).
+      // Fusiontracks also supports a mode 2 where the strobe turns on every other frame (unsupported by sprytracks at the moment)
+      std::map<std::string, std::string> strobCorresp{ {"0","1"},{"1","0"}, {"2","2"} };
+      if (strobCorresp.find(itr->second) != strobCorresp.end())
       {
-        this->Internal->Tracker.SetOption("Embedded " + translatedOptionName, i.second);
+        if (this->Internal->Tracker.SetOption("Strobe mode", strobCorresp.at(itr->second)) != ATR_SUCCESS)
+        {
+          itr = this->Internal->DeviceOptions.erase(itr);
+          continue;
+        }
+      }
+      else
+      {
+        LOG_WARNING("Unsupported strobe mode value " << itr->second);
+        itr = this->Internal->DeviceOptions.erase(itr);
+        continue;
       }
     }
-    else if (i.first.find('_') != std::string::npos) // just try to infer the option name by replacing _ by spaces
+    else/* end of hack*/ if (this->TranslateOptionName(itr->first, translatedOptionName)) // looking for the option in the translation dictionary
     {
-      std::string optionName = i.first;
-      std::replace(optionName.begin(), optionName.end(), '_', ' ');
-      if (this->Internal->Tracker.SetOption(optionName, i.second) == ATRACSYS_RESULT::SUCCESS)
-        LOG_WARNING("Inferred option \"" << optionName << "\" successfully set to " << i.second);
+      if (this->Internal->Tracker.SetOption(translatedOptionName, itr->second) != ATR_SUCCESS)
+      {
+        itr = this->Internal->DeviceOptions.erase(itr);
+        continue;
+      }
     }
-  }
-
-  // if spryTrack, setup for onboard processing
-  if (this->Internal->DeviceType == AtracsysTracker::DEVICE_TYPE::SPRYTRACK_180 || this->Internal->DeviceType == AtracsysTracker::DEVICE_TYPE::SPRYTRACK_300)
-  {
-    this->Internal->Tracker.SetSpryTrackProcessingType(AtracsysTracker::SPRYTRACK_IMAGE_PROCESSING_TYPE::PROCESSING_ONBOARD);
+    // option not found in dictionary, let's try to infer the option name by replacing _ by spaces
+    else if (itr->first.find('_') != std::string::npos && itr->first != "Enable_embedded_processing")
+    {
+      std::string inferredOptionName = itr->first;
+      std::replace(inferredOptionName.begin(), inferredOptionName.end(), '_', ' ');
+      if (this->Internal->Tracker.SetOption(inferredOptionName, itr->second) != ATR_SUCCESS)
+      {
+        itr = this->Internal->DeviceOptions.erase(itr);
+        continue;
+      }
+    }
+    else if (itr->first != "AcquisitionRate" && itr->first != "Id" && itr->first != "Type"
+      && itr->first != "ToolReferenceFrame" && itr->first != "Enable_embedded_processing")
+    {
+      LOG_WARNING("Unknown option \"" << itr->first << "\".");
+      itr = this->Internal->DeviceOptions.erase(itr);
+      continue;
+    }
+    ++itr;
   }
 
   // disable marker status streaming and battery charge streaming, they cause momentary pauses in tracking while sending
@@ -514,36 +572,43 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
     this->Internal->FtkGeometryIdMappedToToolId.insert(newTool);
   }
 
-  // make LED blue during pairing
-  this->Internal->Tracker.SetUserLEDState(0, 0, 255, 0);
-
-  // pair active markers
-  if ((result = this->Internal->Tracker.EnableWirelessMarkerPairing(true)) != ATR_SUCCESS)
+  // if active marker pairing is desired, then its time > 0 second
+  if (this->Internal->ActiveMarkerPairingTimeSec > 0)
   {
-    LOG_ERROR(this->Internal->Tracker.ResultToString(result));
-    return PLUS_FAIL;
+    // make LED blue during pairing
+    this->Internal->Tracker.SetUserLEDState(0, 0, 255, 0);
+
+    // pair active markers
+    if ((result = this->Internal->Tracker.EnableWirelessMarkerPairing(true)) != ATR_SUCCESS)
+    {
+      LOG_ERROR(this->Internal->Tracker.ResultToString(result));
+      return PLUS_FAIL;
+    }
+    LOG_INFO("Active marker pairing period started for " << this->Internal->ActiveMarkerPairingTimeSec << " seconds.");
+
+    // sleep while waiting for tracker to pair active markers
+    vtkIGSIOAccurateTimer::Delay(this->Internal->ActiveMarkerPairingTimeSec);
+
+    LOG_INFO("Active marker pairing period ended.");
+
+    if ((result = this->Internal->Tracker.EnableWirelessMarkerPairing(false)) != ATR_SUCCESS)
+    {
+      LOG_ERROR(this->Internal->Tracker.ResultToString(result));
+      return PLUS_FAIL;
+    }
+
+    // make LED green, pairing is complete
+    this->Internal->Tracker.SetUserLEDState(0, 255, 0, 0);
+
+    // TODO: check number of active markers paired
+
+    std::string markerInfo;
+    this->Internal->Tracker.GetMarkerInfo(markerInfo);
+    if (!markerInfo.empty())
+    {
+      LOG_INFO("Additional info about paired markers:" << markerInfo << std::endl);
+    }
   }
-  LOG_INFO("Active marker pairing period started for " << this->Internal->ActiveMarkerPairingTimeSec << " seconds.");
-
-  // sleep while waiting for tracker to pair active markers
-  vtkIGSIOAccurateTimer::Delay(this->Internal->ActiveMarkerPairingTimeSec);
-
-  LOG_INFO("Active marker pairing period ended.");
-
-  if ((result = this->Internal->Tracker.EnableWirelessMarkerPairing(false)) != ATR_SUCCESS)
-  {
-    LOG_ERROR(this->Internal->Tracker.ResultToString(result));
-    return PLUS_FAIL;
-  }
-
-  // make LED green, pairing is complete
-  this->Internal->Tracker.SetUserLEDState(0, 255, 0, 0);
-
-  // TODO: check number of active markers paired
-
-  std::string markerInfo;
-  this->Internal->Tracker.GetMarkerInfo(markerInfo);
-  LOG_INFO("Additional info about paired markers:" << markerInfo << std::endl);
 
   return PLUS_SUCCESS;
 }
@@ -578,15 +643,33 @@ PlusStatus vtkPlusAtracsysTracker::InternalStopRecording()
 }
 
 //----------------------------------------------------------------------------
+PlusStatus vtkPlusAtracsysTracker::PauseVirtualDevice()
+{
+  LOG_TRACE("vtkPlusAtracsysTracker::PauseVirtualDevice");
+  this->Internal->Tracker.Pause(true);
+  return PLUS_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+PlusStatus vtkPlusAtracsysTracker::UnpauseVirtualDevice()
+{
+  LOG_TRACE("vtkPlusAtracsysTracker::UnpauseVirtualDevice");
+  this->Internal->Tracker.Pause(false);
+  return PLUS_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
 PlusStatus vtkPlusAtracsysTracker::InternalUpdate()
 {
   LOG_TRACE("vtkPlusAtracsysTracker::InternalUpdate");
-  const double unfilteredTimestamp = vtkIGSIOAccurateTimer::GetSystemTime();
+  double unfilteredTimestamp = vtkIGSIOAccurateTimer::GetSystemTime();
 
   std::vector<AtracsysTracker::Marker> markers;
   std::map<std::string, std::string> events;
 
-  ATRACSYS_RESULT result = this->Internal->Tracker.GetMarkersInFrame(markers, events);
+  uint64_t sdkTimestamp = 0;
+  ATRACSYS_RESULT result = this->Internal->Tracker.GetMarkersInFrame(markers, events, sdkTimestamp);
+
   if (result == AtracsysTracker::ATRACSYS_RESULT::ERROR_NO_FRAME_AVAILABLE)
   {
     // waiting for frame
@@ -599,6 +682,10 @@ PlusStatus vtkPlusAtracsysTracker::InternalUpdate()
   }
 
   igsioFieldMapType customFields;
+
+  // save sdk timestamp in customfield
+  customFields["SdkTimestamp"].first = FRAMEFIELD_NONE;
+  customFields["SdkTimestamp"].second = std::to_string(sdkTimestamp);
 
   // save event data in custom field
   for (const auto& it : events)

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.h
@@ -29,6 +29,11 @@ public:
   /* Get SDK version */
   std::string GetSdkVersion();
 
+  /*! Retrieves the device calibration date in ISO format: YYYY-MM-DDTHH:MM:SSZ+XX
+  Example: "2020-04-08T21:24:15Z+00" is April 8th, 2020 at 9:24:15pm UTC (+00)
+  */
+  std::string GetCalibrationDate();
+
   /* Get device type */
   std::string GetDeviceType();
 
@@ -50,7 +55,7 @@ public:
 
   /* Device is a hardware tracker. */
   virtual bool IsTracker() const { return true; }
-  virtual bool IsVirtual() const { return false; }
+  virtual bool IsVirtual() const;
 
   /*! Read configuration from xml data */
   virtual PlusStatus ReadConfiguration(vtkXMLDataElement* config);
@@ -70,6 +75,10 @@ public:
   /*!  */
   PlusStatus InternalUpdate();
 
+  /*! Pause/unpause virtual device. */
+  PlusStatus PauseVirtualDevice();
+  PlusStatus UnpauseVirtualDevice();
+
 public:
   // Commands
   static const char* ATRACSYS_COMMAND_SET_FLAG;
@@ -80,6 +89,7 @@ public:
   static const char* ATRACSYS_COMMAND_ENABLE_TOOL;
   static const char* ATRACSYS_COMMAND_ADD_TOOL;
 
+  const std::map<std::string, std::string>& GetDeviceOptions() const;
   PlusStatus GetOptionValue(const std::string& optionName, std::string& optionValue);
 
   // Command methods
@@ -108,7 +118,6 @@ private: // Functions
 
   /*! Stop the tracking system and bring it back to its initial state. */
   PlusStatus InternalStopRecording();
-
   std::vector<std::string> DisabledToolIds;
 
   class vtkInternal;


### PR DESCRIPTION
This PR continues the rework of option management started [here](https://github.com/PlusToolkit/PlusLib/pull/1108).
This time, we focus on robustness. All input options (valid and unvalid) are still stored in vtkPlusDevice::Parameters, but it is now possible to access only the valid device options (those that have been successfully set) via vtkPlusAtracsysTracker::GetDeviceOptions().

Additionnally, one can now get the device calibration date.