### PR TITLE
CI: Update ITK version to 5.4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         build_type: [Release]
         arch: [x64]
     with:
-      itk-hash: 898def645183e6a2d3293058ade451ec416c4514 # v5.4.2
+      itk-hash: f98d5fac5e1d5ef694f3010f12bbbc2c792994c6 # v5.4.4
       os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
       build-type: ${{ matrix.build_type }}
@@ -81,7 +81,7 @@ jobs:
         build_type: [Release]
         arch: [x64]
     with:
-      itk-hash: 898def645183e6a2d3293058ade451ec416c4514 # v5.4.2
+      itk-hash: f98d5fac5e1d5ef694f3010f12bbbc2c792994c6 # v5.4.4
       os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
       build-type: ${{ matrix.build_type }}
@@ -98,7 +98,7 @@ jobs:
         build_type: [Release]
         arch: [Win32]
     with:
-      itk-hash: 898def645183e6a2d3293058ade451ec416c4514 # v5.4.2
+      itk-hash: f98d5fac5e1d5ef694f3010f12bbbc2c792994c6 # v5.4.4
       os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
       build-type: ${{ matrix.build_type }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,7 +47,7 @@ jobs:
         build_type: [Release]
         arch: [x64]
     with:
-      itk-hash: 898def645183e6a2d3293058ade451ec416c4514 # v5.4.2
+      itk-hash: f98d5fac5e1d5ef694f3010f12bbbc2c792994c6 # v5.4.4
       os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
       build-type: ${{ matrix.build_type }}
@@ -61,7 +61,7 @@ jobs:
         build_type: [Release]
         arch: [Win32]
     with:
-      itk-hash: 898def645183e6a2d3293058ade451ec416c4514 # v5.4.2
+      itk-hash: f98d5fac5e1d5ef694f3010f12bbbc2c792994c6 # v5.4.4
       os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
       build-type: ${{ matrix.build_type }}


### PR DESCRIPTION
This updates ITK to use in Plus build CI jobs.

This corresponds to the change in https://github.com/PlusToolkit/PlusBuild/pull/96. @Sunderlandkyl Should these 2 places (Pluslib CI and the PlusBuild) be kept in sync?