### PR TITLE
ENH: Add GitHub actions for CI and Nightly builds

### DIFF
--- a/.github/workflows/build-itk.yml
+++ b/.github/workflows/build-itk.yml
@@ -1,0 +1,97 @@
+name: Build ITK
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      os:
+        required: true
+        type: string
+      build-type:
+        required: false
+        type: string
+        default: Release
+      itk-hash:
+        required: true
+        type: string
+      build-options:
+        required: false
+        type: string
+      cache-prefix:
+        required: false
+        type: string
+        default: itk
+
+    outputs:
+      cache-key:
+        value: ${{ jobs.itk.outputs.cache-key }}
+      install-path:
+        value: ${{ jobs.itk.outputs.install-path }}
+
+jobs:
+  itk:
+    runs-on: ${{ inputs.os }}
+    outputs:
+      cache-key: ${{ steps.set-outputs.outputs.cache-key }}
+      install-path: ${{ steps.set-outputs.outputs.install-path }}
+    env:
+      CACHE_KEY: ${{ inputs.cache-prefix }}-${{ inputs.os }}-${{ inputs.arch }}-${{ inputs.itk-hash }}
+
+    steps:
+
+      - name: Cache ITK Build
+        id: cache-itk
+        uses: actions/cache@v4
+        with:
+          path: itk-install
+          key: ${{ env.CACHE_KEY }}
+
+      - name: Install Dependencies
+        if: contains(inputs.os, 'ubuntu') && steps.cache-itk.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          sudo apt update && sudo apt install -y cmake g++ libgl1-mesa-dev libxt-dev libxrender-dev libxext-dev libglu1-mesa-dev make
+
+      - name: Clone ITK
+        if: steps.cache-itk.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir itk
+          cd itk
+          git init
+          git remote add origin https://github.com/InsightSoftwareConsortium/ITK.git
+          git fetch --depth 1 origin ${{ inputs.itk-hash }}
+          git checkout FETCH_HEAD
+
+      - name: Configure ITK
+        if: steps.cache-itk.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cmake -S itk -B itk-build -G "Visual Studio 17 2022" -A ${{ inputs.arch }} \
+            -DCMAKE_INSTALL_PREFIX=itk-install \
+            -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} \
+            -DBUILD_SHARED_LIBS=ON \
+            -DBUILD_TESTING=OFF \
+            ${{ inputs.build-options }}
+
+      - name: Build ITK
+        if: steps.cache-itk.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cmake --build itk-build --parallel 4 --config ${{ inputs.build-type }}
+
+      - name: Install ITK
+        if: steps.cache-itk.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cmake --install itk-build
+
+      - name: Set Outputs
+        id: set-outputs
+        shell: bash
+        run: |
+          echo "cache-key=$CACHE_KEY" >> $GITHUB_OUTPUT
+          ITK_DIR=$(find "${GITHUB_WORKSPACE}/itk-install/lib/cmake" -maxdepth 1 -type d -name "ITK-*")
+          echo "install-path=${ITK_DIR}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-plus.yml
+++ b/.github/workflows/build-plus.yml
@@ -1,0 +1,144 @@
+name: Build Plus
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+        default: x64
+      # Dependency versions
+      qt-version:
+        required: false
+        type: string
+        default: '5.15.0'
+      vtk-cache-key:
+        required: true
+        type: string
+      itk-cache-key:
+        required: true
+        type: string
+
+      # Plus cache
+      plus-cache-key:
+        required: false
+        type: string
+
+      # Plus build options
+      plus-config:
+        required: true
+        type: string
+
+      # Uploaded archive name
+      archive-name:
+        required: false
+        type: string
+        default: PlusInstaller
+
+      # Repos/tags for PlusLib and PlusApp
+      pluslib-repository:
+        required: false
+        type: string
+        default: https://github.com/PlusToolkit/PlusLib.git
+      pluslib-tag:
+        required: false
+        type: string
+        default: master
+      plusapp-repository:
+        required: false
+        type: string
+        default: https://github.com/Sunderlandkyl/PlusApp.git
+      plusapp-tag:
+        required: false
+        type: string
+        default: install_branch_temp
+
+    secrets:
+      pltools-access-token:
+        required: false
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Restore VTK Cache
+      uses: actions/cache/restore@v4
+      with:
+        path: vtk-install
+        key: ${{ inputs.vtk-cache-key }}
+
+    - name: Restore ITK Cache
+      uses: actions/cache/restore@v4
+      with:
+        path: itk-install
+        key: ${{ inputs.itk-cache-key }}
+
+    - name: Plus Cache
+      if: ${{ inputs.plus-cache-key != '' }}
+      id: cache-plus
+      uses: actions/cache@v4
+      with:
+        path: build
+        key: ${{ inputs.plus-cache-key }}
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        dir: ${{ github.workspace }}/Qt
+        version: ${{ inputs.qt-version }}
+        arch: ${{ inputs.arch == 'x64' && 'win64_msvc2019_64' || 'win32_msvc2019' }}
+
+    - name: Clone PlusBuild
+      uses: actions/checkout@v4
+      with:
+        repository: PlusToolkit/PlusBuild
+        ref: master
+        path: PlusBuild
+
+    - name: Clone PLTools
+      uses: actions/checkout@v4
+      with:
+        repository: PerkLab/PLTools
+        ref: master
+        path: PLTools
+        token: ${{ secrets.pltools-access-token }}
+
+    - name: Configure PlusBuild
+      shell: bash
+      run: |
+        cmake -S PlusBuild -B build \
+          -G "Visual Studio 17 2022" -A ${{ inputs.arch }} \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DPLUSLIB_GIT_REPOSITORY=${{ inputs.pluslib-repository }} \
+          -DPLUSLIB_GIT_REVISION=${{ inputs.pluslib-tag }} \
+          -DPLUSAPP_GIT_REPOSITORY=${{ inputs.plusapp-repository }} \
+          -DPLUSAPP_GIT_REVISION=${{ inputs.plusapp-tag }} \
+          -DQt5_Dir="${QT_DIR}" \
+          ${{ inputs.plus-config }}
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      run: |
+        ctest -C Release -D Experimental -V
+
+    - uses: ilammy/msvc-dev-cmd@v1
+    - name: Package
+      if: contains(runner.os, 'windows')
+      working-directory: ${{github.workspace}}/build/PlusApp-bin
+      run: |
+        ./CreatePackage.bat
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.archive-name }}
+        path: ${{github.workspace}}/build/PlusApp-bin/*.exe
+
+    # Delete the installer so that it isn't included in the cache.
+    - name: Delete installer
+      shell: bash
+      run: |
+        rm -rfv build/PlusApp-bin/*.exe
+        rm -rfv build/PlusApp-bin/*.zip
+        rm -rfv build/PlusApp-bin/_CPack_Packages

--- a/.github/workflows/build-vtk.yml
+++ b/.github/workflows/build-vtk.yml
@@ -1,0 +1,108 @@
+name: Build VTK
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      os:
+        required: true
+        type: string
+      build-type:
+          required: false
+          type: string
+          default: Release
+      vtk-hash:
+        required: true
+        type: string
+      build-options:
+        required: false
+        type: string
+      cache-prefix:
+        required: false
+        type: string
+        default: vtk
+
+    outputs:
+      cache-key:
+        value: ${{ jobs.vtk.outputs.cache-key }}
+      install-path:
+        value: ${{ jobs.vtk.outputs.install-path }}
+
+jobs:
+  vtk:
+    runs-on: ${{ inputs.os }}
+    outputs:
+      cache-key: ${{ steps.set-outputs.outputs.cache-key }}
+      install-path: ${{ steps.set-outputs.outputs.install-path }}
+    env:
+      CACHE_KEY: ${{ inputs.cache-prefix }}-${{ inputs.os }}-${{ inputs.arch }}-${{ inputs.vtk-hash }}
+
+    steps:
+      - name: Cache VTK Build
+        id: cache-vtk
+        uses: actions/cache@v4
+        with:
+          path: vtk-install
+          lookup-only: true
+          key: ${{ env.CACHE_KEY }}
+
+      - name: Install Dependencies
+        if: contains(inputs.os, 'ubuntu') && steps.cache-vtk.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          sudo apt update && sudo apt install -y cmake g++ libgl1-mesa-dev libxt-dev libxrender-dev libxext-dev libglu1-mesa-dev make
+
+      - name: Install Qt
+        if: steps.cache-vtk.outputs.cache-hit != 'true'
+        uses: jurplel/install-qt-action@v4
+        with:
+          dir: ${{github.workspace}}/Qt
+          version: '5.15.0'
+          arch: ${{ inputs.arch == 'x64' && 'win64_msvc2019_64' || 'win32_msvc2019' }}
+
+      - name: Clone VTK
+        if: steps.cache-vtk.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir vtk
+          cd vtk
+          git init
+          git remote add origin https://gitlab.kitware.com/vtk/vtk.git
+          git fetch --depth 1 origin ${{ inputs.vtk-hash }}
+          git checkout FETCH_HEAD
+
+      - name: Configure VTK
+        if: steps.cache-vtk.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cmake -S vtk -B vtk-build -G "Visual Studio 17 2022" -A ${{ inputs.arch }} \
+            -DCMAKE_INSTALL_PREFIX=vtk-install \
+            -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} \
+            -DBUILD_SHARED_LIBS=ON \
+            -DVTK_BUILD_TESTING=OFF \
+            -DVTK_VERSIONED_INSTALL=OFF \
+            -DVTK_GROUP_ENABLE_Qt:STRING=YES \
+            -DQt5_DIR="${QT_DIR}" \
+            ${{ inputs.build-options }}
+
+      - name: Build VTK
+        if: steps.cache-vtk.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cmake --build vtk-build --parallel 4 --config ${{ inputs.build-type }}
+
+      - name: Install VTK
+        if: steps.cache-vtk.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cmake --install vtk-build
+
+      - name: Set Outputs
+        id: set-outputs
+        shell: bash
+        run: |
+          echo "cache-key=$CACHE_KEY" >> $GITHUB_OUTPUT
+          INSTALL_PATH="$GITHUB_WORKSPACE/vtk-install/lib/cmake/vtk"
+          echo "install-path=$INSTALL_PATH" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,258 @@
+name: Continuous integration
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  ########
+  # BUILD AND CACHE VTK
+  update_vtk_x64:
+    uses: ./.github/workflows/build-vtk.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [x64]
+    with:
+      vtk-hash: 6b6b89ee577e6c6a5ee6f5220b9c6a12513c30b4 # v9.4.1
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      build-type: ${{ matrix.build_type }}
+
+  update_vtk_static_x64:
+    uses: ./.github/workflows/build-vtk.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [x64]
+    with:
+      vtk-hash: 6b6b89ee577e6c6a5ee6f5220b9c6a12513c30b4 # v9.4.1
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      build-type: ${{ matrix.build_type }}
+      cache-prefix: vtk-static
+      build-options: >-
+        -DBUILD_SHARED_LIBS:BOOL=OFF
+
+  update_vtk_Win32:
+    uses: ./.github/workflows/build-vtk.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [Win32]
+    with:
+      vtk-hash: 6b6b89ee577e6c6a5ee6f5220b9c6a12513c30b4 # v9.4.1
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      build-type: ${{ matrix.build_type }}
+
+  ########
+  # BUILD AND CACHE ITK
+  update_itk_x64:
+    uses: ./.github/workflows/build-itk.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [x64]
+    with:
+      itk-hash: 898def645183e6a2d3293058ade451ec416c4514 # v5.4.2
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      build-type: ${{ matrix.build_type }}
+
+  update_itk_static_x64:
+    uses: ./.github/workflows/build-itk.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [x64]
+    with:
+      itk-hash: 898def645183e6a2d3293058ade451ec416c4514 # v5.4.2
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      build-type: ${{ matrix.build_type }}
+      cache-prefix: itk-static
+      build-options: >-
+        -DBUILD_SHARED_LIBS:BOOL=OFF
+
+  update_itk_Win32:
+    uses: ./.github/workflows/build-itk.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [Win32]
+    with:
+      itk-hash: 898def645183e6a2d3293058ade451ec416c4514 # v5.4.2
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      build-type: ${{ matrix.build_type }}
+
+  build_plus_x64:
+    needs: [update_vtk_x64, update_itk_x64]
+    uses: ./.github/workflows/build-plus.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [x64]
+    secrets:
+      pltools-access-token: ${{ secrets.PLTOOLS_ACCESS_TOKEN }}
+    with:
+      arch: ${{ matrix.arch }}
+      pluslib-repository: https://github.com/${{ github.repository }}.git
+      pluslib-tag: ${{ github.sha }}
+      vtk-cache-key: ${{ needs.update_vtk_x64.outputs.cache-key }}
+      itk-cache-key: ${{ needs.update_itk_x64.outputs.cache-key }}
+      plus-cache-key: plus-latest-x64
+      archive-name: PlusApp-Win64
+      plus-config: >-
+        -DVTK_DIR=${{ needs.update_vtk_x64.outputs.install-path }}
+        -DITK_DIR=${{ needs.update_itk_x64.outputs.install-path }}
+        -DPLUSBUILD_BUILDNAME_POSTFIX=gh-ci-x64
+        -DPLUS_USE_3dConnexion_TRACKER:BOOL=ON
+        -DPLUS_USE_Ascension3DGm:BOOL=OFF
+        -DPLUS_USE_BKPROFOCUS_VIDEO:BOOL=OFF
+        -DPLUS_USE_EPIPHAN:BOOL=ON
+        -DPLUS_USE_ICCAPTURING_VIDEO:BOOL=OFF
+        -DPLUS_USE_PHIDGET_SPATIAL_TRACKER:BOOL=ON
+        -DPLUS_USE_NDI:BOOL=ON
+        -DPLUS_USE_VFW_VIDEO:BOOL=ON
+        -DPLUS_USE_OPTITRACK:BOOL=ON
+        -DPLUS_USE_INTELREALSENSE:BOOL=ON
+        -DPLUSBUILD_PREFER_MicronTracker_36:BOOL=OFF
+        -DPLUS_USE_TextRecognizer:BOOL=ON
+        -DPLUS_USE_WITMOTIONTRACKER:BOOL=ON
+        -DPLUS_USE_MKV_IO:BOOL=ON
+        -DPLUS_ENABLE_VIDEOSTREAMING:BOOL=ON
+        -DPLUS_USE_VP9:BOOL=ON
+        -DPLUS_USE_Ascension3DG:BOOL=OFF
+        -DPLUS_USE_BRACHY_TRACKER:BOOL=OFF
+        -DPLUS_USE_NDI_CERTUS:BOOL=OFF
+        -DPLUS_USE_ULTRASONIX_VIDEO:BOOL=OFF
+        -DPLUS_USE_INTERSON_VIDEO:BOOL=OFF
+        -DPLUS_USE_MICRONTRACKER:BOOL=OFF
+        -DPLUS_USE_MMF_VIDEO:BOOL=ON
+        -DPLUS_USE_STEALTHLINK:BOOL=OFF
+        -DPLUS_USE_OPTICAL_MARKER_TRACKER:BOOL=ON
+        -DPLUSBUILD_USE_OpenCV:BOOL=ON
+        -DPLUS_USE_OpenCV_VIDEO:BOOL=ON
+        -DPLUSBUILD_USE_aruco:BOOL=ON
+
+  build_plus_Win32:
+    needs: [update_vtk_Win32, update_itk_Win32]
+    uses: ./.github/workflows/build-plus.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [Win32]
+    secrets:
+      pltools-access-token: ${{ secrets.PLTOOLS_ACCESS_TOKEN }}
+    with:
+      arch: Win32
+      pluslib-repository: https://github.com/${{ github.repository }}.git
+      pluslib-tag: ${{ github.sha }}
+      vtk-cache-key: ${{ needs.update_vtk_Win32.outputs.cache-key }}
+      itk-cache-key: ${{ needs.update_itk_Win32.outputs.cache-key }}
+      plus-cache-key: plus-latest-Win32
+      archive-name: PlusApp-Win32
+      plus-config: >-
+        -DVTK_DIR=${{ needs.update_vtk_Win32.outputs.install-path }}
+        -DITK_DIR=${{ needs.update_itk_Win32.outputs.install-path }}
+        -DPLUSAPP_PACKAGE_EDITION:STRING=""
+        -DPLUSBUILD_BUILDNAME_POSTFIX=gh-ci-Win32
+        -DPLUSBUILD_DOCUMENTATION:BOOL=OFF
+        -DPLUS_USE_3dConnexion_TRACKER:BOOL=ON
+        -DPLUS_USE_BKPROFOCUS_VIDEO:BOOL=OFF
+        -DPLUS_USE_EPIPHAN:BOOL=ON
+        -DPLUS_USE_ICCAPTURING_VIDEO:BOOL=ON
+        -DPLUS_USE_PHIDGET_SPATIAL_TRACKER:BOOL=ON
+        -DPLUS_USE_NDI:BOOL=ON
+        -DPLUS_USE_VFW_VIDEO:BOOL=ON
+        -DPLUS_USE_OPTITRACK:BOOL=ON
+        -DPLUS_USE_INTELREALSENSE:BOOL=ON
+        -DPLUS_USE_TextRecognizer:BOOL=ON
+        -DPLUS_USE_WITMOTIONTRACKER:BOOL=ON
+        -DPLUS_USE_MKV_IO:BOOL=ON
+        -DPLUS_ENABLE_VIDEOSTREAMING:BOOL=ON
+        -DPLUS_USE_VP9:BOOL=ON
+        -DPLUS_USE_Ascension3DG:BOOL=ON
+        -DPLUS_USE_BRACHY_TRACKER:BOOL=ON
+        -DPLUS_USE_NDI_CERTUS:BOOL=ON
+        -DPLUS_USE_MICRONTRACKER:BOOL=ON
+        -DPLUSBUILD_PREFER_MicronTracker_36:BOOL=OFF
+        -DPLUS_USE_MMF_VIDEO:BOOL=ON
+        -DPLUS_USE_OPTICAL_MARKER_TRACKER:BOOL=ON
+        -DPLUSBUILD_USE_OpenCV:BOOL=ON
+        -DPLUSBUILD_USE_aruco:BOOL=ON
+        -DPLUS_USE_OpenCV_VIDEO:BOOL=ON
+
+  build_plus_static_x64:
+    needs: [update_vtk_static_x64, update_itk_static_x64]
+    uses: ./.github/workflows/build-plus.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [x64]
+    secrets:
+      pltools-access-token: ${{ secrets.PLTOOLS_ACCESS_TOKEN }}
+    with:
+      arch: ${{ matrix.arch }}
+      pluslib-repository: https://github.com/${{ github.repository }}.git
+      pluslib-tag: ${{ github.sha }}
+      vtk-cache-key: ${{ needs.update_vtk_static_x64.outputs.cache-key }}
+      itk-cache-key: ${{ needs.update_itk_static_x64.outputs.cache-key }}
+      plus-cache-key: plus-static-x64
+      archive-name: PlusApp-Static-Win64
+      plus-config: >-
+        -DVTK_DIR=${{ needs.update_vtk_static_x64.outputs.install-path }}
+        -DITK_DIR=${{ needs.update_itk_static_x64.outputs.install-path }}
+        -DPLUSBUILD_BUILDNAME_POSTFIX=gh-static-x64
+        -DPLUSBUILD_BUILD_SHARED_LIBS:BOOL=OFF
+        -DPLUS_USE_3dConnexion_TRACKER:BOOL=ON
+        -DPLUS_USE_Ascension3DGm:BOOL=OFF
+        -DPLUS_USE_BKPROFOCUS_VIDEO:BOOL=OFF
+        -DPLUS_USE_EPIPHAN:BOOL=ON
+        -DPLUS_USE_ICCAPTURING_VIDEO:BOOL=OFF
+        -DPLUS_USE_PHIDGET_SPATIAL_TRACKER:BOOL=ON
+        -DPLUS_USE_NDI:BOOL=ON
+        -DPLUS_USE_VFW_VIDEO:BOOL=ON
+        -DPLUS_USE_OPTITRACK:BOOL=OFF
+        -DPLUS_USE_INTELREALSENSE:BOOL=OFF
+        -DPLUSBUILD_PREFER_MicronTracker_36:BOOL=OFF
+        -DPLUS_USE_TextRecognizer:BOOL=OFF
+        -DPLUS_USE_WITMOTIONTRACKER:BOOL=ON
+        -DPLUS_USE_MKV_IO:BOOL=OFF
+        -DPLUS_ENABLE_VIDEOSTREAMING:BOOL=ON
+        -DPLUS_USE_VP9:BOOL=ON
+        -DPLUS_USE_Ascension3DG:BOOL=OFF
+        -DPLUS_USE_BRACHY_TRACKER:BOOL=OFF
+        -DPLUS_USE_NDI_CERTUS:BOOL=OFF
+        -DPLUS_USE_ULTRASONIX_VIDEO:BOOL=OFF
+        -DPLUS_USE_INTERSON_VIDEO:BOOL=OFF
+        -DPLUS_USE_MICRONTRACKER:BOOL=OFF
+        -DPLUS_USE_MMF_VIDEO:BOOL=ON
+        -DPLUS_USE_STEALTHLINK:BOOL=OFF
+        -DPLUS_USE_OPTICAL_MARKER_TRACKER:BOOL=OFF
+        -DPLUSBUILD_USE_OpenCV:BOOL=OFF
+        -DPLUS_USE_OpenCV_VIDEO:BOOL=OFF
+        -DPLUSBUILD_USE_aruco:BOOL=OFF

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,363 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: "43 5 * * *" # Run nightly at 5:43 UTC. Picked a time when the load may be lower. https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule
+
+jobs:
+  ########
+  # BUILD AND CACHE VTK
+  update_vtk_x64:
+    uses: ./.github/workflows/build-vtk.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [x64]
+    with:
+      vtk-hash: 6b6b89ee577e6c6a5ee6f5220b9c6a12513c30b4 # v9.4.1
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      build-type: ${{ matrix.build_type }}
+
+  update_vtk_Win32:
+    uses: ./.github/workflows/build-vtk.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [Win32]
+    with:
+      vtk-hash: 6b6b89ee577e6c6a5ee6f5220b9c6a12513c30b4 # v9.4.1
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      build-type: ${{ matrix.build_type }}
+
+  ########
+  # BUILD AND CACHE ITK
+  update_itk_x64:
+    uses: ./.github/workflows/build-itk.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [x64]
+    with:
+      itk-hash: 898def645183e6a2d3293058ade451ec416c4514 # v5.4.2
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      build-type: ${{ matrix.build_type }}
+
+  update_itk_Win32:
+    uses: ./.github/workflows/build-itk.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [Win32]
+    with:
+      itk-hash: 898def645183e6a2d3293058ade451ec416c4514 # v5.4.2
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      build-type: ${{ matrix.build_type }}
+
+  build_plus_x64:
+    needs: [update_vtk_x64, update_itk_x64]
+    uses: ./.github/workflows/build-plus.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [x64]
+    secrets:
+      pltools-access-token: ${{ secrets.PLTOOLS_ACCESS_TOKEN }}
+    with:
+      arch: ${{ matrix.arch }}
+      pluslib-repository: https://github.com/${{ github.repository }}.git
+      pluslib-tag: ${{ github.sha }}
+      vtk-cache-key: ${{ needs.update_vtk_x64.outputs.cache-key }}
+      itk-cache-key: ${{ needs.update_itk_x64.outputs.cache-key }}
+      plus-cache-key: plus-latest-x64
+      archive-name: PlusApp-Win64
+      plus-config: >-
+        -DVTK_DIR=${{ needs.update_vtk_x64.outputs.install-path }}
+        -DITK_DIR=${{ needs.update_itk_x64.outputs.install-path }}
+        -DPLUSBUILD_BUILDNAME_POSTFIX=gh-package-x64
+        -DPLUS_USE_3dConnexion_TRACKER:BOOL=ON
+        -DPLUS_USE_Ascension3DGm:BOOL=OFF
+        -DPLUS_USE_BKPROFOCUS_VIDEO:BOOL=OFF
+        -DPLUS_USE_EPIPHAN:BOOL=ON
+        -DPLUS_USE_ICCAPTURING_VIDEO:BOOL=OFF
+        -DPLUS_USE_PHIDGET_SPATIAL_TRACKER:BOOL=ON
+        -DPLUS_USE_NDI:BOOL=ON
+        -DPLUS_USE_VFW_VIDEO:BOOL=ON
+        -DPLUS_USE_OPTITRACK:BOOL=ON
+        -DPLUS_USE_INTELREALSENSE:BOOL=ON
+        -DPLUSBUILD_PREFER_MicronTracker_36:BOOL=OFF
+        -DPLUS_USE_TextRecognizer:BOOL=ON
+        -DPLUS_USE_WITMOTIONTRACKER:BOOL=ON
+        -DPLUS_USE_MKV_IO:BOOL=ON
+        -DPLUS_ENABLE_VIDEOSTREAMING:BOOL=ON
+        -DPLUS_USE_VP9:BOOL=ON
+        -DPLUS_USE_Ascension3DG:BOOL=OFF
+        -DPLUS_USE_BRACHY_TRACKER:BOOL=OFF
+        -DPLUS_USE_NDI_CERTUS:BOOL=OFF
+        -DPLUS_USE_ULTRASONIX_VIDEO:BOOL=OFF
+        -DPLUS_USE_INTERSON_VIDEO:BOOL=OFF
+        -DPLUS_USE_MICRONTRACKER:BOOL=OFF
+        -DPLUS_USE_MMF_VIDEO:BOOL=ON
+        -DPLUS_USE_STEALTHLINK:BOOL=OFF
+        -DPLUS_USE_OPTICAL_MARKER_TRACKER:BOOL=ON
+        -DPLUSBUILD_USE_OpenCV:BOOL=ON
+        -DPLUS_USE_OpenCV_VIDEO:BOOL=ON
+        -DPLUSBUILD_USE_aruco:BOOL=ON
+
+  build_plus_x64_clarius_cast:
+    needs: [update_vtk_x64, update_itk_x64, build_plus_x64] # Build off of the base x64 package
+    uses: ./.github/workflows/build-plus.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [x64]
+    secrets:
+      pltools-access-token: ${{ secrets.PLTOOLS_ACCESS_TOKEN }}
+    with:
+      arch: ${{ matrix.arch }}
+      pluslib-repository: https://github.com/${{ github.repository }}.git
+      pluslib-tag: ${{ github.sha }}
+      vtk-cache-key: ${{ needs.update_vtk_x64.outputs.cache-key }}
+      itk-cache-key: ${{ needs.update_itk_x64.outputs.cache-key }}
+      plus-cache-key: plus-latest-x64
+      archive-name: PlusApp-Clarius-Win64
+      plus-config: >-
+        -DPLUSAPP_PACKAGE_EDITION:STRING="ClariusCast"
+        -DPLUSBUILD_BUILDNAME_POSTFIX=ClariusCast-gh-package-x64
+        -DPLUS_USE_CLARIUS:BOOL=ON
+
+  build_plus_x64_clarius_oem:
+    needs: [update_vtk_x64, update_itk_x64, build_plus_x64] # Build off of the base x64 package
+    uses: ./.github/workflows/build-plus.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [x64]
+    secrets:
+      pltools-access-token: ${{ secrets.PLTOOLS_ACCESS_TOKEN }}
+    with:
+      arch: ${{ matrix.arch }}
+      pluslib-repository: https://github.com/${{ github.repository }}.git
+      pluslib-tag: ${{ github.sha }}
+      vtk-cache-key: ${{ needs.update_vtk_x64.outputs.cache-key }}
+      itk-cache-key: ${{ needs.update_itk_x64.outputs.cache-key }}
+      plus-cache-key: plus-latest-x64
+      archive-name: PlusApp-ClariusOEM-Win64
+      plus-config: >-
+        -DPLUSAPP_PACKAGE_EDITION:STRING="ClariusOEM"
+        -DPLUSBUILD_BUILDNAME_POSTFIX=ClariusOEM-gh-package-x64
+        -DPLUS_USE_CLARIUS_OEM:BOOL=ON
+
+  build_plus_x64_telemed:
+    needs: [update_vtk_x64, update_itk_x64, build_plus_x64] # Build off of the base x64 package
+    uses: ./.github/workflows/build-plus.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [x64]
+    secrets:
+      pltools-access-token: ${{ secrets.PLTOOLS_ACCESS_TOKEN }}
+    with:
+      arch: ${{ matrix.arch }}
+      pluslib-repository: https://github.com/${{ github.repository }}.git
+      pluslib-tag: ${{ github.sha }}
+      vtk-cache-key: ${{ needs.update_vtk_x64.outputs.cache-key }}
+      itk-cache-key: ${{ needs.update_itk_x64.outputs.cache-key }}
+      plus-cache-key: plus-latest-x64
+      archive-name: PlusApp-Telemed-Win64
+      plus-config: >-
+        -DPLUSAPP_PACKAGE_EDITION:STRING="Telemed"
+        -DPLUSBUILD_BUILDNAME_POSTFIX=Telemed-gh-package-x64
+        -DPLUS_USE_TELEMED_VIDEO:BOOL=ON
+
+  build_plus_x64_sprytrack_telemed:
+    needs: [update_vtk_x64, update_itk_x64, build_plus_x64] # Build off of the base x64 package
+    uses: ./.github/workflows/build-plus.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [x64]
+    secrets:
+      pltools-access-token: ${{ secrets.PLTOOLS_ACCESS_TOKEN }}
+    with:
+      arch: ${{ matrix.arch }}
+      pluslib-repository: https://github.com/${{ github.repository }}.git
+      pluslib-tag: ${{ github.sha }}
+      vtk-cache-key: ${{ needs.update_vtk_x64.outputs.cache-key }}
+      itk-cache-key: ${{ needs.update_itk_x64.outputs.cache-key }}
+      plus-cache-key: plus-latest-x64
+      archive-name: PlusApp-spryTrack-Telemed-Win64
+      plus-config: >-
+        -DPLUSAPP_PACKAGE_EDITION:STRING="spryTrack-Telemed"
+        -DPLUSBUILD_BUILDNAME_POSTFIX=spryTrack-Telemed-gh-package-x64
+        -DPLUS_USE_TELEMED_VIDEO:BOOL=ON
+        -DPLUS_USE_ATRACSYS:BOOL=ON
+        -DPLUS_USE_ATRACSYS_DEVICE_TYPE:STRING="stk"
+
+  build_plus_x64_fusiontrack:
+    needs: [update_vtk_x64, update_itk_x64, build_plus_x64] # Build off of the base x64 package
+    uses: ./.github/workflows/build-plus.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [x64]
+    secrets:
+      pltools-access-token: ${{ secrets.PLTOOLS_ACCESS_TOKEN }}
+    with:
+      arch: ${{ matrix.arch }}
+      pluslib-repository: https://github.com/${{ github.repository }}.git
+      pluslib-tag: ${{ github.sha }}
+      vtk-cache-key: ${{ needs.update_vtk_x64.outputs.cache-key }}
+      itk-cache-key: ${{ needs.update_itk_x64.outputs.cache-key }}
+      plus-cache-key: plus-latest-x64
+      archive-name: PlusApp-fusionTrack-Win64
+      plus-config: >-
+        -DPLUSAPP_PACKAGE_EDITION:STRING="fusionTrack"
+        -DPLUSBUILD_BUILDNAME_POSTFIX=fusionTrack-gh-package-x64
+        -DPLUS_USE_ATRACSYS:BOOL=ON
+        -DPLUS_USE_ATRACSYS_DEVICE_TYPE:STRING="ftk"
+
+  build_plus_Win32:
+    needs: [update_vtk_Win32, update_itk_Win32]
+    uses: ./.github/workflows/build-plus.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [Win32]
+    secrets:
+      pltools-access-token: ${{ secrets.PLTOOLS_ACCESS_TOKEN }}
+    with:
+      arch: ${{ matrix.arch }}
+      pluslib-repository: https://github.com/${{ github.repository }}.git
+      pluslib-tag: ${{ github.sha }}
+      vtk-cache-key: ${{ needs.update_vtk_Win32.outputs.cache-key }}
+      itk-cache-key: ${{ needs.update_itk_Win32.outputs.cache-key }}
+      plus-cache-key: plus-latest-Win32
+      archive-name: PlusApp-Win32
+      plus-config: >-
+        -DVTK_DIR=${{ needs.update_vtk_Win32.outputs.install-path }}
+        -DITK_DIR=${{ needs.update_itk_Win32.outputs.install-path }}
+        -DPLUSAPP_PACKAGE_EDITION:STRING=""
+        -DPLUSBUILD_BUILDNAME_POSTFIX=gh-package-Win32
+        -DPLUSBUILD_DOCUMENTATION:BOOL=OFF
+        -DPLUS_USE_3dConnexion_TRACKER:BOOL=ON
+        -DPLUS_USE_BKPROFOCUS_VIDEO:BOOL=OFF
+        -DPLUS_USE_EPIPHAN:BOOL=ON
+        -DPLUS_USE_ICCAPTURING_VIDEO:BOOL=ON
+        -DPLUS_USE_PHIDGET_SPATIAL_TRACKER:BOOL=ON
+        -DPLUS_USE_NDI:BOOL=ON
+        -DPLUS_USE_VFW_VIDEO:BOOL=ON
+        -DPLUS_USE_OPTITRACK:BOOL=ON
+        -DPLUS_USE_INTELREALSENSE:BOOL=ON
+        -DPLUS_USE_TextRecognizer:BOOL=ON
+        -DPLUS_USE_WITMOTIONTRACKER:BOOL=ON
+        -DPLUS_USE_MKV_IO:BOOL=ON
+        -DPLUS_ENABLE_VIDEOSTREAMING:BOOL=ON
+        -DPLUS_USE_VP9:BOOL=ON
+        -DPLUS_USE_Ascension3DG:BOOL=ON
+        -DPLUS_USE_BRACHY_TRACKER:BOOL=ON
+        -DPLUS_USE_NDI_CERTUS:BOOL=ON
+        -DPLUS_USE_MICRONTRACKER:BOOL=ON
+        -DPLUSBUILD_PREFER_MicronTracker_36:BOOL=OFF
+        -DPLUS_USE_MMF_VIDEO:BOOL=ON
+        -DPLUS_USE_OPTICAL_MARKER_TRACKER:BOOL=ON
+        -DPLUSBUILD_USE_OpenCV:BOOL=ON
+        -DPLUSBUILD_USE_aruco:BOOL=ON
+        -DPLUS_USE_OpenCV_VIDEO:BOOL=ON
+
+  build_plus_Win32_thorlabs:
+    needs: [update_vtk_Win32, update_itk_Win32, build_plus_Win32]
+    uses: ./.github/workflows/build-plus.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [Win32]
+    secrets:
+      pltools-access-token: ${{ secrets.PLTOOLS_ACCESS_TOKEN }}
+    with:
+      arch: ${{ matrix.arch }}
+      pluslib-repository: https://github.com/${{ github.repository }}.git
+      pluslib-tag: ${{ github.sha }}
+      vtk-cache-key: ${{ needs.update_vtk_Win32.outputs.cache-key }}
+      itk-cache-key: ${{ needs.update_itk_Win32.outputs.cache-key }}
+      plus-cache-key: plus-latest-Win32
+      archive-name: PlusApp-Thorlabs-Win32
+      plus-config: >-
+        -DPLUSAPP_PACKAGE_EDITION:STRING="ThorLabs"
+        -DPLUSBUILD_BUILDNAME_POSTFIX=Thorlabs-gh-package-Win32
+        -DPLUS_USE_THORLABS_VIDEO:BOOL=ON
+
+  build_plus_Win32_interson:
+    needs: [update_vtk_Win32, update_itk_Win32, build_plus_Win32]
+    uses: ./.github/workflows/build-plus.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [Win32]
+    secrets:
+      pltools-access-token: ${{ secrets.PLTOOLS_ACCESS_TOKEN }}
+    with:
+      arch: ${{ matrix.arch }}
+      pluslib-repository: https://github.com/${{ github.repository }}.git
+      pluslib-tag: ${{ github.sha }}
+      vtk-cache-key: ${{ needs.update_vtk_Win32.outputs.cache-key }}
+      itk-cache-key: ${{ needs.update_itk_Win32.outputs.cache-key }}
+      plus-cache-key: plus-latest-Win32
+      archive-name: PlusApp-Interson-Win32
+      plus-config: >-
+        -DPLUSAPP_PACKAGE_EDITION:STRING="Interson"
+        -DPLUSBUILD_BUILDNAME_POSTFIX=Interson-gh-package-Win32
+        -DPLUS_USE_INTERSON_VIDEO:BOOL=ON
+
+  build_plus_Win32_telemed:
+    needs: [update_vtk_Win32, update_itk_Win32, build_plus_Win32]
+    uses: ./.github/workflows/build-plus.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release]
+        arch: [Win32]
+    secrets:
+      pltools-access-token: ${{ secrets.PLTOOLS_ACCESS_TOKEN }}
+    with:
+      arch: ${{ matrix.arch }}
+      pluslib-repository: https://github.com/${{ github.repository }}.git
+      pluslib-tag: ${{ github.sha }}
+      vtk-cache-key: ${{ needs.update_vtk_Win32.outputs.cache-key }}
+      itk-cache-key: ${{ needs.update_itk_Win32.outputs.cache-key }}
+      plus-cache-key: plus-latest-Win32
+      archive-name: PlusApp-Telemed-Win32
+      plus-config: >-
+        -DPLUSAPP_PACKAGE_EDITION:STRING="Telemed"
+        -DPLUSBUILD_BUILDNAME_POSTFIX=Telmed-gh-package-Win32
+        -DPLUS_USE_TELEMED_VIDEO:BOOL=ON


### PR DESCRIPTION
This commit adds GitHub actions that builds + packages Plus.

On commit/PR, the CI action runs x64, x86, x64-static builds. Every day, the nightly script will run and generate packages for nightly release.