### PR TITLE
ENH: Expose additional methods for WinProbe

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -64,6 +64,12 @@ const char* vtkPlusWinProbeVideoSource::SET_B_FRAME_RATE_LIMIT       = "SetBFram
 const char* vtkPlusWinProbeVideoSource::GET_B_FRAME_RATE_LIMIT       = "GetBFrameRateLimit";
 const char* vtkPlusWinProbeVideoSource::SET_B_HARMONIC_ENABLED       = "SetBHarmonicEnabled";
 const char* vtkPlusWinProbeVideoSource::GET_B_HARMONIC_ENABLED       = "GetBHarmonicEnabled";
+const char* vtkPlusWinProbeVideoSource::SET_B_TRANSMIT_CURRENT       = "SetBTransmitCurrent";
+const char* vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_CURRENT       = "GetBTransmitCurrent";
+const char* vtkPlusWinProbeVideoSource::SET_B_TRANSMIT_CYCLE_COUNT   = "SetBTransmitCycleCount";
+const char* vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_CYCLE_COUNT   = "GetBTransmitCycleCount";
+const char* vtkPlusWinProbeVideoSource::SET_B_TRANSMIT_FNUMBER       = "SetBTransmitFNumber";
+const char* vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_FNUMBER       = "GetBTransmitFNumber";
 const char* vtkPlusWinProbeVideoSource::GET_TRANSDUCER_INTERNAL_ID   = "GetTransducerInternalID";
 const char* vtkPlusWinProbeVideoSource::SET_ARFI_ENABLED             = "SetARFIEnabled";
 const char* vtkPlusWinProbeVideoSource::GET_ARFI_ENABLED             = "GetARFIEnabled";
@@ -262,6 +268,8 @@ PlusStatus vtkPlusWinProbeVideoSource::WriteConfiguration(vtkXMLDataElement* roo
   deviceConfig->SetIntAttribute("MWidthLines", this->m_MWidth);
   deviceConfig->SetIntAttribute("MAcousticLineCount", this->GetMAcousticLineCount());
   deviceConfig->SetIntAttribute("MDepth", this->GetMDepth());
+  deviceConfig->SetIntAttribute("BTransmitCurrent", this->GetBTransmitCurrent());
+  deviceConfig->SetIntAttribute("BTransmitCycleCount", this->GetBTransmitCycleCount());
   deviceConfig->SetUnsignedLongAttribute("Voltage", this->GetVoltage());
   deviceConfig->SetUnsignedLongAttribute("MinValue", this->GetMinValue());
   deviceConfig->SetUnsignedLongAttribute("MaxValue", this->GetMaxValue());
@@ -271,6 +279,7 @@ PlusStatus vtkPlusWinProbeVideoSource::WriteConfiguration(vtkXMLDataElement* roo
   deviceConfig->SetAttribute("Mode", ModeToString(this->m_Mode).c_str());
   deviceConfig->SetDoubleAttribute("FirstGainValue", this->GetFirstGainValue());
   deviceConfig->SetDoubleAttribute("OverallTimeGainCompensation", this->GetOverallTimeGainCompensation());
+  deviceConfig->SetDoubleAttribute("BTransmitFNumber", this->GetBTransmitFNumber());
   deviceConfig->SetIntAttribute("BFrameRateLimit", this->GetBFrameRateLimit());
 
   deviceConfig->SetVectorAttribute("TimeGainCompensation", 8, m_TimeGainCompensation);
@@ -944,6 +953,10 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
   // Update decimation variable on start, based on scan depth
   m_SSDecimation = ::GetSSDecimation();
   this->SetSpatialCompoundEnabled(m_SpatialCompoundEnabled); // also takes care of angle  and count
+  this->SetBHarmonicEnabled(m_BHarmonicEnabled);
+  this->SetBTransmitCurrent(m_BTransmitCurrent);
+  this->SetBTransmitCycleCount(m_BTransmitCycleCount);
+  this->SetBTransmitFNumber(m_BTransmitFNumber);
 
   //setup size for DirectX image
   LOG_DEBUG("Setting output size to " << m_PrimaryFrameSize[0] << "x" << m_PrimaryFrameSize[1]);
@@ -1703,6 +1716,63 @@ bool vtkPlusWinProbeVideoSource::GetBHarmonicEnabled()
     m_BHarmonicEnabled = GetBIsHarmonic();
   }
   return m_BHarmonicEnabled;
+}
+
+void vtkPlusWinProbeVideoSource::SetBTransmitCurrent(int value)
+{
+  if(Connected)
+  {
+    SetBTxCurrent(value);
+    SetPendingRecreateTables(true);
+  }
+  m_BTransmitCurrent = GetBTxCurrent();
+}
+
+int vtkPlusWinProbeVideoSource::GetBTransmitCurrent()
+{
+  if(Connected)
+  {
+    m_BTransmitCurrent = GetBTxCurrent();
+  }
+  return m_BTransmitCurrent;
+}
+
+void vtkPlusWinProbeVideoSource::SetBTransmitCycleCount(uint16_t value)
+{
+  if(Connected)
+  {
+    SetTxTxCycleCount(value);
+    SetPendingRecreateTables(true);
+  }
+  m_BTransmitCycleCount = GetBTransmitCycleCount();
+}
+
+uint16_t vtkPlusWinProbeVideoSource::GetBTransmitCycleCount()
+{
+  if(Connected)
+  {
+    m_BTransmitCycleCount = GetTxTxCycleCount();
+  }
+  return m_BTransmitCycleCount;
+}
+
+void vtkPlusWinProbeVideoSource::SetBTransmitFNumber(double value)
+{
+  if(Connected)
+  {
+    SetTxTxFNumber(value);
+    SetPendingRecreateTables(true);
+  }
+  m_BTransmitFNumber = GetBTransmitFNumber();
+}
+
+double vtkPlusWinProbeVideoSource::GetBTransmitFNumber()
+{
+  if(Connected)
+  {
+    m_BTransmitFNumber = GetTxTxFNumber();
+  }
+  return m_BTransmitFNumber;
 }
 
 bool vtkPlusWinProbeVideoSource::GetMModeEnabled()

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -72,6 +72,12 @@ public:
   static const char* GET_B_FRAME_RATE_LIMIT;
   static const char* SET_B_HARMONIC_ENABLED;
   static const char* GET_B_HARMONIC_ENABLED;
