### PR TITLE
BUG: Fix Capistrano device failing to connect after power cycle with cSDK2023 drivers

### DIFF
--- a/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.h
+++ b/src/PlusDataCollection/Capistrano/vtkPlusCapistranoVideoSource.h
@@ -230,6 +230,9 @@ public:
   /*! Get the pulse period used for the MIS mode. Only implemented with Capistrano SDK 2019.2 and newer. */
   PlusStatus GetMISPulsePeriod(unsigned int& PulsePeriod);
 
+  /*! Check if a board is attached. */
+  bool IsBoardAttached();
+
 protected:
   /*! Constructor */
   vtkPlusCapistranoVideoSource();


### PR DESCRIPTION
This fixes an issue where the Capistrano device would fail to connect the first time after it was power cycled. This will now keep checking if the imaging engine board is present as it waits for the device to re-enumerate after firmware is uploaded to the board during initial connection after being power cycle.