### PR TITLE
Add support for Clarius Cast v12

### DIFF
--- a/src/PlusDataCollection/Clarius/vtkPlusClarius.cxx
+++ b/src/PlusDataCollection/Clarius/vtkPlusClarius.cxx
@@ -91,7 +91,7 @@ protected:
   Callback function used when connecting
   Input value is the udpPort.
   */
-  static void ConnectReturnFn(int udpPort, int swRevMatch);
+  static void ConnectReturnFn(int udpPort, int imuPort, int swRevMatch);
 
   /*!
   Callback function for raw data request
@@ -219,7 +219,7 @@ long long int vtkPlusClarius::vtkInternal::SecondsToNanoSeconds(double s)
 }
 
 //----------------------------------------------------------------------------
-void vtkPlusClarius::vtkInternal::ConnectReturnFn(int udpPort, int swRevMatch)
+void vtkPlusClarius::vtkInternal::ConnectReturnFn(int udpPort, int imuPort, int swRevMatch)
 {
   vtkPlusClarius* device = vtkPlusClarius::GetInstance();
   if (device == NULL)


### PR DESCRIPTION
Addresses connection error caused by a change in CusConnectFn, which now expects imuPort as its second argument.

Note that this change breaks compatibility with <v12. That said, considering that Clarius remotely pushes their updates, I'm not sure if it is necessary to maintain support for older versions.