+  static const char* SET_B_TRANSMIT_CURRENT;
+  static const char* GET_B_TRANSMIT_CURRENT;
+  static const char* SET_B_TRANSMIT_CYCLE_COUNT;
+  static const char* GET_B_TRANSMIT_CYCLE_COUNT;
+  static const char* SET_B_TRANSMIT_FNUMBER;
+  static const char* GET_B_TRANSMIT_FNUMBER;
   static const char* GET_TRANSDUCER_INTERNAL_ID;
   static const char* SET_ARFI_ENABLED;
   static const char* GET_ARFI_ENABLED;
@@ -293,6 +299,15 @@ public:
 
   void SetBHarmonicEnabled(bool value);
   bool GetBHarmonicEnabled();
+
+  void SetBTransmitCurrent(int value);
+  int GetBTransmitCurrent();
+
+  void SetBTransmitCycleCount(uint16_t value);
+  uint16_t GetBTransmitCycleCount();
+
+  void SetBTransmitFNumber(double value);
+  double GetBTransmitFNumber();
 
   void SetBRFEnabled(bool value);
   bool GetBRFEnabled();
@@ -523,6 +538,9 @@ protected:
   double m_FirstGainValue = 15;
   int32_t m_BFrameRateLimit = 0;
   bool m_BHarmonicEnabled = false;
+  int m_BTransmitCurrent = 0;
+  uint16_t m_BTransmitCycleCount = 2;
+  double m_BTransmitFNumber = 3;
   std::vector<vtkPlusDataSource*> m_PrimarySources;
   std::vector<vtkPlusDataSource*> m_ExtraSources;
 

--- a/src/PlusServer/Commands/vtkPlusWinProbeCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusWinProbeCommand.cxx
@@ -275,6 +275,9 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_DECIMATION)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_FRAME_RATE_LIMIT)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_HARMONIC_ENABLED)
+        || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_CURRENT)
+        || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_CYCLE_COUNT)
+        || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_FNUMBER)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_TRANSDUCER_INTERNAL_ID)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_ENABLED)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_START_SAMPLE)
@@ -334,6 +337,12 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
           res = std::to_string(device->GetBFrameRateLimit());
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_HARMONIC_ENABLED))
           res = device->GetBHarmonicEnabled() ? "True" : "False";
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_CURRENT))
+          res = std::to_string(device->GetBTransmitCurrent());
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_CYCLE_COUNT))
+          res = std::to_string(device->GetBTransmitCycleCount());
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_FNUMBER))
+          res = std::to_string(device->GetBTransmitFNumber());
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_TRANSDUCER_INTERNAL_ID))
           res = std::to_string(device->GetTransducerInternalID());
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_ENABLED))
@@ -403,6 +412,9 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_DECIMATION)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_FRAME_RATE_LIMIT)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_HARMONIC_ENABLED)
+             || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_TRANSMIT_CURRENT)
+             || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_TRANSMIT_CYCLE_COUNT)
+             || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_TRANSMIT_FNUMBER)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_ENABLED)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_START_SAMPLE)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_STOP_SAMPLE)
@@ -533,6 +545,24 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
       {
         bool set = igsioCommon::IsEqualInsensitive(value, "true") ? true : false;
         device->SetBHarmonicEnabled(set);
+        status = PLUS_SUCCESS;
+      }
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_TRANSMIT_CURRENT))
+      {
+        int val = stoi(value);
+        device->SetBTransmitCurrent(val);
+        status = PLUS_SUCCESS;
+      }
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_TRANSMIT_CYCLE_COUNT))
+      {
+        uint16_t val = stoi(value);
+        device->SetBTransmitCycleCount(val);
+        status = PLUS_SUCCESS;
+      }
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_TRANSMIT_FNUMBER))
+      {
+        double val = stod(value);
+        device->SetBTransmitFNumber(val);
         status = PLUS_SUCCESS;
       }
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_ENABLED))


### PR DESCRIPTION
Get/Set for the following:
BTxCurrent, TxTxCycleCount, TxTxFNumber