### PR TITLE
Link ITK::IOFDF into PlusCalibration tests for the ITK IO factory manager (guarded)

### DIFF
--- a/src/PlusCalibration/Testing/CMakeLists.txt
+++ b/src/PlusCalibration/Testing/CMakeLists.txt
@@ -333,3 +333,15 @@ TARGET_LINK_LIBRARIES( vtkSegmentedWiresPositionsTest
   ITKCommon
   vtkPlusDataCollection
   )
+# The ITK ImageIO factory-register manager references every enabled ITK IO
+# module (incl. the FDF remote module); ensure these test targets link it.
+foreach(_plus_fdf_target
+    vtkCenterOfRotationCalibAlgoTest vtkFreehandCalibrationStatisticalEvaluation
+    vtkSpacingCalibAlgoTest PatternLocTest vtkLineSegmentationAlgoTest
+    vtkSegmentedWiresPositionsTest)
+  if(TARGET ${_plus_fdf_target})
+    if(TARGET ITK::IOFDF)
+      target_link_libraries(${_plus_fdf_target} ITK::IOFDF)
+    endif()
+  endif()
+endforeach()


### PR DESCRIPTION
When ITK is built with the FDF remote ImageIO module, PlusCalibration test executables fail to link (`undefined itk::FDFImageIOFactoryRegister__Private`): they include the ITK use-file (which generates a factory-register manager referencing every enabled ITK IO module) but their curated ITK component set doesn't link FDF. Link `ITK::IOFDF`, guarded by `if(TARGET ITK::IOFDF)` so builds against an ITK without FDF (e.g. release-5.4) are unaffected.

<details>
<summary>Details</summary>

Verified against ITK 6 (FDF present → links) and ITK 5.4.6 (no FDF target → guard skips, unchanged). One of a set of independent ITK-6 compatibility PRs.
</details>
