### PR TITLE
Migrate deprecated itkTypeMacro to itkOverrideGetNameOfClassMacro (ITK 6, release-5.4 compatible)

### DIFF
--- a/src/Utilities/Ransac/ParametersEstimator.h
+++ b/src/Utilities/Ransac/ParametersEstimator.h
@@ -36,7 +36,7 @@ public:
    typedef SmartPointer<Self>          Pointer;
    typedef SmartPointer<const Self>    ConstPointer;
  
-   itkTypeMacro( ParametersEstimator, Object );
+   itkOverrideGetNameOfClassMacro(ParametersEstimator);
 
   /**
    * Exact estimation of parameters.

--- a/src/Utilities/Ransac/PlaneParametersEstimator.h
+++ b/src/Utilities/Ransac/PlaneParametersEstimator.h
@@ -30,9 +30,9 @@ public:
   typedef SmartPointer<Self>                                       Pointer;
   typedef SmartPointer<const Self>                                 ConstPointer;
  
-  itkTypeMacro( PlaneParametersEstimator, ParametersEstimator );
+  itkOverrideGetNameOfClassMacro(PlaneParametersEstimator);
      /** New method for creating an object using a factory. */
-  itkNewMacro( Self )
+  itkNewMacro( Self );
 
   /**
    * Compute the (hyper)plane defined by the given data points.

--- a/src/Utilities/Ransac/RANSAC.h
+++ b/src/Utilities/Ransac/RANSAC.h
@@ -69,9 +69,9 @@ namespace itk
     typedef SmartPointer<Self>         Pointer;
     typedef SmartPointer<const Self>   ConstPointer;
 
-    itkTypeMacro(RANSAC, Object);
+    itkOverrideGetNameOfClassMacro(RANSAC);
     /** New method for creating an object using a factory. */
-    itkNewMacro(Self)
+    itkNewMacro(Self);
 
     /**
      * Set/Get the number of threads used by the RANSAC implementation.

--- a/src/Utilities/Ransac/SphereParametersEstimator.h
+++ b/src/Utilities/Ransac/SphereParametersEstimator.h
@@ -27,9 +27,9 @@ public:
   typedef SmartPointer<Self>                                       Pointer;
   typedef SmartPointer<const Self>                                 ConstPointer;
  
-  itkTypeMacro( SphereParametersEstimator, ParametersEstimator );
+  itkOverrideGetNameOfClassMacro(SphereParametersEstimator);
      /** New method for creating an object using a factory. */
-  itkNewMacro( Self )
+  itkNewMacro( Self );
   
   enum LeastSquaresType {ALGEBRAIC = 0, GEOMETRIC};
 


### PR DESCRIPTION
Migrate the deprecated `itkTypeMacro`/`itkTypeMacroNoParent` and add the now-required trailing semicolons to `itkNewMacro` in the RANSAC utility headers, so PlusLib builds against ITK 6 (including `ITK_FUTURE_LEGACY_REMOVE` builds) while staying compatible with ITK release-5.4.

<details>
<summary>Details</summary>

- `itkTypeMacro(X, Super)` → `itkOverrideGetNameOfClassMacro(X)`; `itkTypeMacroNoParent(X)` → `itkVirtualGetNameOfClassMacro(X)`. Under `ITK_FUTURE_LEGACY_REMOVE` the old macros are `static_assert(false, ...)`.
- ITK 6 makes `ITK_NOOP_STATEMENT` a `static_assert(true, "")`, so bare `itkNewMacro(Self)` now needs a terminating `;`.
- The replacement macros exist since ITK 5.4.0, and the added semicolons are inert empty declarations there → release-5.4 compatible.

Verified building PlusLib against ITK 6 and ITK 5.4.6. One of a set of independent ITK-6 compatibility PRs.
</details>
