### PR TITLE
BUG: Fix handling of timestamp for WinProbe rendered frames

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1015,6 +1015,7 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalDisconnect()
 // ----------------------------------------------------------------------------
 PlusStatus vtkPlusWinProbeVideoSource::InternalStartRecording()
 {
+  this->FrameNumber = 0;
   WPExecute();
   return PLUS_SUCCESS;
 }
@@ -1132,7 +1133,6 @@ PlusStatus vtkPlusWinProbeVideoSource::FreezeDevice(bool freeze)
   if(IsRecording())
   {
     this->StopRecording();
-    this->FrameNumber = 0;
   }
   else
   {

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1233,7 +1233,7 @@ PlusStatus vtkPlusWinProbeVideoSource::SetScanDepthMm(float depth)
   {
     if(Recording)
     {
-      WPStopScanning();
+      this->StopRecording();
     }
     ::SetSSDepth(depth);
     SetPendingRecreateTables(true);
@@ -1243,7 +1243,7 @@ PlusStatus vtkPlusWinProbeVideoSource::SetScanDepthMm(float depth)
     m_SSDecimation = ::GetSSDecimation();
     if(Recording)
     {
-      WPExecute();
+      this->StartRecording();
     }
   }
   return PLUS_SUCCESS;

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -496,6 +496,7 @@ protected:
   std::string m_FPGAVersion;
   double m_ADCfrequency = 60.0e6; //MHz
   double m_TimestampOffset = 0; //difference between program start time and latest internal timer restart
+  double m_RenderedTimestampOffset = 0; //difference between program start time and latest internal timer restart
   double first_timestamp = 0;
   FrameSizeType m_PrimaryFrameSize = { 128, 256, 1 };
   FrameSizeType m_ExtraFrameSize = { 256, 128, 1 };


### PR DESCRIPTION
This includes a fix for better handling of the timestamp for rendered WinProbe frames because currently the timestamp offset sometimes gets randomly pushed to the future resulting in new frames getting ignored as they are considered "old" resulting in the stream appearing frozen. With these changes I have no longer observed a spurious frame increasing the timestamp so that when the ultrasound sequencer restarts, new frames always come through rather than the occasional longer than expected freeze of the live stream as we wait for new frames to have a timestamp beyond the spurious far one.

cc: @nhjohnston as another person who has used hardware to confirm these changes.