### PR TITLE
Qualify unqualified cout/endl in vtkPlusPolydataForce

### DIFF
--- a/src/PlusDataCollection/Haptics/vtkPlusPolydataForce.cxx
+++ b/src/PlusDataCollection/Haptics/vtkPlusPolydataForce.cxx
@@ -11,6 +11,8 @@ See License.txt for details.
 #include "vtkPlusPolydataForce.h"
 #include "vtkMatrix4x4.h"
 
+using namespace std;
+
 //----------------------------------------------------------------------------
 
 vtkStandardNewMacro( vtkPlusPolydataForce )


### PR DESCRIPTION
`vtkPlusPolydataForce.cxx` used bare `cout`/`endl`, which no longer resolve under current libc++ (`use of undeclared identifier 'cout'`). Add a `using` directive so it compiles. Independent of ITK/VTK version.

<details>
<summary>Details</summary>

Surfaced while building PlusLib against ITK 6 with a recent clang/libc++, but the cause is standard-library strictness, not ITK. One of a set of independent ITK-6 compatibility PRs.
</details>
