### PR TITLE
ENH Added network configuration for Atracsys and other improvements

### DIFF
--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.cxx
@@ -374,6 +374,9 @@ public:
   // library version 
   std::string LibVersion;
 
+  // firmware soft version
+  std::string FirmwareSoftwareVersion;
+
   // calibration date
   std::string CalibrationDate;
 
@@ -682,7 +685,7 @@ bool Tracker::IsVirtual()
 }
 
 //----------------------------------------------------------------------------
-Tracker::RESULT Tracker::Connect()
+Tracker::RESULT Tracker::Connect(const std::string& networkConfigFile)
 {
   if (this->InternalObj->FtkLib != nullptr && this->InternalObj->TrackerSN != 0)
   {
@@ -691,11 +694,24 @@ Tracker::RESULT Tracker::Connect()
   }
 
   // initialize SDK
-  this->InternalObj->FtkLib = ftkInit();
-
-  if (this->InternalObj->FtkLib == NULL)
+  if (networkConfigFile.empty())
   {
-    return ERROR_UNABLE_TO_GET_FTK_HANDLE;
+    this->InternalObj->FtkLib = ftkInit();
+    if (this->InternalObj->FtkLib == NULL)
+    {
+      return ERROR_UNABLE_TO_GET_FTK_HANDLE;
+    }
+  }
+  else
+  {
+    ftkBuffer buffer;
+    this->InternalObj->FtkLib = ftkInitExt(networkConfigFile.c_str(), &buffer);
+    if (this->InternalObj->FtkLib == NULL)
+    {
+      LOG_ERROR(buffer.data);
+      LOG_ERROR("Cannot initialize library with the provided network configuration.");
+      return ERROR_UNABLE_TO_GET_FTK_HANDLE;
+    }
   }
 
   DeviceData device;
@@ -779,6 +795,14 @@ Tracker::RESULT Tracker::Connect()
   ftkGetData(this->InternalObj->FtkLib, this->InternalObj->TrackerSN, info->id, &buff);
   this->InternalObj->CalibrationDate = std::string(buff.data);
 
+  if (!this->GetOptionInfo("Device software version", info))
+  {
+    LOG_ERROR("Option unknown: \"Device software version\"");
+    return ERROR_OPTION_NOT_FOUND;
+  }
+  ftkGetData(this->InternalObj->FtkLib, this->InternalObj->TrackerSN, info->id, &buff);
+  this->InternalObj->FirmwareSoftwareVersion = std::string(buff.data);
+
   // Check whether onboard processing is off or on (spryTrack only)
   if (this->DeviceType == SPRYTRACK_180 || this->DeviceType == SPRYTRACK_300)
   {
@@ -828,6 +852,13 @@ Tracker::RESULT Tracker::Disconnect()
 Tracker::RESULT Tracker::GetSDKversion(std::string& version)
 {
   version = this->InternalObj->LibVersion;
+  return SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+Tracker::RESULT Tracker::GetFirmwareSoftwareVersion(std::string& version)
+{
+  version = this->InternalObj->FirmwareSoftwareVersion;
   return SUCCESS;
 }
 
@@ -951,6 +982,16 @@ Tracker::RESULT Tracker::GetMarkerInfo(std::string& markerInfo)
 Tracker::RESULT Tracker::GetLoadedGeometries(std::map<int, std::vector<std::array<float, 3>>>& geometries)
 {
   geometries = this->InternalObj->Geometries;
+  return SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+Tracker::RESULT Tracker::GetFiducialCoordinates(int geomId, std::vector<std::array<float, 3>>& fidCoords)
+{
+  if (this->InternalObj->Geometries.find(geomId) == this->InternalObj->Geometries.cend())
+    return ERROR_REQUESTED_GEOMETRY_NOT_FOUND;
+
+  fidCoords = this->InternalObj->Geometries.at(geomId);
   return SUCCESS;
 }
 

--- a/src/PlusDataCollection/Atracsys/AtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/AtracsysTracker.h
@@ -125,7 +125,8 @@ namespace Atracsys
       ERROR_CANNOT_GET_MARKER_INFO,
       ERROR_FAILED_TO_SET_STK_PROCESSING_TYPE,
       ERROR_OPTION_NOT_FOUND,
-      ERROR_SET_OPTION
+      ERROR_SET_OPTION,
+      ERROR_REQUESTED_GEOMETRY_NOT_FOUND
     };
 
     enum DEVICE_TYPE
@@ -153,13 +154,16 @@ namespace Atracsys
     void Pause(bool tof);
 
     /*! Connect to Atracsys tracker, must be called before any other function in this wrapper API. */
-    RESULT Connect();
+    RESULT Connect(const std::string& networkConfigFile = "");
 
     /*! Closes connections to Atracsys tracker, must be called at end of application. */
     RESULT Disconnect();
 
     /*! */
     RESULT GetSDKversion(std::string& version);
+
+    /*! */
+    RESULT GetFirmwareSoftwareVersion(std::string& version);
 
     /*! */
     RESULT GetCalibrationDate(std::string& date);
@@ -190,6 +194,9 @@ namespace Atracsys
 
     /*! */
     RESULT GetLoadedGeometries(std::map<int, std::vector<std::array<float,3>>>& geometries);
+
+    /*! */
+    RESULT GetFiducialCoordinates(int geomId, std::vector<std::array<float, 3>>& fidCoords);
 
     /*! */
     std::string ResultToString(RESULT result);

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.cxx
@@ -84,10 +84,12 @@ public:
   int MaxMissingFiducials = 0; // maximum number of missing fiducials
 
   // matches plus tool id to .ini geometry file names/paths
-  std::map<std::string, std::string> PlusIdMappedToGeometryFilename;
+  std::map<std::string, std::string> ToolIdMappedToGeometryFilename;
 
-  // matches fusionTrack internal tool geometry ID to Plus tool ID for updating tools
-  std::map<int, std::string> FtkGeometryIdMappedToToolId;
+  // matches Atracsys internal tool geometry ID to Plus tool ID for updating tools
+  std::map<int, std::string> AtracGeomIdMappedToToolId;
+  // reverse lookup, Plus tool ID to Atracsys internal tool geometry ID
+  std::map<std::string, int> ToolIdMappedToAtracGeomId;
 
   // Atracsys API wrapper class handle
   Atracsys::Tracker Tracker;
@@ -128,6 +130,14 @@ std::string vtkPlusAtracsysTracker::GetSdkVersion()
   std::string v;
   this->InternalObj->Tracker.GetSDKversion(v);
   return v;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkPlusAtracsysTracker::GetFirmwareSoftwareVersion()
+{
+    std::string d;
+    this->InternalObj->Tracker.GetFirmwareSoftwareVersion(d);
+    return d;
 }
 
 //----------------------------------------------------------------------------
@@ -188,6 +198,32 @@ PlusStatus vtkPlusAtracsysTracker::GetLoadedGeometries(std::map<int, std::vector
 }
 
 //----------------------------------------------------------------------------
+PlusStatus vtkPlusAtracsysTracker::GetMarkerGeometry(std::string toolId, std::string& relPath,
+  int& geomId, std::vector<std::array<float, 3>>& fidCoords)
+{
+  if (this->InternalObj->ToolIdMappedToGeometryFilename.find(toolId) == this->InternalObj->ToolIdMappedToGeometryFilename.cend())
+  {
+    LOG_ERROR("Could not get geometry filename for tool " << toolId);
+    return PLUS_FAIL;
+  }
+  relPath = this->InternalObj->ToolIdMappedToGeometryFilename.at(toolId);
+
+  if (this->InternalObj->ToolIdMappedToAtracGeomId.find(toolId) == this->InternalObj->ToolIdMappedToAtracGeomId.cend())
+  {
+    LOG_ERROR("Could not get marker geometry for tool " << toolId);
+    return PLUS_FAIL;
+  }
+  geomId = this->InternalObj->ToolIdMappedToAtracGeomId.at(toolId);
+
+  if (this->InternalObj->Tracker.GetFiducialCoordinates(geomId, fidCoords) != ATR_SUCCESS)
+  {
+    LOG_ERROR("Could not get fiducial coordinates for geometry id " << geomId);
+    return PLUS_FAIL;
+  }
+  return PLUS_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
 bool vtkPlusAtracsysTracker::IsVirtual() const
 {
   return this->InternalObj->Tracker.IsVirtual();
@@ -238,13 +274,13 @@ PlusStatus vtkPlusAtracsysTracker::ReadConfiguration(vtkXMLDataElement* rootConf
     XML_READ_ENUM2_ATTRIBUTE_NONMEMBER_OPTIONAL(TrackingType, toolTrackingType, toolDataElement, "ACTIVE", ACTIVE, "PASSIVE", PASSIVE);
     if (toolTrackingType == ACTIVE)
     {
-      // active tool, can be loaded directly into FtkGeometryIdMappedToToolId
+      // active tool, can be loaded directly into AtracGeomIdMappedToToolId
       int ftkGeometryId = -1;
       XML_READ_SCALAR_ATTRIBUTE_NONMEMBER_OPTIONAL(int, GeometryId, ftkGeometryId, toolDataElement);
       if (ftkGeometryId != -1)
       {
-        std::pair<int, std::string> thisTool(ftkGeometryId, toolId);
-        this->InternalObj->FtkGeometryIdMappedToToolId.insert(thisTool);
+        this->InternalObj->AtracGeomIdMappedToToolId.insert(std::make_pair(ftkGeometryId, toolId));
+        this->InternalObj->ToolIdMappedToAtracGeomId.insert(std::make_pair(toolId, ftkGeometryId));
       }
       else
       {
@@ -254,12 +290,11 @@ PlusStatus vtkPlusAtracsysTracker::ReadConfiguration(vtkXMLDataElement* rootConf
     }
     else if (toolTrackingType == PASSIVE)
     {
-      // passive tool, load into PlusIdMappedToGeometryFilename to have geometry loaded in InternalConnect
+      // passive tool, load into ToolIdMappedToGeometryFilename to have geometry loaded in InternalConnect
       const char* geometryFile;
       if ((geometryFile = toolDataElement->GetAttribute("GeometryFile")) != NULL)
       {
-        std::pair<std::string, std::string> thisTool(toolId, geometryFile);
-        this->InternalObj->PlusIdMappedToGeometryFilename.insert(thisTool);
+        this->InternalObj->ToolIdMappedToGeometryFilename.insert(std::make_pair(toolId, geometryFile));
       }
       else
       {
@@ -326,8 +361,17 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
 {
   LOG_TRACE("vtkPlusAtracsysTracker::InternalConnect");
 
+  // Check if network configuration file is provided
+  std::string networkConfigPath;
+  if (this->InternalObj->DeviceOptions.find("NetworkConfigFile") != this->InternalObj->DeviceOptions.end())
+  {
+    networkConfigPath = vtkPlusConfig::GetInstance()->GetDeviceSetConfigurationPath(
+        this->InternalObj->DeviceOptions["NetworkConfigFile"]);
+  }
+
   // Connect to device
-  ATR_RESULT result = this->InternalObj->Tracker.Connect();
+  ATR_RESULT result = this->InternalObj->Tracker.Connect(networkConfigPath.empty() ? "" : networkConfigPath.c_str());
+
   if (result != ATR_SUCCESS && result != ATR_RESULT::WARNING_CONNECTED_IN_USB2)
   {
     LOG_ERROR(this->InternalObj->Tracker.ResultToString(result));
@@ -540,7 +584,8 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
       }
     }
     else if (itr->first != "AcquisitionRate" && itr->first != "Id" && itr->first != "Type"
-      && itr->first != "ToolReferenceFrame" && itr->first != "Enable_embedded_processing")
+      && itr->first != "ToolReferenceFrame" && itr->first != "Enable_embedded_processing"
+      && itr->first != "NetworkConfigFile")
     {
       LOG_WARNING("Unknown option \"" << itr->first << "\".");
       itr = this->InternalObj->DeviceOptions.erase(itr);
@@ -564,7 +609,7 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
 
   // load passive geometries onto Atracsys
   std::map<std::string, std::string>::iterator it;
-  for (it = begin(this->InternalObj->PlusIdMappedToGeometryFilename); it != end(this->InternalObj->PlusIdMappedToGeometryFilename); it++)
+  for (it = begin(this->InternalObj->ToolIdMappedToGeometryFilename); it != end(this->InternalObj->ToolIdMappedToGeometryFilename); it++)
   {
     // load user defined geometry file
     // TODO: add check for conflicting marker IDs
@@ -575,8 +620,8 @@ PlusStatus vtkPlusAtracsysTracker::InternalConnect()
       LOG_ERROR(this->InternalObj->Tracker.ResultToString(result) << " This error occurred when trying to load geometry file at path: " << geomFilePath);
       return PLUS_FAIL;
     }
-    std::pair<int, std::string> newTool(geometryId, it->first);
-    this->InternalObj->FtkGeometryIdMappedToToolId.insert(newTool);
+    this->InternalObj->AtracGeomIdMappedToToolId.insert(std::make_pair(geometryId, it->first));
+    this->InternalObj->ToolIdMappedToAtracGeomId.insert(std::make_pair(it->first, geometryId));
   }
 
   // if active marker pairing is desired, then its time > 0 second
@@ -702,7 +747,7 @@ PlusStatus vtkPlusAtracsysTracker::InternalUpdate()
   }
 
   std::map<int, std::string>::iterator it;
-  for (it = this->InternalObj->FtkGeometryIdMappedToToolId.begin(); it != this->InternalObj->FtkGeometryIdMappedToToolId.end(); it++)
+  for (it = this->InternalObj->AtracGeomIdMappedToToolId.begin(); it != this->InternalObj->AtracGeomIdMappedToToolId.end(); it++)
   {
     if (std::find(this->DisabledToolIds.begin(), this->DisabledToolIds.end(), it->second) != this->DisabledToolIds.end())
     {
@@ -834,7 +879,7 @@ PlusStatus vtkPlusAtracsysTracker::SetToolEnabled(std::string toolId, bool enabl
   // tool should be disabled, if it exists add to disabled list
   bool toolExists = false;
   std::map<int, std::string>::iterator it;
-  for (it = this->InternalObj->FtkGeometryIdMappedToToolId.begin(); it != this->InternalObj->FtkGeometryIdMappedToToolId.end(); it++)
+  for (it = this->InternalObj->AtracGeomIdMappedToToolId.begin(); it != this->InternalObj->AtracGeomIdMappedToToolId.end(); it++)
   {
     if (igsioCommon::IsEqualInsensitive(it->second, toolId))
     {
@@ -859,7 +904,7 @@ PlusStatus vtkPlusAtracsysTracker::AddToolGeometry(std::string toolId, std::stri
   // make sure geometry with toolId doesn't already exist
   bool toolExists = false;
   std::map<int, std::string>::iterator it;
-  for (it = this->InternalObj->FtkGeometryIdMappedToToolId.begin(); it != this->InternalObj->FtkGeometryIdMappedToToolId.end(); it++)
+  for (it = this->InternalObj->AtracGeomIdMappedToToolId.begin(); it != this->InternalObj->AtracGeomIdMappedToToolId.end(); it++)
   {
     if (igsioCommon::IsEqualInsensitive(it->second, toolId))
     {
@@ -889,7 +934,7 @@ PlusStatus vtkPlusAtracsysTracker::AddToolGeometry(std::string toolId, std::stri
   aToolSource->SetId(toolId);
   this->AddTool(aToolSource);
 
-  // TO DO: add fiducial data as separate sources ?
+  // TODO: add fiducial data as separate sources ?
   //vtkSmartPointer<vtkPlusDataSource> aFids3dSource = vtkSmartPointer<vtkPlusDataSource>::New();
   //aFids3dSource->SetReferenceCoordinateFrameName(this->ToolReferenceFrameName);
   //aFids3dSource->SetType(DATA_SOURCE_TYPE_FIELDDATA);
@@ -925,7 +970,7 @@ PlusStatus vtkPlusAtracsysTracker::AddToolGeometry(std::string toolId, std::stri
 
   // register this tool internally
   std::pair<int, std::string> newTool(geometryId, toolId);
-  this->InternalObj->FtkGeometryIdMappedToToolId.insert(newTool);
+  this->InternalObj->AtracGeomIdMappedToToolId.insert(newTool);
 
   return PLUS_SUCCESS;
 }

--- a/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.h
+++ b/src/PlusDataCollection/Atracsys/vtkPlusAtracsysTracker.h
@@ -29,6 +29,9 @@ public:
   /* Get SDK version */
   std::string GetSdkVersion();
 
+  /* Get Firmware Software Version */
+  std::string GetFirmwareSoftwareVersion();
+
   /*! Retrieves the device calibration date in ISO format: YYYY-MM-DDTHH:MM:SSZ+XX
   Example: "2020-04-08T21:24:15Z+00" is April 8th, 2020 at 9:24:15pm UTC (+00)
   */
@@ -52,6 +55,12 @@ public:
   * that composes the marker
   */
   PlusStatus GetLoadedGeometries(std::map<int, std::vector<std::array<float, 3>>>& geometries);
+
+  /*! Get marker geometry details from tool id :
+  * Based on tool id, retrieves the provided relative file path, the associated Atracsys geometry id
+  * and the vector of x,y,z coordinates of each fiducial that composes the marker
+  */
+  PlusStatus GetMarkerGeometry(std::string toolId, std::string &relPath, int &geomId, std::vector<std::array<float, 3>>& fidCoords);
 
   /* Device is a hardware tracker. */
   virtual bool IsTracker() const { return true; }


### PR DESCRIPTION
This PR introduces several improvements to the Atracsys wrapper:
1) Fixed issue in AtracsysMarkerCreator when the fiducial order was not maintained.
2) Two new functions:
- GetFirmwareSoftwareVersion() to obtain more information on the connected system
- GetMarkerGeometry() to retrieve the geometry of a particular tool based its id
3) Added support for network configuration, allowing to connect to a device set with a custom IP address (different from the default 172.17.1.x). To use it, create a json file like below and place it in the device set configuration folder. Then, set the device attribute `NetworkConfigFile` to its filename in the Device section of the configuration xml:

```
<Device
      Id="TrackerDevice"
      Type="AtracsysTracker"
      NetworkConfigFile="AtracsysNetworkConfig.json"
      MaxMissingFiducials="0"
      MaxMeanRegistrationErrorMm="1.0"
      SymmetriseCoordinates="1"
      EnableIRstrobe="1"
      ToolReferenceFrame="Tracker" >
```

AtracsysNetworkConfig.json:
```
{
  "network": {
    "version": 2,
    "interfaces": [
      {
        "adapter": "172.17.4.100",
        "mtu": 9014,
        "devices": [
          {
            "address": "172.17.4.7",
            "port": 3509
          }
        ]
      }
    ]
  }
}

```