### PR TITLE
BUG: Fix WinProbe live stream not recovering upon depth change

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -1258,20 +1258,12 @@ PlusStatus vtkPlusWinProbeVideoSource::SetScanDepthMm(float depth)
   m_ScanDepth = depth;
   if(Connected)
   {
-    if(Recording)
-    {
-      this->StopRecording();
-    }
     ::SetSSDepth(depth);
     SetPendingRecreateTables(true);
     //what we requested might be only approximately satisfied
     m_ScanDepth = ::GetSSDepth();
     // Update decimation with scan depth
     m_SSDecimation = ::GetSSDecimation();
-    if(Recording)
-    {
-      this->StartRecording();
-    }
   }
   return PLUS_SUCCESS;
 }


### PR DESCRIPTION
Changing imaging depth was triggering start recording which was resetting the frame number and resulting in the live stream not streaming.

In general, changing of the scan depth does not require stopping and starting the recording to execute this parameter change.

cc: @nhjohnston for additional review with hardware