### PR TITLE
BUG: Remove duplicate header from vtkPlusUsImagingParameters

### DIFF
--- a/src/PlusDataCollection/vtkPlusUsImagingParameters.h
+++ b/src/PlusDataCollection/vtkPlusUsImagingParameters.h
@@ -216,8 +216,6 @@ protected:
   virtual ~vtkPlusUsImagingParameters();
 
   const char* GetXMLElementName() override { return vtkPlusUsImagingParameters::US_XML_ELEMENT_TAG; }
-
-  ParameterMap Parameters;
 };
 
 #endif


### PR DESCRIPTION
Found bug when using commit https://github.com/PlusToolkit/PlusLib/commit/27537324cfa05d04eefa6d91d1a0f3cd8b5768e7 to implement MMF camera control parameters

Duplicate header definition of ParameterMap in vtkPlusUsImagingParameters.h prevented UsImagingParameters from being set correctly in configuration .xml file, resulting in "Invalid key request sent..." error.